### PR TITLE
Save Circle-CI cache every time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v6
+          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v6-
 
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
           name: build
           no_output_timeout: 1200
           command: |
+            ccache -z
             make
             ccache -s
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           paths:
             - ./emsdk/emsdk
             - ~/.ccache
-          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v6
+          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v6-{{ .BuildNum }}
 
       - run:
           name: test


### PR DESCRIPTION
Circle-CI doesn't resave the cache if one already exists with the same name.  This makes the ccache-based approach not work as well, since we're only getting the cache from the first build built against a particular version of emsdk.

This tacks on the build number to the cache so every build will produce a unique cache.  Restoring the cache will never then have an exact match, but will use the most recently saved cache available.

This also clears the ccache stats before each build so the stats output at the end will be for this build only (which is more meaningful than the stats over a long period of time, IMHO).