### PR TITLE
Loading wheels from PyPI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 - [Using Pyodide directly from Javascript](using_pyodide_from_javascript.md)
 - [Using Pyodide from a web worker](using_pyodide_from_webworker.md)
 - [Using Pyodide from Iodide](using_pyodide_from_iodide.md)
+- [Installing packages from PyPI](pypi.md)
 
 ## Developing Pyodide
 

--- a/docs/pypi.md
+++ b/docs/pypi.md
@@ -2,6 +2,15 @@
 
 Pyodide has experimental support for installing pure Python wheels from PyPI.
 
+**IMPORTANT:** Since the packages hosted at `files.pythonhosted.org` don't
+support CORS requests, we use a CORS proxy at `cors-anywhere.herokuapp.com` to
+get package contents. This makes a man-in-the-middle attack on the package
+contents possible. However, this threat is minimized by the fact that the
+integrity of each package is checked using a hash obtained directly from
+`pypi.org`. We hope to have this improved in the future, but for now, understand
+the risks and don't use any sensitive data with the packages installed using
+this method.
+
 For use in Iodide:
 
 ```

--- a/docs/pypi.md
+++ b/docs/pypi.md
@@ -1,0 +1,33 @@
+# Installing packages from PyPI
+
+Pyodide has experimental support for installing pure Python wheels from PyPI.
+
+For use in Iodide:
+
+```
+%% py
+import micropip
+micropip.install('snowballstemmer')
+
+# Iodide implicitly waits for the promise to resolve when the packages have finished
+# installing...
+
+%% py
+import snowballstemmer
+snowballstemmer.stemmer('english')
+stemmer.stemWords('go goes going gone'.split())
+```
+
+For use outside of Iodide (just Python), you can use the `then` method on the
+`Promise` that `micropip.install` returns to do work once the packages have
+finished loading:
+
+```
+def do_work(*args):
+  import snowballstemmer
+  snowballstemmer.stemmer('english')
+  stemmer.stemWords('go goes going gone'.split())
+
+import micropip
+micropip.install('snowballstemmer').then(do_work)
+```

--- a/packages/distlib/meta.yaml
+++ b/packages/distlib/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: distlib
+  version: 0.2.8
+source:
+  sha256: 57977cd7d9ea27986ec62f425630e4ddb42efe651ff80bc58ed8dbc3c7c21f19
+  url: https://files.pythonhosted.org/packages/d4/81/ae64653802eceb93f5c33d882f4ea1290bb77ba165ac78d1dfa39e860ea9/distlib-0.2.8.zip
+test:
+  imports:
+  - distlib

--- a/packages/micropip/build/micropip-0.1/micropip.py
+++ b/packages/micropip/build/micropip-0.1/micropip.py
@@ -203,6 +203,15 @@ def install(requirements):
 
     Returns a Promise that resolves when all packages have downloaded and
     installed.
+
+    **IMPORTANT:** Since the packages hosted at `files.pythonhosted.org` don't
+    support CORS requests, we use a CORS proxy at `cors-anywhere.herokuapp.com`
+    to get package contents. This makes a man-in-the-middle attack on the
+    package contents possible. However, this threat is minimized by the fact
+    that the integrity of each package is checked using a hash obtained
+    directly from `pypi.org`. We hope to have this improved in the future, but
+    for now, understand the risks and don't use any sensitive data with the
+    packages installed using this method.
     """
     def do_install(resolve, reject):
         PACKAGE_MANAGER.install(

--- a/packages/micropip/build/micropip-0.1/micropip.py
+++ b/packages/micropip/build/micropip-0.1/micropip.py
@@ -1,0 +1,217 @@
+try:
+    from js import Promise, window, XMLHttpRequest
+except ImportError:
+    window = None
+
+import hashlib
+import importlib
+import io
+import json
+from pathlib import Path
+import zipfile
+
+from distlib import markers, util, version
+
+
+def _nullop(*args):
+    return
+
+
+# Provide implementations of HTTP fetching for in-browser and out-of-browser to
+# make testing easier
+if window is not None:
+    import pyodide
+
+    def _get_url(url):
+        return pyodide.open_url(url)
+
+    def _get_url_async(url, cb):
+        req = XMLHttpRequest.new()
+        req.open('GET', url, True)
+        req.responseType = 'arraybuffer'
+
+        def callback(e):
+            if req.readyState == 4:
+                cb(io.BytesIO(req.response))
+
+        req.onreadystatechange = callback
+        req.send(None)
+
+    # In practice, this is the `site-packages` directory.
+    WHEEL_BASE = Path(__file__).parent
+else:
+    # Outside the browser
+    from urllib.request import urlopen
+
+    def _get_url(url):
+        with urlopen(url) as fd:
+            content = fd.read()
+        return io.BytesIO(content)
+
+    def _get_url_async(url, cb):
+        cb(_get_url(url))
+
+    WHEEL_BASE = Path('.') / 'wheels'
+
+
+def _get_pypi_json(pkgname):
+    url = f'https://cors-anywhere.herokuapp.com/https://pypi.org/pypi/{pkgname}/json'
+    fd = _get_url(url)
+    return json.load(fd)
+
+
+class _WheelInstaller:
+    def extract_wheel(self, fd):
+        with zipfile.ZipFile(fd) as zf:
+            zf.extractall(WHEEL_BASE)
+
+    def validate_wheel(self, data, fileinfo):
+        sha256 = fileinfo['digests']['sha256']
+        m = hashlib.sha256()
+        m.update(data.getvalue())
+        if m.hexdigest() != sha256:
+            raise ValueError("Contents don't match hash")
+
+    def __call__(self, name, fileinfo, resolve, reject):
+        url = self.fetch_wheel(name, fileinfo)
+
+        def callback(wheel):
+            try:
+                self.validate_wheel(wheel, fileinfo)
+                self.extract_wheel(wheel)
+            except Exception as e:
+                reject(str(e))
+            else:
+                resolve()
+
+        _get_url_async(url, callback)
+
+
+class _RawWheelInstaller(_WheelInstaller):
+    def fetch_wheel(self, name, fileinfo):
+        return 'https://cors-anywhere.herokuapp.com/' + fileinfo['url']
+
+
+class _PackageManager:
+    version_scheme = version.get_scheme('normalized')
+
+    def __init__(self):
+        self.installed_packages = {}
+
+    def install(
+            self,
+            requirements,
+            ctx=None,
+            wheel_installer=None,
+            resolve=_nullop,
+            reject=_nullop
+    ):
+        try:
+            if ctx is None:
+                ctx = {'extra': None}
+
+            if wheel_installer is None:
+                wheel_installer = _RawWheelInstaller()
+
+            complete_ctx = dict(markers.DEFAULT_CONTEXT)
+            complete_ctx.update(ctx)
+
+            if isinstance(requirements, str):
+                requirements = [requirements]
+
+            transaction = {
+                'wheels': [],
+                'locked': dict(self.installed_packages)
+            }
+            for requirement in requirements:
+                self.add_requirement(requirement, ctx, transaction)
+        except Exception as e:
+            reject(str(e))
+
+        resolve_count = [len(transaction['wheels'])]
+        def do_resolve():
+            resolve_count[0] -= 1
+            if resolve_count[0] == 0:
+                resolve(f'Installed {", ".join(self.installed_packages.keys())}')
+
+        for name, wheel, ver in transaction['wheels']:
+            wheel_installer(name, wheel, do_resolve, reject)
+            self.installed_packages[name] = ver
+
+    def add_requirement(self, requirement, ctx, transaction):
+        req = util.parse_requirement(requirement)
+
+        if req.marker:
+            if not markers.evaluator.evaluate(
+                    req.marker, ctx):
+                return
+
+        matcher = self.version_scheme.matcher(req.requirement)
+
+        # If we already have something that will work, don't
+        # fetch again
+        for name, ver in transaction['locked'].items():
+            if name == req.name:
+                if matcher.match(ver):
+                    break
+                else:
+                    raise ValueError(
+                        f"Requested '{requirement}', "
+                        f"but {name}=={ver} is already installed"
+                    )
+        else:
+            metadata = _get_pypi_json(req.name)
+            wheel, ver = self.find_wheel(metadata, req)
+            transaction['locked'][req.name] = ver
+
+            reqs = metadata.get('info', {}).get('requires_dist') or []
+            for req in reqs:
+                self.add_requirement(req, ctx, transaction)
+
+            transaction['wheels'].append((req.name, wheel, ver))
+
+    def find_wheel(self, metadata, req):
+        releases = []
+        for ver, files in metadata.get('releases', {}).items():
+            ver = self.version_scheme.suggest(ver)
+            if ver is not None:
+                releases.append((ver, files))
+        releases = sorted(releases, reverse=True)
+        matcher = self.version_scheme.matcher(req.requirement)
+        for ver, meta in releases:
+            if matcher.match(ver):
+                for fileinfo in meta:
+                    if fileinfo['filename'].endswith('py3-none-any.whl'):
+                        return fileinfo, ver
+
+        raise ValueError(
+            f"Couldn't find a pure Python 3 wheel for '{req.requirement}'"
+        )
+
+
+# Make PACKAGE_MANAGER singleton
+PACKAGE_MANAGER = _PackageManager()
+del _PackageManager
+
+
+def install(requirements):
+    """
+    Install the given package and all of its dependencies.
+
+    Returns a Promise that resolves when all packages have downloaded and
+    installed.
+    """
+    def do_install(resolve, reject):
+        PACKAGE_MANAGER.install(
+            requirements, resolve=resolve, reject=reject
+        )
+        importlib.invalidate_caches()
+
+    return Promise.new(do_install)
+
+
+__all__ = ['install']
+
+
+if __name__ == '__main__':
+    install('snowballstemmer')

--- a/packages/micropip/build/micropip-0.1/micropip.py
+++ b/packages/micropip/build/micropip-0.1/micropip.py
@@ -23,7 +23,10 @@ if window is not None:
     import pyodide
 
     def _get_url(url):
-        return pyodide.open_url(url)
+        req = XMLHttpRequest.new()
+        req.open('GET', url, False)
+        req.send(None)
+        return io.StringIO(req.response)
 
     def _get_url_async(url, cb):
         req = XMLHttpRequest.new()
@@ -55,7 +58,7 @@ else:
 
 
 def _get_pypi_json(pkgname):
-    url = f'https://cors-anywhere.herokuapp.com/https://pypi.org/pypi/{pkgname}/json'
+    url = f'https://pypi.org/pypi/{pkgname}/json'
     fd = _get_url(url)
     return json.load(fd)
 

--- a/packages/micropip/build/micropip-0.1/setup.py
+++ b/packages/micropip/build/micropip-0.1/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(
+    name='micropip',
+    version='0.1',
+    description='A small version of pip for running in pyodide',
+    author='Michael Droettboom',
+    author_email='mdroettboom@mozilla.com',
+    url='https://github.com/iodide-project/pyodide',
+    py_modules=['micropip'],
+)

--- a/packages/micropip/meta.yaml
+++ b/packages/micropip/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: micropip
+  version: "0.1"
+requirements:
+  run:
+    - distlib
+test:
+  imports:
+  - micropip

--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -371,10 +371,10 @@ EM_JS(int, hiwire_get_byteLength, (int idobj), {
 
 EM_JS(int, hiwire_copy_to_ptr, (int idobj, int ptr), {
   var jsobj = Module.hiwire_get_value(idobj);
-  if ('buffer' in jsobj) {
-    jsobj = jsobj.buffer;
-  }
-  Module.HEAPU8.set(new Uint8Array(jsobj), ptr);
+  // clang-format off
+  var buffer = (jsobj['buffer'] !== undefined) ? jsobj.buffer : jsobj;
+  // clang-format on
+  Module.HEAPU8.set(new Uint8Array(buffer), ptr);
 });
 
 EM_JS(int, hiwire_get_dtype, (int idobj), {
@@ -406,6 +406,9 @@ EM_JS(int, hiwire_get_dtype, (int idobj), {
       break;
     case 'Float64Array':
       dtype = 9; // FLOAT64_TYPE;
+      break;
+    case 'ArrayBuffer':
+      dtype = 3;
       break;
     default:
       dtype = 3; // UINT8CLAMPED_TYPE;

--- a/test/test_micropip.py
+++ b/test/test_micropip.py
@@ -1,0 +1,24 @@
+import time
+
+
+def test_install_simple(selenium_standalone):
+    selenium_standalone.run("import os")
+    selenium_standalone.load_package("micropip")
+    selenium_standalone.run("import micropip")
+    selenium_standalone.run("micropip.install('snowballstemmer')")
+
+    for i in range(10):
+        if selenium_standalone.run(
+                "os.path.exists"
+                "('/lib/python3.6/site-packages/snowballstemmer')"
+        ):
+            break
+        else:
+            time.sleep(1)
+
+    selenium_standalone.run("import snowballstemmer")
+    selenium_standalone.run("stemmer = snowballstemmer.stemmer('english')")
+    assert selenium_standalone.run(
+        "stemmer.stemWords('go going goes gone'.split())") == [
+            'go', 'go', 'goe', 'gone'
+        ]


### PR DESCRIPTION
This shows that at least it should be theoretically possible to load pure Python wheels from PyPI.

The biggest obstacle is that `files.pythonhosted.org` doesn't seem to allow CORS requests, so we're blocked from downloading files directly from there.  There is a workaround: running a local `devpi` server, patched to support CORS -- details in the docs.  But that's not a great solution.  Perhaps `files.pythonhosted.org` could lift that restriction (it's possible it's just an oversight, but it could be there for good reason).  Alternatively, the iodide server could grow the ability to proxy PyPI packages.

Some other missing details:
- [x] Package distlib as a real package, rather than vendoring
- [x] Provide a callback when packages have finished loading (due to browser design, they must be loaded asyncronously)