### PR TITLE
Fix #109: Fix the path of external data files

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -117,6 +117,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   };
 
   Module.filePackagePrefixURL = baseURL;
+  Module.locateFile = (path) => baseURL + path;
   var postRunPromise = new Promise((resolve, reject) => {
     Module.postRun = () => {
       delete window.Module;


### PR DESCRIPTION
The data files weren't getting found if the .html page was at a different location than all of the pyodide stuff.  This should fix that by overriding the `locateFile` hook function.