### PR TITLE
Explicit destroy

### DIFF
--- a/docs/type_conversions.md
+++ b/docs/type_conversions.md
@@ -82,9 +82,16 @@ currently supported:
 
 An additional limitation is that when passing a Python object to Javascript,
 there is no way for Javascript to automatically garbage collect that object.
-Therefore, Python objects must be manually free'd when passed to Javascript, or
-they will leak. (TODO: There isn't currently a way to do this, but it will be
-implemented soon).
+Therefore, custom Python objects must be manually destroyed when passed to Javascript, or
+they will leak. To do this, call `.destroy()` on the object, after which Javascript will no longer have access to the object.
+
+```javascript
+var foo = pyodide.pyimport('foo');
+foo.call_method();
+foo.destroy();
+foo.call_method(); // This will raise an exception, since the object has been
+                   // destroyed
+```
 
 ## Using Python objects from Javascript
 

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -148,7 +148,7 @@ def test_pyproxy_destroy(selenium):
             "f.destroy();\n"
             "f.get_value();\n")
     except JavascriptException as e:
-        assert 'f.get_value is not a function' in str(e)
+        assert 'Object has already been destroyed' in str(e)
     else:
         assert False, 'Expected exception'
 

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -52,6 +52,8 @@ def test_pythonexc2js(selenium):
         selenium.run_js('return pyodide.runPython("5 / 0")')
     except JavascriptException as e:
         assert('ZeroDivisionError' in str(e))
+    else:
+        assert False, 'Expected exception'
 
 
 def test_js2python(selenium):
@@ -129,6 +131,26 @@ def test_pyproxy(selenium):
     assert not selenium.run("hasattr(f, 'baz')")
     assert selenium.run_js(
         "return pyodide.pyimport('f').toString()").startswith('<Foo')
+
+
+def test_pyproxy_destroy(selenium):
+    selenium.run(
+        "class Foo:\n"
+        "  bar = 42\n"
+        "  def get_value(self, value):\n"
+        "    return value * 64\n"
+        "f = Foo()\n"
+    )
+    try:
+        selenium.run_js(
+            "let f = pyodide.pyimport('f');\n"
+            "console.assert(f.get_value(1) === 64);\n"
+            "f.destroy();\n"
+            "f.get_value();\n")
+    except JavascriptException as e:
+        assert 'f.get_value is not a function' in str(e)
+    else:
+        assert False, 'Expected exception'
 
 
 def test_jsproxy(selenium):


### PR DESCRIPTION
Provide a way to explicitly dereference a Python object from Javascript.