### PR TITLE
MAINT Fix and refactor tests/make_test_list.py

### DIFF
--- a/test/make_test_list.py
+++ b/test/make_test_list.py
@@ -5,24 +5,36 @@ Generate a list of test modules in the CPython distribution.
 import os
 from pathlib import Path
 
-tests = []
 
-TEST_DIR = Path("../cpython/build/3.6.4/host/lib/python3.6/test")
+TEST_DIR = (Path(__file__).parent
+            / "cpython/build/3.6.4/host/lib/python3.6/test")
 
-for root, dirs, files in os.walk(
-        "../cpython/build/3.6.4/host/lib/python3.6/test"):
-    root = Path(root).relative_to(TEST_DIR)
-    if root == '.':
-        root = ''
-    else:
-        root = '.'.join(root.split('/')) + '.'
 
-    for filename in files:
-        filename = Path(filename)
-        if str(filename).startswith("test_") and filename.suffix == ".py":
-            tests.append(str(root / filename.stem))
+def collect_tests(base_dir):
+    """Collect CPython unit tests"""
+    # Note: this functionality is somewhat equivalent to pytest test
+    # collection.
+    tests = []
 
-tests.sort()
-with open("python_tests.txt", "w") as fp:
-    for test in tests:
-        fp.write(test + '\n')
+    for root, dirs, files in os.walk(base_dir):
+        root = Path(root).relative_to(base_dir)
+
+        if str(root) == '.':
+            root = ''
+        else:
+            root = '.'.join(str(root).split('/')) + '.'
+
+        for filename in files:
+            filename = Path(filename)
+            if str(filename).startswith("test_") and filename.suffix == ".py":
+                tests.append(root + filename.stem)
+
+    tests.sort()
+    return tests
+
+
+if __name__ == '__main__':
+    tests = collect_tests(TEST_DIR)
+    with open("python_tests.txt", "w") as fp:
+        for test in tests:
+            fp.write(test + '\n')


### PR DESCRIPTION
This fixes and refactors somewhat `tests/make_test_list.py`: I was getting errors when trying to use it, I think due to the pathlib conversion (and the fact that some of these are not file systems paths but python import paths). 

It also factorized the code in a function, so it's not run when the module is imported. I think pytest with different options could have executed it during test collections (e.g. while searching for doctests), and this is generally safer.

The new output (for Python 3.7) can be found in https://github.com/iodide-project/pyodide/pull/77#discussion_r215598245