### PR TITLE
Install to a directory, and use that, instead of just the build/lib...

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -18,6 +18,7 @@ source:
     - patches/pass-along-errors-from-init.patch
     - patches/use-dummy-threading.patch
     - patches/use-local-blas-lapack.patch
+    - patches/fix-install-with-skip-build.patch
 
 build:
   cflags: -include math.h -I../../config

--- a/packages/numpy/patches/fix-install-with-skip-build.patch
+++ b/packages/numpy/patches/fix-install-with-skip-build.patch
@@ -1,0 +1,14 @@
+diff --git a/numpy/distutils/command/install_clib.py b/numpy/distutils/command/install_clib.py
+index 662aa00bd..6f51e22ca 100644
+--- a/numpy/distutils/command/install_clib.py
++++ b/numpy/distutils/command/install_clib.py
+@@ -20,6 +20,9 @@ class install_clib(Command):
+     def run (self):
+         build_clib_cmd = get_cmd("build_clib")
+         build_dir = build_clib_cmd.build_clib
++        if build_dir is None:
++            build_clib_cmd.finalize_options()
++            build_dir = build_clib_cmd.build_clib
+ 
+         # We need the compiler to get the library name -> filename association
+         if not build_clib_cmd.compiler:

--- a/tools/buildpkg.py
+++ b/tools/buildpkg.py
@@ -135,17 +135,17 @@ def compile(path, srcpath, pkg, args):
 
 
 def package_files(buildpath, srcpath, pkg, args):
-    if (buildpath / '.pacakaged').is_file():
+    if (buildpath / '.packaged').is_file():
         return
 
     name = pkg['package']['name']
-    libdir = get_libdir(srcpath, args)
+    install_prefix = (srcpath / 'install').resolve()
     subprocess.run([
         'python',
         Path(os.environ['EMSCRIPTEN']) / 'tools' / 'file_packager.py',
         name + '.data',
         '--preload',
-        '{}@/lib/python3.6/site-packages'.format(libdir),
+        '{}@/'.format(install_prefix),
         '--js-output={}'.format(name + '.js'),
         '--export-name=pyodide',
         '--exclude', '*.wasm.pre',

--- a/tools/pywasmcross
+++ b/tools/pywasmcross
@@ -186,12 +186,23 @@ def clean_out_native_artifacts():
                 path.unlink()
 
 
+def install_for_distribution():
+    subprocess.check_call(
+        [Path(args.host) / 'bin' / 'python3',
+         'setup.py',
+         'install',
+         '--skip-build',
+         '--prefix=install',
+         '--old-and-unmanageable'])
+
+
 def build_wrap(args):
     build_log_path = Path('build.log')
     if not build_log_path.is_file():
         capture_compile(args)
     clean_out_native_artifacts()
     replay_compile(args)
+    install_for_distribution()
 
 
 def parse_args():


### PR DESCRIPTION
Fixes #126.

Currently, pyodide assumes that the contents of `build/lib...` are what gets installed into site-packages.  This is usually the case, but with numpy (and possibly others), not all files that are installed end up in `build/lib...`.  This adds an extra step after wasm compilation to run `setup.py install --skip-build --prefix=install --old-and-unmanageable` and then uses the results of that to build the package.  This should include everything that would get installed.

This does mean that the packages are now slightly larger.  Notably, matplotlib wasn't includeing mpl_toolkits before (which include 3D support), so there's an inadvertent bugfix there, too.