### PR TITLE
Add support for sha256 checksum

### DIFF
--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -68,10 +68,12 @@ The tarball may be in any of the formats supported by Python's
 #### `source/md5`
 
 The MD5 checksum of the tarball. It is recommended to use SHA256 instead of MD5.
+At most one checksum entry sould be provided per package.
 
 #### `source/sha256`
 
 The SHA256 checksum of the tarball. It is recommended to use SHA256 instead of MD5.
+At most one checksum entry sould be provided per package.
 
 #### `source/patches`
 

--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -67,7 +67,11 @@ The tarball may be in any of the formats supported by Python's
 
 #### `source/md5`
 
-The MD5 checksum of the tarball.  (TODO: More hash types should be supported in the future).
+The MD5 checksum of the tarball. It is recommended to use SHA256 instead of MD5.
+
+#### `source/sha256`
+
+The SHA256 checksum of the tarball. It is recommended to use SHA256 instead of MD5.
 
 #### `source/patches`
 

--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -68,12 +68,12 @@ The tarball may be in any of the formats supported by Python's
 #### `source/md5`
 
 The MD5 checksum of the tarball. It is recommended to use SHA256 instead of MD5.
-At most one checksum entry sould be provided per package.
+At most one checksum entry should be provided per package.
 
 #### `source/sha256`
 
 The SHA256 checksum of the tarball. It is recommended to use SHA256 instead of MD5.
-At most one checksum entry sould be provided per package.
+At most one checksum entry should be provided per package.
 
 #### `source/patches`
 

--- a/packages/pytz/meta.yaml
+++ b/packages/pytz/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/10/76/52efda4ef98e7544321fd8d5d512e11739c1df18b0649551aeccfb1c8376/pytz-2018.4.tar.gz
-  md5: f054437920c895dd14a4509fabafe029
+  sha256: c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749
 
   patches:
     - patches/dummy-threading.patch

--- a/tools/buildpkg.py
+++ b/tools/buildpkg.py
@@ -21,11 +21,16 @@ def check_checksum(path, pkg):
     """
     Checks that a tarball matches the checksum in the package metadata.
     """
-    if 'md5' not in pkg['source']:
+    checksum_keys = {'md5', 'sha256'}.intersection(pkg['source'])
+    if not checksum_keys:
         return
-    checksum = pkg['source']['md5']
+    elif len(checksum_keys) != 1:
+        raise ValueError('Only one checksum should be included in a package '
+                         'setup; found {}.'.format(checksum_keys))
+    checksum_algorithm = checksum_keys.pop()
+    checksum = pkg['source'][checksum_algorithm]
     CHUNK_SIZE = 1 << 16
-    h = hashlib.md5()
+    h = getattr(hashlib, checksum_algorithm)()
     with open(path, 'rb') as fd:
         while True:
             chunk = fd.read(CHUNK_SIZE)
@@ -33,7 +38,7 @@ def check_checksum(path, pkg):
             if len(chunk) < CHUNK_SIZE:
                 break
     if h.hexdigest() != checksum:
-        raise ValueError("Invalid checksum")
+        raise ValueError("Invalid {} checksum".format(checksum_algorithm))
 
 
 def download_and_extract(buildpath, packagedir, pkg, args):


### PR DESCRIPTION
As part of https://github.com/iodide-project/pyodide/pull/95 this adds support for sha256 checksum. 

The main motivation is to facilitate the adaptation of existing conda-forge feedstocks (`meta.yaml`) that use sha256 (instead of MD5) by default. 