### PR TITLE
Skip compile and configure cases during numpy build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Install the following dependencies into the default Python installation:
 
    `pip install pytest selenium`
 
-Install [geckodriver](https://github.com/mozilla/geckodriver/releases) somewhere
+Install [geckodriver](https://github.com/mozilla/geckodriver/releases) and
+[chromedriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) somewhere
 on your `PATH`.
 
 `make test`

--- a/tools/pywasmcross
+++ b/tools/pywasmcross
@@ -104,6 +104,8 @@ def handle_command(line, args):
     for arg in line:
         if r'/file.c' in arg or '_configtest' in arg:
             return
+        if re.match('/tmp/.*/source\.[bco]+', arg):
+            return
         if arg == '-print-multiarch':
             return
 


### PR DESCRIPTION
This skips a few unsupported compile-and-configure cases when building numpy, as suggested in https://github.com/iodide-project/pyodide/issues/92#issuecomment-407772458

Closes https://github.com/iodide-project/pyodide/issues/92

Also mentions to install chromedriver in the README that is currently required to run tests.