### PR TITLE
MAINT Use multi-line code snippets in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ Various common utilities for testing.
 
 import atexit
 import multiprocessing
+import textwrap
 import os
 import pathlib
 import queue
@@ -73,10 +74,16 @@ class SeleniumWrapper:
         self.driver.execute_script("window.logs = []")
 
     def run(self, code):
+        if isinstance(code, str) and code.startswith('\n'):
+            # we have a multiline string, fix indentation
+            code = textwrap.dedent(code)
         return self.run_js(
             'return pyodide.runPython({!r})'.format(code))
 
     def run_js(self, code):
+        if isinstance(code, str) and code.startswith('\n'):
+            # we have a multiline string, fix indentation
+            code = textwrap.dedent(code)
         catch = f"""
             Error.stackTraceLimit = Infinity;
             try {{ {code} }}

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1,12 +1,17 @@
 def test_pytest(selenium):
-    selenium.load_package('pytest')
-    selenium.load_package('numpy')
-    selenium.load_package('nose')
-    selenium.run('from pathlib import Path')
-    selenium.run('import os')
-    selenium.run('import numpy')
-    selenium.run('base_dir = Path(numpy.__file__).parent / "core" / "tests"')
-    selenium.run("import pytest;"
-                 "pytest.main([base_dir / 'test_api.py'])")
+    selenium.load_package(['pytest', 'numpy', 'nose'])
+
+    selenium.run(
+        """
+        from pathlib import Path
+        import os
+        import numpy
+        import pytest
+
+        base_dir = Path(numpy.__file__).parent / "core" / "tests"
+        """)
+
+    selenium.run("pytest.main([base_dir / 'test_api.py'])")
+
     logs = '\n'.join(selenium.logs)
     assert 'INTERNALERROR' not in logs


### PR DESCRIPTION
This allows to use multi-line strings for code snippets in tests, e.g.

Instead of,
```py
selenium.run(
       "class Foo:\n"
       "  bar = 42\n"
       "  def get_value(self, value):\n"
       "    return value * 64\n"
       "f = Foo()\n")
```
it becomes possible to use,
```py
selenium.run(
       """
       class Foo:
         bar = 42
         def get_value(self, value):
           return value * 64
       f = Foo()
       """)
```
The indentation is fixed with `textwrap.dedent` if the code snippet starts with a newline.

This applies to both `selenium.run` and `selenium.run_js`, as a result the corresponding snippets are more readable. This also allows to use both `"` and `'` without escaping them.