### PR TITLE
Mechanism for testing imports

### DIFF
--- a/packages/cycler/meta.yaml
+++ b/packages/cycler/meta.yaml
@@ -5,3 +5,7 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/c2/4b/137dea450d6e1e3d474e1d873cd1d4f7d3beed7e0dc973b06e8e10d32488/cycler-0.10.0.tar.gz
   md5: 4cb42917ac5007d1cdff6cccfe2d016b
+
+test:
+  imports:
+    - cycler

--- a/packages/kiwisolver/meta.yaml
+++ b/packages/kiwisolver/meta.yaml
@@ -5,3 +5,7 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/31/60/494fcce70d60a598c32ee00e71542e52e27c978e5f8219fae0d4ac6e2864/kiwisolver-1.0.1.tar.gz
   md5: e2a1718b837e2cd001f7c06934616fcd
+
+test:
+  imports:
+    - kiwisolver

--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -39,3 +39,7 @@ requirements:
     - pyparsing
     - python-dateutil
     - pytz
+
+test:
+  imports:
+    - matplotlib

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -20,3 +20,8 @@ source:
 
 build:
   cflags: -include math.h -I../../config
+
+
+test:
+  imports:
+    - numpy

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -17,3 +17,7 @@ requirements:
     - numpy
     - python-dateutil
     - pytz
+
+test:
+  imports:
+    - pandas

--- a/packages/pyparsing/meta.yaml
+++ b/packages/pyparsing/meta.yaml
@@ -8,3 +8,7 @@ source:
 
   patches:
     - patches/dummy_threading.patch
+
+test:
+  imports:
+    - pyparsing

--- a/packages/python-dateutil/meta.yaml
+++ b/packages/python-dateutil/meta.yaml
@@ -8,3 +8,7 @@ source:
 
   patches:
     - patches/dummy-thread-lock.patch
+
+test:
+  imports:
+    - dateutil

--- a/packages/pytz/meta.yaml
+++ b/packages/pytz/meta.yaml
@@ -8,3 +8,7 @@ source:
 
   patches:
     - patches/dummy-threading.patch
+
+test:
+  imports:
+    - pytz

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -1,0 +1,30 @@
+import pytest
+import os
+from pathlib import Path
+import sys
+
+BASE_DIR = Path(__file__).parent.parent
+PKG_DIR = BASE_DIR / 'packages'
+
+# TODO: remove once we have a proper Python package for common functions
+sys.path.append(str(BASE_DIR / 'tools'))
+import common  # noqa
+
+
+def registered_packages():
+    packages = [name for name in os.listdir(PKG_DIR)
+                if (PKG_DIR / name).is_dir()]
+    return packages
+
+
+@pytest.mark.parametrize('name', registered_packages())
+def test_meta(selenium, name):
+    # check that we can parse the meta.yaml
+    meta = common.parse_package(PKG_DIR / name / 'meta.yaml')
+
+    if 'test' in meta:
+        if 'imports' in meta['test']:
+            # check imports
+            for import_name in meta['test']['imports']:
+                selenium.load_package(import_name)
+                selenium.run('import %s' % import_name)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -43,5 +43,5 @@ def test_import(name, selenium):
                         selenium.__class__.__name__.replace('Wrapper', '')))
 
     for import_name in meta.get('test', {}).get('imports', []):
-        selenium.load_package(import_name)
+        selenium.load_package(name)
         selenium.run('import %s' % import_name)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -12,9 +12,19 @@ import common  # noqa
 
 
 def registered_packages():
+    """Returns a list of registred package names"""
     packages = [name for name in os.listdir(PKG_DIR)
                 if (PKG_DIR / name).is_dir()]
     return packages
+
+
+def registered_packages_meta():
+    """Returns a dictionary with the contents of `meta.yaml`
+    for each registed package
+    """
+    packages = registered_packages
+    return {name: common.parse_package(PKG_DIR / name / 'meta.yaml')
+            for name in packages}
 
 
 @pytest.mark.parametrize('name', registered_packages())
@@ -22,9 +32,7 @@ def test_meta(selenium, name):
     # check that we can parse the meta.yaml
     meta = common.parse_package(PKG_DIR / name / 'meta.yaml')
 
-    if 'test' in meta:
-        if 'imports' in meta['test']:
-            # check imports
-            for import_name in meta['test']['imports']:
-                selenium.load_package(import_name)
-                selenium.run('import %s' % import_name)
+    # check imports
+    for import_name in meta.get('test', {}).get('imports', []):
+        selenium.load_package(import_name)
+        selenium.run('import %s' % import_name)

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -27,12 +27,21 @@ def registered_packages_meta():
             for name in packages}
 
 
+UNSUPPORTED_PACKAGES = {'ChromeWrapper': ['pandas'],
+                        'FirefoxWrapper': []}
+
+
 @pytest.mark.parametrize('name', registered_packages())
-def test_meta(selenium, name):
+def test_import(name, selenium):
     # check that we can parse the meta.yaml
     meta = common.parse_package(PKG_DIR / name / 'meta.yaml')
 
-    # check imports
+    if name in UNSUPPORTED_PACKAGES[selenium.__class__.__name__]:
+        pytest.xfail(
+                '{} fails to load and is not supported on {}.'
+                .format(name,
+                        selenium.__class__.__name__.replace('Wrapper', '')))
+
     for import_name in meta.get('test', {}).get('imports', []):
         selenium.load_package(import_name)
         selenium.run('import %s' % import_name)


### PR DESCRIPTION
Extracted from https://github.com/iodide-project/pyodide/pull/95

As suggested in https://github.com/iodide-project/pyodide/pull/95#discussion_r205541913 this adds a mechanism to test imports specified in `meta.yaml` with e.g.
```
test:
  imports:
    - dateutil
```

One of the issue though is this test is extremely slow to fail. The package cannot be imported it timesout and the default timeout for loading packages 20 seconds I think https://github.com/iodide-project/pyodide/blob/master/test/conftest.py#L41  Maybe this value could be reduced somewhat?

Manually checked that this raises an exception non existing packages. Only added an entry for cycler for now.