### PR TITLE
Generate test resources with make all

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
             ccache -z
             make
             ccache -s
-            make build/test.html build/test_data.txt
 
       - save_cache:
           paths:
@@ -93,7 +92,7 @@ jobs:
 
             source pyodide-env/bin/activate
             export PATH=$PWD/firefox:$PATH
-            pytest test -v --instafail -k firefox
+            pytest test -v -k firefox
 
   test-chrome:
     <<: *defaults
@@ -110,7 +109,7 @@ jobs:
 
             source pyodide-env/bin/activate
             export PATH=$PWD/firefox:$PATH
-            pytest test -v --instafail -k chrome
+            pytest test -v -k chrome
 
   deploy:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,12 @@ jobs:
             # Set up the Debian testing repo, and then install g++ from there...
             sudo bash -c "echo \"deb http://ftp.us.debian.org/debian testing main contrib non-free\" >> /etc/apt/sources.list"
             sudo apt-get update
-            sudo apt-get install node-less cmake build-essential flake8 uglifyjs python3-yaml chromium ccache
+            sudo apt-get install node-less cmake build-essential clang-format-6.0 flake8 uglifyjs python3-yaml chromium ccache
             sudo apt-get install -t testing g++-8
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8
             sudo update-alternatives --set gcc /usr/bin/gcc-8
+            sudo ln -s /usr/bin/clang-format-6.0 /usr/bin/clang-format
 
             sudo pip install virtualenv
             
@@ -43,7 +44,6 @@ jobs:
             wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
             unzip chromedriver_linux64.zip
             mv chromedriver firefox
-
 
       - run:
           name: lint

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ all: build/pyodide.asm.js \
 	build/matplotlib-sideload.html \
 	build/renderedhtml.css \
   build/test.data \
-  build/packages.json
+  build/packages.json \
+  build/test_data.txt \
+  build/test.html
 
 
 build/pyodide.asm.js: src/main.bc src/jsimport.bc src/jsproxy.bc src/js2python.bc \
@@ -103,6 +105,10 @@ build/renderedhtml.css: src/renderedhtml.less
 
 test: all
 	pytest test/ -v
+
+
+build/test_data.txt: test/data.txt
+	cp test/data.txt build/test_data.txt
 
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,8 @@ build/renderedhtml.css: src/renderedhtml.less
 	lessc $< $@
 
 
-test: all build/test.html build/test_data.txt
-	py.test test -v -r sxX --instafail
-
-
-build/test_data.txt: test/data.txt
-	cp test/data.txt build/test_data.txt
+test: all
+	pytest test/ -v
 
 
 lint:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install [geckodriver](https://github.com/mozilla/geckodriver/releases) and
 [chromedriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) somewhere
 on your `PATH`.
 
-`make test`
+`pytest test/`
 
 # Benchmarking
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+addopts =
+    -r sxX
+    --instafail

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,6 @@ import multiprocessing
 import os
 import pathlib
 import queue
-import shutil
 import sys
 
 try:
@@ -114,16 +113,8 @@ class ChromeWrapper(SeleniumWrapper):
 
 
 if pytest is not None:
-
-    @pytest.fixture(scope='session')
-    def setup_resources():
-        shutil.copyfile(TEST_PATH / 'data.txt',
-                        BUILD_PATH / 'test_data.txt')
-        shutil.copyfile(TEST_PATH.parent / 'src' / 'test.html',
-                        BUILD_PATH / 'test.html')
-
     @pytest.fixture(params=['firefox', 'chrome'])
-    def selenium_standalone(request, setup_resources):
+    def selenium_standalone(request):
         if request.param == 'firefox':
             cls = FirefoxWrapper
         elif request.param == 'chrome':
@@ -136,7 +127,7 @@ if pytest is not None:
             selenium.driver.quit()
 
     @pytest.fixture(params=['firefox', 'chrome'], scope='module')
-    def _selenium_cached(request, setup_resources):
+    def _selenium_cached(request):
         # Cached selenium instance. This is a copy-paste of
         # selenium_standalone to avoid fixture scope issues
         if request.param == 'firefox':


### PR DESCRIPTION
This aims to improve the user workflow for running tests. Running pytest directly has multiple advantages when compared to `make test` (including the abilty to run a subset of tests, using other plugins etc). At the same time, currently there is a risk of not generating the needed resources files that have to be created with,
```
make build/test.html build/test_data.txt
```

When those are missing, for any reason, the error message is unhelpful, and can lead to long debugging time as in https://github.com/iodide-project/pyodide/pull/127#issuecomment-416345852

This PR,
 - improves the error message if `build/tests.html` is missing for any reason (there is [no way to get the HTTP response status with selenium](https://stackoverflow.com/a/6512785/1791279))
 - auto-copies `build/tests.html` and `build/test_data.txt` at each pytest session with a session level fixture. This only copies ~540 bytes, so I don't think it's an issue to copy them each time. The advantages is that after `make`  one can directly run pytest with the desired options.
 - factorizes some pytest options in `setup.cfg` to avoid copying them each time in CI etc.