### PR TITLE
MAINT: Update {chrome,firefox}_options to options

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -129,7 +129,7 @@ class FirefoxWrapper(SeleniumWrapper):
         self.JavascriptException = JavascriptException
 
         return Firefox(
-            executable_path='geckodriver', firefox_options=options)
+            executable_path='geckodriver', options=options)
 
 
 class ChromeWrapper(SeleniumWrapper):
@@ -146,7 +146,7 @@ class ChromeWrapper(SeleniumWrapper):
 
         self.JavascriptException = WebDriverException
 
-        return Chrome(chrome_options=options)
+        return Chrome(options=options)
 
 
 if pytest is not None:


### PR DESCRIPTION
Selenium is saying:

```
/home/circleci/repo/pyodide-env/lib/python3.7/site-packages/selenium/webdriver/chrome/webdriver.py:50: DeprecationWarning: use options instead of chrome_options
  warnings.warn('use options instead of chrome_options', DeprecationWarning)
```