### PR TITLE
Avoid using UTF8ToString

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -67,6 +67,15 @@ EM_JS(int, hiwire_string_utf8, (int ptr), {
   return Module.hiwire_new_value(UTF8ToString(ptr));
 });
 
+EM_JS(int, hiwire_string_ascii, (int ptr), {
+  var jsstr = "";
+  var idx = ptr;
+  for (var idx = ptr; Module.HEAPU8[idx] != 0; ++idx) {
+    jsstr += String.fromCharCode(Module.HEAPU8[idx]);
+  }
+  return Module.hiwire_new_value(jsstr);
+});
+
 EM_JS(int, hiwire_bytes, (int ptr, int len), {
   var bytes = new Uint8ClampedArray(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire_new_value(bytes);

--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -68,12 +68,7 @@ EM_JS(int, hiwire_string_utf8, (int ptr), {
 });
 
 EM_JS(int, hiwire_string_ascii, (int ptr), {
-  var jsstr = "";
-  var idx = ptr;
-  for (var idx = ptr; Module.HEAPU8[idx] != 0; ++idx) {
-    jsstr += String.fromCharCode(Module.HEAPU8[idx]);
-  }
-  return Module.hiwire_new_value(jsstr);
+  return Module.hiwire_new_value(AsciiToString(ptr));
 });
 
 EM_JS(int, hiwire_bytes, (int ptr, int len), {

--- a/src/hiwire.h
+++ b/src/hiwire.h
@@ -87,6 +87,16 @@ int
 hiwire_string_utf8(int ptr);
 
 /**
+ * Create a new Javascript string, given a pointer to a null-terminated buffer
+ * containing ascii (well, technically latin-1). The string data itself is
+ * copied.
+ *
+ * Returns: New reference
+ */
+int
+hiwire_string_ascii(int ptr);
+
+/**
  * Create a new Javascript Uint8ClampedArray, given a pointer to a buffer and a
  * length, in bytes.
  *

--- a/src/python2js.c
+++ b/src/python2js.c
@@ -21,7 +21,7 @@ pythonexc2js()
   int exc;
 
   if (type == NULL || type == Py_None || value == NULL || value == Py_None) {
-    excval = hiwire_string_utf8((int)"No exception type or value");
+    excval = hiwire_string_ascii((int)"No exception type or value");
     PyErr_Print();
     PyErr_Clear();
     goto exit;
@@ -31,7 +31,7 @@ pythonexc2js()
   if (tbmod == NULL) {
     PyObject* repr = PyObject_Repr(value);
     if (repr == NULL) {
-      excval = hiwire_string_utf8((int)"Could not get repr for exception");
+      excval = hiwire_string_ascii((int)"Could not get repr for exception");
     } else {
       excval = python2js(repr);
       Py_DECREF(repr);
@@ -46,7 +46,7 @@ pythonexc2js()
     }
     if (format_exception == NULL) {
       excval =
-        hiwire_string_utf8((int)"Could not get format_exception function");
+        hiwire_string_ascii((int)"Could not get format_exception function");
     } else {
       PyObject* pylines;
       if (no_traceback) {
@@ -58,7 +58,7 @@ pythonexc2js()
       }
       if (pylines == NULL) {
         excval =
-          hiwire_string_utf8((int)"Error calling traceback.format_exception");
+          hiwire_string_ascii((int)"Error calling traceback.format_exception");
         PyErr_Print();
         PyErr_Clear();
         goto exit;


### PR DESCRIPTION
The only places we were using it was for strings that are ASCII anyway,
so this is both more efficient and avoids this Chrome bug:

https://bugs.chromium.org/p/chromium/issues/detail?id=868404