### PR TITLE
Ensure that package loading runs in sequence

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -53,18 +53,16 @@ var languagePluginLoader = new Promise((resolve, reject) => {
 
       if (package in loadedPackages) {
         if (package_uri != loadedPackages[package]) {
-          console.error(
-              `URI mismatch, attempting to load package ` +
-              `${package} from ${package_uri} while it is already ` +
-              `loaded from ${loadedPackages[package]}!`);
+          console.error(`URI mismatch, attempting to load package ` +
+                        `${package} from ${package_uri} while it is already ` +
+                        `loaded from ${loadedPackages[package]}!`);
           return;
         }
       } else if (package in toLoad) {
         if (package_uri != toLoad[package]) {
-          console.error(
-              `URI mismatch, attempting to load package ` +
-              `${package} from ${package_uri} while it is already ` +
-              `being loaded from ${toLoad[package]}!`);
+          console.error(`URI mismatch, attempting to load package ` +
+                        `${package} from ${package_uri} while it is already ` +
+                        `being loaded from ${toLoad[package]}!`);
           return;
         }
       } else {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -125,9 +125,8 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   let loadPackage = (names) => {
     /* We want to make sure that only one loadPackage invocation runs at any
      * given time, so this creates a "chain" of promises. */
-    loadPackagePromise = loadPackagePromise
-      .then(() => _loadPackage(names))
-      .catch((e) => console.log(e.to_string()));
+    loadPackagePromise = loadPackagePromise.then(() => _loadPackage(names))
+                             .catch((e) => console.log(e.to_string()));
     return loadPackagePromise;
   };
 

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -45,24 +45,27 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       const package = _uri_to_package_name(package_uri);
 
       if (package == null) {
-        throw new Error(`Invalid package name or URI '${package_uri}'`);
+        console.error(`Invalid package name or URI '${package_uri}'`);
+        return;
       } else if (package == package_uri) {
         package_uri = 'default channel';
       }
 
       if (package in loadedPackages) {
         if (package_uri != loadedPackages[package]) {
-          throw new Error(
+          console.error(
               `URI mismatch, attempting to load package ` +
               `${package} from ${package_uri} while it is already ` +
               `loaded from ${loadedPackages[package]}!`);
+          return;
         }
       } else if (package in toLoad) {
         if (package_uri != toLoad[package]) {
-          throw new Error(
+          console.error(
               `URI mismatch, attempting to load package ` +
               `${package} from ${package_uri} while it is already ` +
               `being loaded from ${toLoad[package]}!`);
+          return;
         }
       } else {
         console.log(`Loading ${package} from ${package_uri}`);
@@ -125,8 +128,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   let loadPackage = (names) => {
     /* We want to make sure that only one loadPackage invocation runs at any
      * given time, so this creates a "chain" of promises. */
-    loadPackagePromise = loadPackagePromise.then(() => _loadPackage(names))
-                             .catch((e) => console.log(e.to_string()));
+    loadPackagePromise = loadPackagePromise.then(() => _loadPackage(names));
     return loadPackagePromise;
   };
 

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -125,7 +125,9 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   let loadPackage = (names) => {
     /* We want to make sure that only one loadPackage invocation runs at any
      * given time, so this creates a "chain" of promises. */
-    loadPackagePromise = loadPackagePromise.then(() => _loadPackage(names));
+    loadPackagePromise = loadPackagePromise
+      .then(() => _loadPackage(names))
+      .catch((e) => console.log(e.to_string()));
     return loadPackagePromise;
   };
 

--- a/src/test.html
+++ b/src/test.html
@@ -13,6 +13,9 @@
          console.info = function(message) {
              window.logs.push(message);
          }
+         console.error = function(message) {
+             window.logs.push(message);
+         }
         </script>
         <script src="pyodide_dev.js"></script>
     </head>

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,12 +91,15 @@ class SeleniumWrapper:
         return self.driver.execute_script(catch)
 
     def load_package(self, packages):
-        from selenium.common.exceptions import TimeoutException
-
         self.run_js(
             'window.done = false\n' +
             'pyodide.loadPackage({!r})'.format(packages) +
             '.then(function() { window.done = true; })')
+        self.wait_until_packages_loaded()
+
+    def wait_until_packages_loaded(self):
+        from selenium.common.exceptions import TimeoutException
+
         try:
             self.wait.until(PackageLoaded())
         except TimeoutException as exc:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -94,7 +94,7 @@ class SeleniumWrapper:
         self.run_js(
             'window.done = false\n' +
             'pyodide.loadPackage({!r})'.format(packages) +
-            '.then(function() { window.done = true; })')
+            '.finally(function() { window.done = true; })')
         self.wait_until_packages_loaded()
 
     def wait_until_packages_loaded(self):

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -18,10 +18,9 @@ def test_load_from_url(selenium_standalone, web_server):
 
 def test_uri_mismatch(selenium_standalone):
     selenium_standalone.load_package('pyparsing')
-    with pytest.raises(WebDriverException,
-                       match="URI mismatch, attempting "
-                             "to load package pyparsing"):
-        selenium_standalone.load_package('http://some_url/pyparsing.js')
+    selenium_standalone.load_package('http://some_url/pyparsing.js')
+    assert ("URI mismatch, attempting to load package pyparsing" in
+            selenium_standalone.logs)
     assert "Invalid package name or URI" not in selenium_standalone.logs
 
 
@@ -62,7 +61,7 @@ def test_load_packages_sequential(selenium_standalone, packages):
     selenium.run_js(
         'window.done = false\n' +
         'Promise.all([{}])'.format(promises) +
-        '.then(function() { window.done = true; })')
+        '.finally(function() { window.done = true; })')
     selenium.wait_until_packages_loaded()
     selenium.run(f'import {packages[0]}')
     selenium.run(f'import {packages[1]}')

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -25,14 +25,12 @@ def test_uri_mismatch(selenium_standalone):
 
 
 def test_invalid_package_name(selenium):
-    with pytest.raises(WebDriverException,
-                       match="Invalid package name or URI"):
-        selenium.load_package('wrong name+$')
+    selenium.load_package('wrong name+$')
+    assert "Invalid package name or URI" in selenium.logs
     selenium.clean_logs()
 
-    with pytest.raises(WebDriverException,
-                       match="Invalid package name or URI"):
-        selenium.load_package('tcp://some_url')
+    selenium.load_package('tcp://some_url')
+    assert "Invalid package name or URI" in selenium.logs
 
 
 @pytest.mark.parametrize('packages', [['pyparsing', 'pytz'],

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -1,5 +1,4 @@
 import pytest
-from selenium.common.exceptions import WebDriverException
 
 
 def test_load_from_url(selenium_standalone, web_server):


### PR DESCRIPTION
Fixes #135.

This ensures that even if the user calls `loadPackage` multiple times in sequence, that the loading of packages won't happen in parallel, but will instead wait for the previous invocation to complete.