### PR TITLE
MAINT Minor fixes in the Makefile for make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ benchmark: all build/test.html
 
 clean:
 	rm -fr root
-	rm build/*
-	rm src/*.bc
+	rm -fr build/*
+	rm -fr src/*.bc
 	make -C packages clean
 	make -C six clean
 	echo "The Emsdk and CPython are not cleaned. cd into those directories to do so."

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -5,4 +5,4 @@ all:
 	../tools/buildall . ../build --ldflags="$(SIDE_LDFLAGS)" --host=$(HOSTPYTHONROOT) --target=$(TARGETPYTHONROOT)
 
 clean:
-	rm -rf */build
+	rm -rf ./*/build


### PR DESCRIPTION
Minor fixes in the `Makefile` when running `make clean`.

Without this I'm getting,
```
rm: cannot remove 'build/*': No such file or directory
make: *** [Makefile:121: clean] Error 1
```

also this avoids the `rm -rf */build` notation which is probably fine, but still made me worried (depending on which directory it is run from).