### PR TITLE
WIP: Initial steps toward Scipy support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v4
+          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v5
 
       - run:
           name: build
@@ -58,7 +58,7 @@ jobs:
       - save_cache:
           paths:
             - ./emsdk/emsdk
-          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v4
+          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v5
 
       - run:
           name: test

--- a/emsdk/patches/num_params.patch
+++ b/emsdk/patches/num_params.patch
@@ -7,7 +7,7 @@ index 013e9403..d95fc282 100644
  // to match when dynamically linking, and also dynamic linking is why we
  // can't just detect this automatically in the module we see.)
 -static const int NUM_PARAMS = 15;
-+static const int NUM_PARAMS = 32;
++static const int NUM_PARAMS = 37;
 
  // Converts a value to the ABI type of i64.
  static Expression* toABI(Expression* value, Module* module) {

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: scipy
+  version: 1.1.0
+
+source:
+  url: https://files.pythonhosted.org/packages/07/76/7e844757b9f3bf5ab9f951ccd3e4a8eed91ab8720b0aac8c2adcc2fdae9f/scipy-1.1.0.tar.gz
+  sha256: 878352408424dffaa695ffedf2f9f92844e116686923ed9aa8626fc30d32cfd1
+
+build:
+  cflags: -ICLAPACK-WA/F2CLIBS/libf2c/ -Wno-implicit-function-declaration
+  cxxflags:
+
+requirements:
+  run:
+    - numpy

--- a/tools/pywasmcross
+++ b/tools/pywasmcross
@@ -37,7 +37,7 @@ import common
 
 
 ROOTDIR = os.path.abspath(os.path.dirname(__file__))
-symlinks = set(['cc', 'c++', 'ld', 'ar', 'gcc'])
+symlinks = set(['cc', 'c++', 'ld', 'ar', 'gcc', 'gfortran'])
 
 
 def collect_args(basename):
@@ -98,6 +98,24 @@ def capture_compile(args):
         sys.exit(result.returncode)
 
 
+def f2c(args):
+    new_args = []
+    found_source = False
+    for arg in args:
+        if arg.endswith('.f'):
+            filename = os.path.abspath(arg)
+            subprocess.check_call(
+                ['f2c', os.path.basename(filename)],
+                cwd=os.path.dirname(filename))
+            new_args.append(arg[:-2] + '.c')
+            found_source = True
+        else:
+            new_args.append(arg)
+    if not found_source:
+        return None
+    return new_args
+
+
 def handle_command(line, args):
     # This is a special case to skip the compilation tests in numpy that aren't
     # actually part of the build
@@ -106,8 +124,16 @@ def handle_command(line, args):
             return
         if arg == '-print-multiarch':
             return
+        if arg.startswith('/tmp'):
+            return
 
-    if line[0] == 'ar':
+    if line[0] == 'gfortran':
+        result = f2c(line)
+        if result is None:
+            return
+        line = result
+        new_args = ['emcc']
+    elif line[0] == 'ar':
         new_args = ['emar']
     elif line[0] == 'c++':
         new_args = ['em++']
@@ -122,6 +148,8 @@ def handle_command(line, args):
         new_args.extend(args.ldflags.split())
     elif new_args[0] in ('emcc', 'em++'):
         new_args.extend(args.cflags.split())
+    if new_args[0] == 'em++':
+        new_args.append('-std=c++98')
 
     # Go through and adjust arguments
     for arg in line[1:]:
@@ -140,10 +168,15 @@ def handle_command(line, args):
         arg = re.sub(r'/python([0-9]\.[0-9]+)m', r'/python\1', arg)
         if arg.endswith('.o'):
             arg = arg[:-2] + '.bc'
-        if shared and arg.endswith('.so'):
+            output = arg
+        elif shared and arg.endswith('.so'):
             arg = arg[:-3] + '.wasm'
             output = arg
         new_args.append(arg)
+
+    if os.path.isfile(output):
+        print('SKIPPING: ' + ' '.join(new_args))
+        return
 
     print(' '.join(new_args))
 

--- a/tools/pywasmcross
+++ b/tools/pywasmcross
@@ -148,8 +148,6 @@ def handle_command(line, args):
         new_args.extend(args.ldflags.split())
     elif new_args[0] in ('emcc', 'em++'):
         new_args.extend(args.cflags.split())
-    if new_args[0] == 'em++':
-        new_args.append('-std=c++98')
 
     # Go through and adjust arguments
     for arg in line[1:]:


### PR DESCRIPTION
**This PR is not intended to be merged.  It's just a convenient way to communicate work already done to @rngadam.**

Make sure you've read https://github.com/iodide-project/pyodide/blob/master/docs/new_packages.md for any of this to make sense.

The main change here is for FORTRAN support.  The changes to `pywasmcross` convert native calls to `gfortran` to calls to `f2c` (a FORTRAN-to-C compiler) followed by calls to `emcc` (the emscripten C compiler).  This requires having `f2c` installed (which I just installed from its Fedora package -- Debian should be similar).

This requires the `f2c` runtime library compiled to WebAssembly.  Fortunately, someone else has already done that here: https://github.com/adrianbg/CLAPACK-WA  You'll want to download and compile that (using pyodide's fork of `emsdk`), and then adjust the path in `meta.yaml` here to point to that.  (Eventually, that should be done automatically as part of the Pyodide build, I just haven't gotten around to that yet).