### PR TITLE
Fix #53: Make "run all" work

### DIFF
--- a/src/matplotlib-sideload.html
+++ b/src/matplotlib-sideload.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Python - iodide</title>
-<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180605.css">
+<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180623.css">
 </head>
 <body>
 <script id="jsmd" type="text/jsmd">
@@ -54,7 +54,7 @@ Press Shift+Enter on the cell below to display the plot.
      let jsmd = document.getElementById('jsmd');
      jsmd.innerHTML = jsmd.innerHTML + text;
      let script = document.createElement('script');
-     script.src = 'https://iodide.io/dist/iodide.pyodide-20180605.js';
+     script.src = 'https://iodide.io/dist/iodide.pyodide-20180623.js';
      script.onload = () => {
          let pyodide = document.createElement('script');
          pyodide.src = 'https://iodide.io/pyodide-demo/pyodide.js';

--- a/src/matplotlib.html
+++ b/src/matplotlib.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Python - iodide</title>
-<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180605.css">
+<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180623.css">
 </head>
 <body>
 <script id="jsmd" type="text/jsmd">
@@ -204,6 +204,6 @@ plt.gcf().canvas.mpl_connect('motion_notify_event', motion_notify)
 plt.show()
 </script>
 <div id='page'></div>
-<script src='https://iodide.io/dist/iodide.pyodide-20180605.js'></script>
+<script src='https://iodide.io/dist/iodide.pyodide-20180623.js'></script>
 </body>
 </html>

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -62,6 +62,10 @@ var languagePluginLoader = new Promise((resolve, reject) => {
                                '_importlib.invalidate_caches()\n');
     });
 
+    if (window.iodide !== undefined) {
+      window.iodide.evalQueue.await([promise]);
+    }
+
     return promise;
   };
 

--- a/src/python.html
+++ b/src/python.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>Python - iodide</title>
-<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180605.css">
+<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180623.css">
 </head>
 <body>
 <script id="jsmd" type="text/jsmd">
@@ -262,6 +262,6 @@ A couple things that already work that will be coming to this example notebook s
 %% js
 </script>
 <div id='page'></div>
-<script src='https://iodide.io/dist/iodide.pyodide-20180605.js'></script>
+<script src='https://iodide.io/dist/iodide.pyodide-20180623.js'></script>
 </body>
 </html>


### PR DESCRIPTION
This calls `iodide.evalQueue.await` from `loadPackage` so that it will wait for the `loadPackage` to complete before running the next cell.  Also updates the version of iodide to one that includes `iodide.evalQueue.await`.