### PR TITLE
Use promise for initialization. Use postRun hook to resolve.

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -1,7 +1,6 @@
-
-{
+var languagePluginLoader = new Promise((resolve, reject) => {
     let baseURL = "{{DEPLOY}}";
-    let wasmURL = baseURL + 'pyodide.asm.wasm?x=' + Date.now();
+    let wasmURL = `${baseURL}pyodide.asm.wasm?x=${Date.now()}`;
     let wasmXHR = new XMLHttpRequest();
     wasmXHR.open('GET', wasmURL, true);
     wasmXHR.responseType = 'arraybuffer';
@@ -11,14 +10,21 @@
         if (wasmXHR.status === 200 || wasmXHR.status === 0) {
             Module.wasmBinary = wasmXHR.response;
         } else {
-            alert("Couldn't download the pyodide.asm.wasm binary.  Response was " + wasmXHR.status);
+            alert(`Couldn't download the pyodide.asm.wasm binary.  Response was ${wasmXHR.status}`);
+            reject();
         }
 
         Module.baseURL = baseURL;
-        var script = document.createElement('script');
-        script.onload = function() { window.pyodide = pyodide(Module); };
-        script.src = baseURL + "pyodide.asm.js";
+        Module.postRun = () => {
+            resolve();
+        }
+        let script = document.createElement('script');
+        script.src = `${baseURL}pyodide.asm.js`;
+        script.onload = () => {
+            window.pyodide = pyodide(Module);
+        };
         document.body.appendChild(script);
     };
     wasmXHR.send(null);
-}
+});
+languagePluginLoader

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -10,7 +10,8 @@ var languagePluginLoader = new Promise((resolve, reject) => {
         if (wasmXHR.status === 200 || wasmXHR.status === 0) {
             Module.wasmBinary = wasmXHR.response;
         } else {
-            alert(`Couldn't download the pyodide.asm.wasm binary.  Response was ${wasmXHR.status}`);
+            console.warn(
+                `Couldn't download the pyodide.asm.wasm binary.  Response was ${wasmXHR.status}`);
             reject();
         }
 


### PR DESCRIPTION
This is related to https://github.com/iodide-project/iodide/pull/554

I figured out how to get a callback when the WebAssembly is ready, so there's no need for polling anymore.