### PR TITLE
Fix #80: Delete emsdk if rerunning make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,5 +173,5 @@ build/packages.json: $(CPYTHONLIB)
 	make -C packages
 
 
-emsdk/emsdk/emsdk:
+emsdk/emsdk/.complete:
 	make -C emsdk

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ root/.built: \
 	touch root/.built
 
 
-$(CPYTHONLIB): emsdk/emsdk/emsdk
+$(CPYTHONLIB): emsdk/emsdk/emsdk/.complete
 	make -C $(CPYTHONROOT)
 
 
@@ -173,5 +173,5 @@ build/packages.json: $(CPYTHONLIB)
 	make -C packages
 
 
-emsdk/emsdk/.complete:
+emsdk/emsdk/emsdk/.complete:
 	make -C emsdk

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -4,6 +4,7 @@ all: emsdk/emsdk
 # run out of memory
 
 emsdk/emsdk:
+	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone https://github.com/juj/emsdk.git
 	sed -i -e "s#CPU_CORES = max(multiprocessing.cpu_count()-1, 1)#CPU_CORES = 3#g" emsdk/emsdk
 	( \

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -1,9 +1,9 @@
-all: emsdk/emsdk
+all: emsdk/emsdk/.complete
 
 # We hack the CPU_CORES, because if you use all of the cores on Circle-CI, you
 # run out of memory
 
-emsdk/emsdk:
+emsdk/emsdk/.complete:
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone https://github.com/juj/emsdk.git
 	sed -i -e "s#CPU_CORES = max(multiprocessing.cpu_count()-1, 1)#CPU_CORES = 3#g" emsdk/emsdk
@@ -17,7 +17,8 @@ emsdk/emsdk:
     make ; \
 	  cd ../.. ; \
     cp binaryen/tag-1.38.4/bin/binaryen.js binaryen/tag-1.38.4_64bit_binaryen/bin ; \
-		./emsdk activate --embedded --build=Release sdk-tag-1.38.4-64bit binaryen-tag-1.38.4-64bit \
+		./emsdk activate --embedded --build=Release sdk-tag-1.38.4-64bit binaryen-tag-1.38.4-64bit ; \
+    touch .complete \
 	)
 
 clean:


### PR DESCRIPTION
This Makefile isn't really a Makefile anyway (in that it doesn't really express things as dependencies.  It's really just a script to get someone else's Makefile (in this case emsdk) built.  This should fix the immediate problem, however.