### PR TITLE
MAINT Fix emscripten version 1.38.10 everywhere and remove python2 from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ ccache/emcc:
 	if hash ccache &>/dev/null; then \
     ln -s `which ccache` $(PYODIDE_ROOT)/ccache/emcc ; \
   else \
-    ln -s emsdk/emsdk/emscripten/tag-1.38.4/emcc $(PYODIDE_ROOT)/ccache/emcc; \
+    ln -s emsdk/emsdk/emscripten/tag-1.38.10/emcc $(PYODIDE_ROOT)/ccache/emcc; \
   fi
 
 
@@ -180,7 +180,7 @@ ccache/em++:
 	if hash ccache &>/dev/null; then \
     ln -s `which ccache` $(PYODIDE_ROOT)/ccache/em++ ; \
   else \
-    ln -s emsdk/emsdk/emscripten/tag-1.38.4/em++ $(PYODIDE_ROOT)/ccache/em++; \
+    ln -s emsdk/emsdk/emscripten/tag-1.38.10/em++ $(PYODIDE_ROOT)/ccache/em++; \
   fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build/pyodide.asm.js: src/main.bc src/jsimport.bc src/jsproxy.bc src/js2python.b
 
 
 build/pyodide.asm.data: root/.built
-	python2 $(FILEPACKAGER) build/pyodide.asm.data --preload root/lib@lib --js-output=build/pyodide.asm.data.js --use-preload-plugins
+	python $(FILEPACKAGER) build/pyodide.asm.data --preload root/lib@lib --js-output=build/pyodide.asm.data.js --use-preload-plugins
 	uglifyjs build/pyodide.asm.data.js -o build/pyodide.asm.data.js
 
 
@@ -136,7 +136,7 @@ build/test.data: $(CPYTHONLIB)
 	  cd $(CPYTHONLIB)/test; \
 	  find -type d -name __pycache__ -prune -exec rm -rf {} \; \
 	)
-	python2 $(FILEPACKAGER) build/test.data --preload $(CPYTHONLIB)/test@/lib/python3.6/test --js-output=build/test.js --export-name=pyodide --exclude \*.wasm.pre --exclude __pycache__
+	python $(FILEPACKAGER) build/test.data --preload $(CPYTHONLIB)/test@/lib/python3.6/test --js-output=build/test.js --export-name=pyodide --exclude \*.wasm.pre --exclude __pycache__
 	uglifyjs build/test.js -o build/test.js
 
 

--- a/tools/buildpkg.py
+++ b/tools/buildpkg.py
@@ -141,7 +141,7 @@ def package_files(buildpath, srcpath, pkg, args):
     name = pkg['package']['name']
     libdir = get_libdir(srcpath, args)
     subprocess.run([
-        'python2',
+        'python',
         Path(os.environ['EMSCRIPTEN']) / 'tools' / 'file_packager.py',
         buildpath / (name + '.data'),
         '--preload',


### PR DESCRIPTION
This PR,
 - replaces a couple remaining 1.38.4 emscripten tags by 1.38.10 that didn't make it in https://github.com/iodide-project/pyodide/pull/89 (this is not detected in CI as it uses ccache that bypasses that if branch).
 - replaces `python2` in build with the default `python`, as this is contrairy to the claim in the readme that only Python 3 is needed. Also as far as I can tell `tools/file_packager.py` from emsdk is Python 3 compatible. The build also works (mostly) fine for me with Python3.