### PR TITLE
Load multiple packages in pyodide.loadPackage

### DIFF
--- a/docs/using_pyodide_from_iodide.md
+++ b/docs/using_pyodide_from_iodide.md
@@ -61,6 +61,11 @@ When you request a package from the official repository, all of that package's
 dependencies are also loaded. Dependency resolution is not yet implemented
 when loading packages from custom URLs.
 
+Multiple packages can also be loaded in a single call,
+```js
+pyodide.loadPackage(['cycler', 'pytz'])
+```
+
 `pyodide.loadPackage` returns a `Promise`.
 
 ```javascript

--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -49,6 +49,11 @@ When you request a package from the official repository, all of that package's
 dependencies are also loaded. Dependency resolution is not yet implemented
 when loading packages from custom URLs.
 
+Multiple packages can also be loaded in a single call,
+```js
+pyodide.loadPackage(['cycler', 'pytz'])
+```
+
 `pyodide.loadPackage` returns a `Promise`.
 
 ```javascript

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -36,7 +36,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   let loadPackage = (names) => {
     // DFS to find all dependencies of the requested packages
     let packages = window.pyodide.packages.dependencies;
-    let queue = new Array(names);
+    let queue = [].concat(names || []);
     let toLoad = new Array();
     while (queue.length) {
       let package_uri = queue.pop();

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -49,8 +49,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
         package_uri = 'default channel';
       }
 
-      console.log(`Loading ${package} from ${package_uri}`);
-
       if (package in loadedPackages) {
         if (package_uri != loadedPackages[package]) {
           throw new Error(
@@ -58,7 +56,16 @@ var languagePluginLoader = new Promise((resolve, reject) => {
               `${package} from ${package_uri} while it is already ` +
               `loaded from ${loadedPackages[package]}!`);
         }
+      } else if (package in toLoad) {
+        if (package_uri != toLoad[package]) {
+          throw new Error(
+              `URI mismatch, attempting to load package ` +
+              `${package} from ${package_uri} while it is already ` +
+              `being loaded from ${toLoad[package]}!`);
+        }
       } else {
+        console.log(`Loading ${package} from ${package_uri}`);
+
         toLoad[package] = package_uri;
         if (packages.hasOwnProperty(package)) {
           packages[package].forEach((subpackage) => {

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -37,8 +37,12 @@ def test_invalid_package_name(selenium):
         selenium.load_package('tcp://some_url')
 
 
-def test_load_packages_multiple(selenium):
-    selenium.load_package(['pyparsing', 'pytz'])
+def test_load_packages_multiple(selenium_standalone):
+    selenium = selenium_standalone
+    selenium.load_package(['pyparsing', 'matplotlib'])
+    selenium.run('import pyparsing')
+    selenium.run('import matplotlib')
+    assert selenium.logs.count('Loading pyparsing') == 1
 
 
 @pytest.mark.xfail(reason='Not implemented')


### PR DESCRIPTION
This solves part of https://github.com/iodide-project/pyodide/issues/135 and allows loading multiple packages in a single `pyodide.loadPackage` call,
```py
pyodide.loadPackage(['numpy', 'matplotlib'])
```
I'm am a bit bothered by the singular of "package". Maybe ideally it could have been another method `pyodide.loadPackages` or more neutral `pyodide.load`? Generally, in the use case where we have a list of dependencies and want to load them, this could be useful. The analogy with `pip install` that can install one or multiple packages also works.  WDYT ?

This PR also adds a unit test `test_load_packages_simultaneous` (that fails on master) corresponding to the case where we make two `pyodide.loadPackage` calls leading to an error. I'm  not quite sure how to address that (and my understanding of concurrent programming in JS is fairly limited). One possibility could have been to store a reference to the promise, created in `loadPackage` and if the reference is not `null`, wait for it to complete in any subsequent `loadPackage` call. The issue is that there is quite a bit of code in `loadPackage` that happens before the promise is returned (even assuming that this approach would work).
