### PR TITLE
Fix #115: Forcibly use the local copy of blas and lapack

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -17,6 +17,7 @@ source:
     - patches/init-alloc-cache.patch
     - patches/pass-along-errors-from-init.patch
     - patches/use-dummy-threading.patch
+    - patches/use-local-blas-lapack.patch
 
 build:
   cflags: -include math.h -I../../config

--- a/packages/numpy/patches/use-local-blas-lapack.patch
+++ b/packages/numpy/patches/use-local-blas-lapack.patch
@@ -1,0 +1,17 @@
+diff --git a/numpy/distutils/system_info.py b/numpy/distutils/system_info.py
+old mode 100644
+new mode 100755
+index bea120cf9..5b2ccb2c1
+--- a/numpy/distutils/system_info.py
++++ b/numpy/distutils/system_info.py
+@@ -406,8 +406,8 @@ def get_info(name, notfound_action=0):
+           'numeric': Numeric_info,
+           'numarray': numarray_info,
+           'numerix': numerix_info,
+-          'lapack_opt': lapack_opt_info,
+-          'blas_opt': blas_opt_info,
++          'lapack_opt': lapack_src_info,
++          'blas_opt': blas_src_info,
+           'boost_python': boost_python_info,
+           'agg2': agg2_info,
+           'wx': wx_info,


### PR DESCRIPTION
This changes the method used to find BLAS and LAPACK so it will find the local copy that comes with Numpy rather than system-installed ones.