### PR TITLE
Guard against infinite recursion when converting self-referential data structures

### DIFF
--- a/src/python2js.c
+++ b/src/python2js.c
@@ -279,10 +279,11 @@ _python2js_cache(PyObject* x, PyObject* map)
   PyObject* val = PyDict_GetItem(map, id);
   int result;
   if (val) {
-    result = hiwire_incref(PyLong_AsLong(val));
+    result = PyLong_AsLong(val);
+    if (result != -1) {
+      result = hiwire_incref(result);
+    }
     Py_DECREF(val);
-    /* No need to check for result == -1, because that's the same */
-    /* value we use here to indicate error */
   } else {
     result = _python2js(x, map);
   }

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -406,3 +406,23 @@ def test_version_info(selenium):
     version_js_str = selenium.run_js("return pyodide.version()")
     version_js = LooseVersion(version_js_str)
     assert version_py == version_js
+
+
+def test_recursive_list(selenium):
+    selenium.run(
+        """
+        x = []
+        x.append(x)
+        """
+    )
+    selenium.run_js("x = pyodide.pyimport('x')")
+
+
+def test_recursive_dict(selenium):
+    selenium.run(
+        """
+        x = {}
+        x[0] = x
+        """
+    )
+    selenium.run_js("x = pyodide.pyimport('x')")

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -408,21 +408,21 @@ def test_version_info(selenium):
     assert version_py == version_js
 
 
-def test_recursive_list(selenium):
-    selenium.run(
+def test_recursive_list(selenium_standalone):
+    selenium_standalone.run(
         """
         x = []
         x.append(x)
         """
     )
-    selenium.run_js("x = pyodide.pyimport('x')")
+    selenium_standalone.run_js("x = pyodide.pyimport('x')")
 
 
-def test_recursive_dict(selenium):
-    selenium.run(
+def test_recursive_dict(selenium_standalone):
+    selenium_standalone.run(
         """
         x = {}
         x[0] = x
         """
     )
-    selenium.run_js("x = pyodide.pyimport('x')")
+    selenium_standalone.run_js("x = pyodide.pyimport('x')")


### PR DESCRIPTION
This properly re-creates self-referential data structures when copying from Python to Javascript.

[ The inverse isn't needed since js objects and arrays are passed to Python as proxy objects instead of being converted to Python dicts and lists.  This is because (1) Javascript Objects and Arrays are sorta-kinda-the-same-thing and (2) operator overloading is so much better in Python so this approach is reasonable. ]