### PR TITLE
Fix: Loading packages from custom URLs (part 1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,9 @@ jobs:
             export PATH=$PWD/firefox:$PATH
             pytest test -v -k chrome
 
+      - store_artifacts:
+          path: /home/circleci/repo/build/
+
   deploy:
     machine:
       enabled: true

--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -50,7 +50,8 @@ The supported keys in the `meta.yaml` file are described below.
 The name of the package. It must match the name of the package used when
 expanding the tarball, which is sometimes different from the name of the package
 in the Python namespace when installed. It must also match the name of the
-directory in which the `meta.yaml` file is placed.
+directory in which the `meta.yaml` file is placed. It can only contain
+alpha-numeric characters and `-`, `_`.
 
 #### `package/version`
 

--- a/docs/using_pyodide_from_iodide.md
+++ b/docs/using_pyodide_from_iodide.md
@@ -51,7 +51,15 @@ Pyodide. To use other libraries, you'll need to load their package using
 from a Javascript cell. This downloads the file data over the network (as a
 `.data` and `.js` index file) and installs the files in the virtual filesystem.
 
-When you request a package, all of that package's dependencies are also loaded.
+Packages can be loaded by name, for those included in the official pyodide
+repository (e.g. `pyodide.loadPackage('numpy')`). It is also possible to load
+packages from custom URLs (e.g.
+`pyodide.loadPackage('https://foo/bar/numpy.js')`), in which case the URL must
+end with `<package-name>.js`.
+
+When you request a package from the official repository, all of that package's
+dependencies are also loaded. Dependency resolution is not yet implemented
+when loading packages from custom URLs.
 
 `pyodide.loadPackage` returns a `Promise`.
 

--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -39,7 +39,15 @@ Pyodide. To use other libraries, you'll need to load their package using
 `pyodide.loadPackage`. This downloads the file data over the network (as a
 `.data` and `.js` index file) and installs the files in the virtual filesystem.
 
-When you request a package, all of that package's dependencies are also loaded.
+Packages can be loaded by name, for those included in the official pyodide
+repository (e.g. `pyodide.loadPackage('numpy')`). It is also possible to load
+packages from custom URLs (e.g.
+`pyodide.loadPackage('https://foo/bar/numpy.js')`), in which case the URL must
+end with `<package-name>.js`.
+
+When you request a package from the official repository, all of that package's
+dependencies are also loaded. Dependency resolution is not yet implemented
+when loading packages from custom URLs.
 
 `pyodide.loadPackage` returns a `Promise`.
 

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -3,7 +3,7 @@
  */
 
 // Regexp for validating package name and URI
-var package_name_regexp = '[a-z0-9_\-]+'
+var package_name_regexp = '[a-z0-9_][a-z0-9_\-]*'
 var package_uri_regexp =
     new RegExp('^https?://.*?(' + package_name_regexp + ').js$', 'i');
 var package_name_regexp = new RegExp('^' + package_name_regexp + '$', 'i');
@@ -44,8 +44,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       const package = _uri_to_package_name(package_uri);
 
       if (package == null) {
-        console.log(`Invalid package name or URI '${package_uri}'`);
-        break;
+        throw new Error(`Invalid package name or URI '${package_uri}'`);
       } else if (package == package_uri) {
         package_uri = 'default channel';
       }
@@ -54,9 +53,10 @@ var languagePluginLoader = new Promise((resolve, reject) => {
 
       if (package in loadedPackages) {
         if (package_uri != loadedPackages[package]) {
-          console.log(`Error: URI mismatch, attempting to load package ` +
-                      `${package} from ${package_uri} while it is already ` +
-                      `loaded from ${loadedPackages[package]}!`);
+          throw new Error(
+              `URI mismatch, attempting to load package ` +
+              `${package} from ${package_uri} while it is already ` +
+              `loaded from ${loadedPackages[package]}!`);
         }
       } else {
         toLoad[package] = package_uri;
@@ -67,7 +67,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
             }
           });
         } else {
-          console.log(`Unknown package '${package}'`);
+          log.console(`Unknown package '${package}'`);
         }
       }
     }

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -20,6 +20,13 @@ var languagePluginLoader = new Promise((resolve, reject) => {
     let toLoad = new Set();
     while (queue.length) {
       const package = queue.pop();
+      var valid_package_name_regexp = new RegExp('^[a-zA-Z0-9_\-]+$');
+      console.log(package + valid_package_name_regexp.test(package));
+      if (!valid_package_name_regexp.test(package)) {
+          console.log(`Invalid package name '${package}'`);
+          break;
+      }
+
       if (!loadedPackages.has(package)) {
         toLoad.add(package);
         if (packages.hasOwnProperty(package)) {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -4,10 +4,9 @@
 
 // Regexp for validating package name and URI
 var package_name_regexp = '[a-z0-9_\-]+'
-var package_uri_regexp = new RegExp(
-     '^https?://.*?(' + package_name_regexp + ').js$', 'i');
+var package_uri_regexp =
+    new RegExp('^https?://.*?(' + package_name_regexp + ').js$', 'i');
 var package_name_regexp = new RegExp('^' + package_name_regexp + '$', 'i');
-
 
 var languagePluginLoader = new Promise((resolve, reject) => {
   // This is filled in by the Makefile to be either a local file or the
@@ -33,7 +32,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       return null;
     }
   };
-
 
   let loadPackage = (names) => {
     // DFS to find all dependencies of the requested packages
@@ -82,7 +80,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       pyodide.monitorRunDependencies = (n) => {
         if (n === 0) {
           for (let package in toLoad) {
-              loadedPackages[package] = toLoad[package];
+            loadedPackages[package] = toLoad[package];
           }
           delete pyodide.monitorRunDependencies;
           const packageList = Array.from(Object.keys(toLoad)).join(', ');
@@ -93,10 +91,10 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       for (let package in toLoad) {
         let script = document.createElement('script');
         let package_uri = toLoad[package];
-        if (package_uri == 'packages.json') {
-            script.src = `${baseURL}${package}.js`;
+        if (package_uri == 'default channel') {
+          script.src = `${baseURL}${package}.js`;
         } else {
-            script.src = `${package_uri}`;
+          script.src = `${package_uri}`;
         }
         script.onerror = (e) => { reject(e); };
         document.body.appendChild(script);

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -5,7 +5,7 @@
 // Regexp for validating package name and URI
 var package_name_regexp = '[a-zA-Z0-9_\-]+'
 var package_uri_regexp = new RegExp(
-     '^(?:https?|file)://.*?(' + package_name_regexp + ').js$');
+     '^https?://.*?(' + package_name_regexp + ').js$');
 var package_name_regexp = new RegExp('^' + package_name_regexp + '$');
 
 
@@ -41,7 +41,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
     let queue = new Array(names);
     let toLoad = new Array();
     while (queue.length) {
-      var package_uri = queue.pop();
+      let package_uri = queue.pop();
 
       const package = _uri_to_package_name(package_uri);
 
@@ -57,7 +57,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       if (package in loadedPackages) {
         if (package_uri != loadedPackages[package]) {
           console.log(`Error: URI mismatch, attempting to load package ` +
-                      `${package} from ${package_uri} while is already ` +
+                      `${package} from ${package_uri} while it is already ` +
                       `loaded from ${loadedPackages[package]}!`);
         }
       } else {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -3,10 +3,10 @@
  */
 
 // Regexp for validating package name and URI
-var package_name_regexp = '[a-zA-Z0-9_\-]+'
+var package_name_regexp = '[a-z0-9_\-]+'
 var package_uri_regexp = new RegExp(
-     '^https?://.*?(' + package_name_regexp + ').js$');
-var package_name_regexp = new RegExp('^' + package_name_regexp + '$');
+     '^https?://.*?(' + package_name_regexp + ').js$', 'i');
+var package_name_regexp = new RegExp('^' + package_name_regexp + '$', 'i');
 
 
 var languagePluginLoader = new Promise((resolve, reject) => {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -67,7 +67,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
             }
           });
         } else {
-          log.console(`Unknown package '${package}'`);
+          console.log(`Unknown package '${package}'`);
         }
       }
     }

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -49,7 +49,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
         console.log(`Invalid package name or URI '${package_uri}'`);
         break;
       } else if (package == package_uri) {
-        package_uri = 'packages.json';
+        package_uri = 'default channel';
       }
 
       console.log(`Loading ${package} from ${package_uri}`);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -53,6 +53,9 @@ class SeleniumWrapper:
         logs = self.driver.execute_script("return window.logs")
         return '\n'.join(str(x) for x in logs)
 
+    def clean_logs(self):
+        self.driver.execute_script("window.logs = []")
+
     def run(self, code):
         return self.run_js(
             'return pyodide.runPython({!r})'.format(code))
@@ -145,11 +148,10 @@ if pytest is not None:
     def selenium(_selenium_cached):
         # selenium instance cached at the module level
         try:
-            # clean selenium logs for each test run
-            _selenium_cached.driver.execute_script("window.logs = []")
+            _selenium_cached.clean_logs()
             yield _selenium_cached
         finally:
-            print('\n'.join(str(x) for x in _selenium_cached.logs))
+            print(_selenium_cached.logs)
 
 
 PORT = 0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,7 +40,8 @@ def _display_driver_logs(browser, driver):
     elif browser == 'firefox':
         # browser logs are not available in GeckoDriver
         # https://github.com/mozilla/geckodriver/issues/284
-        print('Cannot access browser logs for Firefox.')
+        print('Accessing raw browser logs with Selenium is not '
+              'supported by Firefox.')
 
 
 class SeleniumWrapper:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -205,5 +205,10 @@ def run_web_server(q):
         httpd.serve_forever()
 
 
+@pytest.fixture
+def web_server():
+    return '127.0.0.1', PORT
+
+
 if multiprocessing.current_process().name == 'MainProcess':
     spawn_web_server()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,7 +50,8 @@ class SeleniumWrapper:
 
     @property
     def logs(self):
-        return self.driver.execute_script("return window.logs")
+        logs = self.driver.execute_script("return window.logs")
+        return '\n'.join(str(x) for x in logs)
 
     def run(self, code):
         return self.run_js(
@@ -123,7 +124,7 @@ if pytest is not None:
         try:
             yield selenium
         finally:
-            print('\n'.join(str(x) for x in selenium.logs))
+            print(selenium.logs)
             selenium.driver.quit()
 
     @pytest.fixture(params=['firefox', 'chrome'], scope='module')

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -1,3 +1,5 @@
+import pytest
+from selenium.common.exceptions import WebDriverException
 
 
 def test_load_from_url(selenium_standalone, web_server):
@@ -16,15 +18,19 @@ def test_load_from_url(selenium_standalone, web_server):
 
 def test_uri_mismatch(selenium_standalone):
     selenium_standalone.load_package('pyparsing')
-    selenium_standalone.load_package('http://some_url/pyparsing.js')
+    with pytest.raises(WebDriverException,
+                       match="URI mismatch, attempting "
+                             "to load package pyparsing"):
+        selenium_standalone.load_package('http://some_url/pyparsing.js')
     assert "Invalid package name or URI" not in selenium_standalone.logs
-    assert ("URI mismatch, attempting "
-            "to load package pyparsing") in selenium_standalone.logs
 
 
 def test_invalid_package_name(selenium):
-    selenium.load_package('wrong name+$')
-    assert "Invalid package name or URI" in selenium.logs
+    with pytest.raises(WebDriverException,
+                       match="Invalid package name or URI"):
+        selenium.load_package('wrong name+$')
     selenium.clean_logs()
-    selenium.load_package('tcp://some_url')
-    assert "Invalid package name or URI" in selenium.logs
+
+    with pytest.raises(WebDriverException,
+                       match="Invalid package name or URI"):
+        selenium.load_package('tcp://some_url')

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-import time
 
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import threading

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -1,36 +1,17 @@
-import os
-from pathlib import Path
-
-from http.server import HTTPServer, SimpleHTTPRequestHandler
-import threading
-
-import pytest
 
 
-@pytest.fixture
-def static_web_server():
-    # serve artefacts from a different port
-    build_dir = Path(__file__).parent.parent / 'build'
-    os.chdir(build_dir)
-    try:
-        url, port = ('127.0.0.1', 8888)
-        server = HTTPServer((url, port), SimpleHTTPRequestHandler)
-        thread = threading.Thread(target=server.serve_forever)
-        thread.start()
-        yield url, port
-    finally:
-        server.shutdown()
+def test_load_from_url(selenium_standalone, web_server):
 
-
-def test_load_from_url(selenium_standalone, static_web_server):
-
-    url, port = static_web_server
+    url, port = web_server
 
     selenium_standalone.load_package(f"http://{url}:{port}/pyparsing.js")
     assert "Invalid package name or URI" not in selenium_standalone.logs
 
     selenium_standalone.run("from pyparsing import Word, alphas")
     selenium_standalone.run("Word(alphas).parseString('hello')")
+
+    selenium_standalone.load_package(f"http://{url}:{port}/numpy.js")
+    selenium_standalone.run("import numpy as np")
 
 
 def test_uri_mismatch(selenium_standalone):

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+import time
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def static_web_server():
+    # serve artefacts from a different port
+    build_dir = Path(__file__).parent.parent / 'build'
+    os.chdir(build_dir)
+    try:
+        url, port = ('127.0.0.1', 8888)
+        server = HTTPServer((url, port), SimpleHTTPRequestHandler)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        yield url, port
+    finally:
+        server.shutdown()
+
+
+def test_load_from_url(selenium_standalone, static_web_server):
+
+    url, port = static_web_server
+
+    selenium_standalone.load_package(f"http://{url}:{port}/pyparsing.js")
+    assert "Invalid package name or URI" not in selenium_standalone.logs
+
+    selenium_standalone.run("from pyparsing import Word, alphas")
+    selenium_standalone.run("Word(alphas).parseString('hello')")
+
+
+def test_uri_mismatch(selenium_standalone):
+    selenium_standalone.load_package('pyparsing')
+    selenium_standalone.load_package('http://some_url/pyparsing.js')
+    assert "Invalid package name or URI" not in selenium_standalone.logs
+    assert ("URI mismatch, attempting "
+            "to load package pyparsing") in selenium_standalone.logs
+
+
+def test_invalid_package_name(selenium):
+    selenium.load_package('wrong name+$')
+    assert "Invalid package name or URI" in selenium.logs
+    selenium.clean_logs()
+    selenium.load_package('tcp://some_url')
+    assert "Invalid package name or URI" in selenium.logs

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -7,7 +7,8 @@ import pytest
 
 
 def test_init(selenium_standalone):
-    assert 'Python initialization complete' in selenium_standalone.logs
+    assert ('Python initialization complete'
+            in selenium_standalone.logs.splitlines())
     assert len(selenium_standalone.driver.window_handles) == 1
 
 
@@ -19,7 +20,7 @@ def test_webbrowser(selenium):
 
 def test_print(selenium):
     selenium.run("print('This should be logged')")
-    assert 'This should be logged' in selenium.logs
+    assert 'This should be logged' in selenium.logs.splitlines()
 
 
 def test_python2js(selenium):


### PR DESCRIPTION
Fixes the first part of https://github.com/iodide-project/pyodide/issues/121

This PR allows to load packages from user defined URLs (without handling dependencies for now).  A few details on the current implementation,
 - the URL is assumed to start with http or https, the package name is inferred from the URL using the template (`https://some_path/{package_name}.js`)
 - packages names are assumed to composed of letters, numbers and/or `-`, `_`
 - if the provided URI doesn't look like a URL or a package name, an error is sent to the `console.log` and no loading takes place.
 - if one attempts to load the same package from two separate sources (e.g. a URL and `package.json`) an error will be raised. Loading the same package twice from the same URI does nothing.  