### PR TITLE
full nodejs support in file_packager.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ ccache
 /emsdk/emsdk
 
 /six/six-1.11.0
+/lz4/lz4-1.8.3

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ all: build/pyodide.asm.js \
 	build/pyodide.js \
 	build/pyodide_dev.js \
 	build/python.html \
+	build/python_dev.html \
 	build/matplotlib.html \
 	build/matplotlib-sideload.html \
 	build/renderedhtml.css \
@@ -84,6 +85,10 @@ build/pyodide.js: src/pyodide.js
 
 
 build/python.html: src/python.html
+	cp $< $@
+
+
+build/python_dev.html: src/python_dev.html
 	cp $< $@
 
 

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -83,7 +83,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.patched
 	cp config.site $(BUILD)/
 	( \
 		cd $(BUILD); \
-		CONFIG_SITE=./config.site READELF=true emconfigure ./configure --without-threads --without-pymalloc --disable-shared --disable-ipv6 --without-gcc --host=asmjs-unknown-emscripten --build=$(shell $(BUILD)/config.guess) --prefix=$(INSTALL) ; \
+		CONFIG_SITE=./config.site READELF=true emconfigure ./configure --without-pymalloc --disable-shared --disable-ipv6 --without-gcc --host=asmjs-unknown-emscripten --build=$(shell $(BUILD)/config.guess) --prefix=$(INSTALL) ; \
 	)
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Using Pyodide directly from Javascript](using_pyodide_from_javascript.md)
 - [Using Pyodide from Iodide](using_pyodide_from_iodide.md)
 - [Type conversions](type_conversions.md): describes how data types are shared between Python and Javascript
+- [API Reference](api_reference.md)
 
 ## Developing Pyodide
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,157 @@
+# API Reference
+
+*pyodide version 0.1.0*
+
+Backward compatibility of the API is not guaranteed at this point.
+
+
+## Python API
+
+
+### pyodide.open_url(url)
+
+Fetches a given *url* and returns a `io.StringIO` to access its contents.
+
+*Parameters*
+
+| name  | type | description     |
+|-------|------|-----------------|
+| *url* | str  | the URL to open |
+
+
+*Returns*
+
+A `io.StringIO` object with the URL contents./
+
+### pyodide.eval_code(code, ns)
+
+Runs a string of code. The last part of the string may be an expression, in which case, its value is returned.
+
+This function may be overridden to change how `pyodide.runPython` interprets code, for example to perform
+some preprocessing on the Python code first.
+
+*Parameters*
+
+| name   | type  | description           |
+|--------|-------|-----------------------|
+| *code* | str   | the code to evaluate  |
+| *ns*   | dict  | evaluation name space |
+
+
+*Returns*
+
+Either the resulting object or `None`.
+
+
+## Javascript API
+
+### pyodide.loadPackage(names)
+
+Load a package or a list of packages over the network.
+
+This makes the files for the package available in the virtual filesystem.  
+The package needs to be imported from Python before it can be used.
+
+*Parameters*
+
+| name    | type            | description                           |
+|---------|-----------------|---------------------------------------|
+| *names* | {String, Array} | package name, or URL. Can be either a single element, or an array.          |
+
+
+*Returns*
+
+Loading is asynchronous, therefore, this returns a promise.
+
+
+### pyodide.loadedPackage
+
+`Array` with loaded packages.
+
+Use `Object.keys(pyodide.loadedPackage)` to access the names of the
+loaded packages, and `pyodide.loadedPackage[package_name]` to access
+install location for a particular `package_name`.
+
+### pyodide.pyimport(name)
+
+Access a Python object from Javascript.  The object must be in the global Python namespace.
+
+For example, to access the `foo` Python object from Javascript:
+
+   `var foo = pyodide.pyimport('foo')`
+
+*Parameters*
+
+| name    | type   | description          |
+|---------|--------|----------------------|
+| *names* | String | Python variable name |
+
+
+*Returns*
+
+| name      | type    | description                           |
+|-----------|---------|---------------------------------------|
+| *object*  | *any*   | If one of the basic types (string,    |
+|           |         | number, boolean, array, object), the  |
+|           |         | Python object is converted to         |
+|           |         | Javascript and returned.  For other   |
+|           |         | types, a Proxy object to the Python   |
+|           |         | object is returned.                   |
+
+
+### pyodide.repr(obj)
+
+Gets the Python's string representation of an object.
+
+This is equivalent to calling `repr(obj)` in Python.
+
+*Parameters*
+
+| name    | type   | description         |
+|---------|--------|---------------------|
+| *obj*   | *any*  | Input object        |
+
+
+*Returns*
+
+| name       | type    | description                               |
+|------------|---------|-------------------------------------------|
+| *str_repr* | String  | String representation of the input object |
+
+
+### pyodide.runPython(code)
+
+Runs a string of code. The last part of the string may be an expression, in which case, its value is returned.
+
+*Parameters*
+
+| name    | type   | description                    |
+|---------|--------|--------------------------------|
+| *code*  | String | Python code to evaluate        |
+
+
+*Returns*
+
+| name       | type    | description                     |
+|------------|---------|---------------------------------|
+| *jsresult* | *any*   | Result, converted to Javascript |
+
+
+### pyodide.version()
+
+Returns the pyodide version.
+
+It can be either the exact release version (e.g. `0.1.0`), or 
+the latest release version followed by the number of commits since, and
+the git hash of the current commit (e.g. `0.1.0-1-bd84646`).
+
+*Parameters*
+
+None
+
+*Returns*
+
+| name      | type   | description            |
+|-----------|--------|------------------------|
+| *version* | String | Pyodide version string |
+

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -1,7 +1,7 @@
 all: emsdk/.complete
 
 # We hack the CPU_CORES, because if you use all of the cores on Circle-CI, you
-# run out of memory
+# run out of memory.
 
 emsdk/.complete:
 	if [ -d emsdk ]; then rm -rf emsdk; fi

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -1,0 +1,96 @@
+diff --git a/emsdk/emscripten/tag-1.38.10/src/library_lz4.js b/emsdk/emscripten/tag-1.38.10/src/library_lz4.js
+index 4c3f583b7..5291002a4 100644
+--- a/src/library_lz4.js
++++ b/src/library_lz4.js
+@@ -5,26 +5,14 @@ mergeInto(LibraryManager.library, {
+     DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
+     FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
+     CHUNK_SIZE: -1,
+-    codec: null,
+     init: function() {
+-      if (LZ4.codec) return;
+-      LZ4.codec = (function() {
+-        {{{ read('mini-lz4.js') }}};
+-        return MiniLZ4;
+-      })();
+-      LZ4.CHUNK_SIZE = LZ4.codec.CHUNK_SIZE;
++      LZ4.CHUNK_SIZE = 2048;
+     },
+     loadPackage: function (pack) {
+       LZ4.init();
+       var compressedData = pack['compressedData'];
+-      if (!compressedData) compressedData = LZ4.codec.compressPackage(pack['data']);
++      // if (!compressedData) compressedData = LZ4.codec.compressPackage(pack['data']);
+       assert(compressedData.cachedIndexes.length === compressedData.cachedChunks.length);
+-      for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
+-        compressedData.cachedIndexes[i] = -1;
+-        compressedData.cachedChunks[i] = compressedData.data.subarray(compressedData.cachedOffset + i*LZ4.CHUNK_SIZE,
+-                                                                      compressedData.cachedOffset + (i+1)*LZ4.CHUNK_SIZE);
+-        assert(compressedData.cachedChunks[i].length === LZ4.CHUNK_SIZE);
+-      }
+       pack['metadata'].files.forEach(function(file) {
+         var dir = PATH.dirname(file.filename);
+         var name = PATH.basename(file.filename);
+@@ -36,6 +24,12 @@ mergeInto(LibraryManager.library, {
+           end: file.end,
+         });
+       });
++      compressedData.buf = Module['_malloc'](LZ4.CHUNK_SIZE);
++      for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
++        compressedData.cachedIndexes[i] = -1;
++        compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE);
++        assert(compressedData.cachedChunks[i] !== null)
++      }
+     },
+     createNode: function (parent, name, mode, dev, contents, mtime) {
+       var node = FS.createNode(parent, name, mode);
+@@ -112,6 +106,7 @@ mergeInto(LibraryManager.library, {
+         //console.log('LZ4 read ' + [offset, length, position]);
+         length = Math.min(length, stream.node.size - position);
+         if (length <= 0) return 0;
++
+         var contents = stream.node.contents;
+         var compressedData = contents.compressedData;
+         var written = 0;
+@@ -122,6 +117,8 @@ mergeInto(LibraryManager.library, {
+           var chunkIndex = Math.floor(start / LZ4.CHUNK_SIZE);
+           var compressedStart = compressedData.offsets[chunkIndex];
+           var compressedSize = compressedData.sizes[chunkIndex];
++          var startInChunk = start % LZ4.CHUNK_SIZE;
++          var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);
+           var currChunk;
+           if (compressedData.successes[chunkIndex]) {
+             var found = compressedData.cachedIndexes.indexOf(chunkIndex);
+@@ -138,18 +135,19 @@ mergeInto(LibraryManager.library, {
+                 Module['decompressedChunks'] = (Module['decompressedChunks'] || 0) + 1;
+               }
+               var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
+-              //var t = Date.now();
+-              var originalSize = LZ4.codec.uncompress(compressed, currChunk);
+-              //console.log('decompress time: ' + (Date.now() - t));
++              // var t = Date.now();
++              // var originalSize = LZ4.codec.uncompress(compressed, currChunk);
++              Module.HEAPU8.set(compressed, compressedData.buf);
++              var originalSize = Module['_LZ4_decompress_safe'](compressedData.buf, currChunk, compressedSize, LZ4.CHUNK_SIZE);
++              // console.log('decompress time: ' + (Date.now() - t));
+               if (chunkIndex < compressedData.successes.length-1) assert(originalSize === LZ4.CHUNK_SIZE); // all but the last chunk must be full-size
++              buffer.set(Module.HEAPU8.subarray(currChunk + startInChunk, currChunk + endInChunk), offset + written);
+             }
+-          } else {
++          }
++          else {
+             // uncompressed
+-            currChunk = compressedData.data.subarray(compressedStart, compressedStart + LZ4.CHUNK_SIZE);
++            buffer.set(compressedData.data.subarray(compressedStart + startInChunk, compressedStart + endInChunk), offset + written);
+           }
+-          var startInChunk = start % LZ4.CHUNK_SIZE;
+-          var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);
+-          buffer.set(currChunk.subarray(startInChunk, endInChunk), offset + written);
+           var currWritten = endInChunk - startInChunk;
+           written += currWritten;
+         }
+@@ -181,4 +179,3 @@ if (LibraryManager.library['$FS__deps']) {
+   warn('FS does not seem to be in use (no preloaded files etc.), LZ4 will not do anything');
+ }
+ #endif
+-

--- a/lz4/Makefile
+++ b/lz4/Makefile
@@ -1,0 +1,36 @@
+PYODIDE_ROOT=$(abspath ..)
+include ../Makefile.envs
+
+LZ4VERSION=1.8.3
+
+ROOT=$(abspath .)
+
+SRC=$(ROOT)/lz4-$(LZ4VERSION)
+TARBALL=$(ROOT)/downloads/lz4-$(LZ4VERSION).tgz
+URL=https://github.com/lz4/lz4/archive/v$(LZ4VERSION).tar.gz
+
+
+all: $(SRC)/lib/liblz4.a
+
+
+clean:
+	-rm -fr downloads
+	-rm -fr $(SRC)
+
+
+$(TARBALL):
+	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
+	wget -q -O $@ $(URL)
+#	md5sum --quiet --check checksums || (rm $@; false)
+
+
+$(SRC)/Makefile: $(TARBALL)
+	tar -C . -xf $(TARBALL)
+	touch $(SRC)/Makefile
+
+
+$(SRC)/lib/liblz4.a: $(SRC)/Makefile
+	( \
+		cd $(SRC) ; \
+		emmake make ; \
+	)

--- a/lz4/checksums
+++ b/lz4/checksums
@@ -1,0 +1,1 @@
+d5ce78f7b1b76002bbfffa6f78a5fc4e  downloads/lz4-1.8.3.tgz

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -32,6 +32,49 @@ var languagePluginLoader = new Promise((resolve, reject) => {
     }
   };
 
+  // clang-format off
+  let preloadWasm = () => {
+    // On Chrome, we have to instantiate wasm asynchronously. Since that
+    // can't be done synchronously within the call to dlopen, we instantiate
+    // every .so that comes our way up front, caching it in the
+    // `preloadedWasm` dictionary.
+
+    let promise = new Promise((resolve) => resolve());
+    let FS = pyodide._module.FS;
+
+    function recurseDir(rootpath) {
+      let dirs;
+      try {
+        dirs = FS.readdir(rootpath);
+      } catch {
+        return;
+      }
+      for (entry of dirs) {
+        if (entry.startsWith('.')) {
+          continue;
+        }
+        const path = rootpath + entry;
+        if (entry.endsWith('.so')) {
+          if (Module['preloadedWasm'][path] === undefined) {
+            promise = promise
+              .then(() => Module['loadWebAssemblyModule'](
+                FS.readFile(path), true))
+              .then((module) => {
+                Module['preloadedWasm'][path] = module;
+              });
+          }
+        } else if (FS.isDir(FS.lookupPath(path).node.mode)) {
+          recurseDir(path + '/');
+        }
+      }
+    }
+
+    recurseDir('/');
+
+    return promise;
+  }
+  // clang-format on
+
   let _loadPackage = (names) => {
     // DFS to find all dependencies of the requested packages
     let packages = window.pyodide._module.packages.dependencies;
@@ -104,7 +147,11 @@ var languagePluginLoader = new Promise((resolve, reject) => {
           }
           delete window.pyodide._module.monitorRunDependencies;
           const packageList = Array.from(Object.keys(toLoad)).join(', ');
-          resolve(`Loaded ${packageList}`);
+          if (!isFirefox) {
+            preloadWasm().then(() => {resolve(`Loaded ${packageList}`)});
+          } else {
+            resolve(`Loaded ${packageList}`);
+          }
         }
       };
 
@@ -196,11 +243,9 @@ var languagePluginLoader = new Promise((resolve, reject) => {
 
   Module.noImageDecoding = true;
   Module.noAudioDecoding = true;
+  Module.noWasmDecoding = true;
+  Module.preloadedWasm = {};
   let isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-  if (isFirefox) {
-    console.log("Skipping wasm decoding");
-    Module.noWasmDecoding = true;
-  }
 
   let wasm_promise = WebAssembly.compileStreaming(fetch(wasmURL));
   Module.instantiateWasm = (info, receiveInstance) => {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -35,6 +35,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   let _loadPackage = (names) => {
     // DFS to find all dependencies of the requested packages
     let packages = window.pyodide._module.packages.dependencies;
+    let loadedPackages = window.pyodide.loadedPackages;
     let queue = [].concat(names || []);
     let toLoad = new Array();
     while (queue.length) {
@@ -79,6 +80,18 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       }
     }
 
+    window.pyodide._module.locateFile = (path) => {
+      // handle packages loaded from custom URLs
+      let package = path.replace(/\.data$/, "");
+      if (package in toLoad) {
+        let package_uri = toLoad[package];
+        if (package_uri != 'default channel') {
+          return package_uri.replace(/\.js$/, ".data");
+        };
+      };
+      return baseURL + path;
+    };
+
     let promise = new Promise((resolve, reject) => {
       if (Object.keys(toLoad).length === 0) {
         resolve('No new packages to load');
@@ -87,7 +100,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       window.pyodide._module.monitorRunDependencies = (n) => {
         if (n === 0) {
           for (let package in toLoad) {
-            loadedPackages[package] = toLoad[package];
+            window.pyodide.loadedPackages[package] = toLoad[package];
           }
           delete window.pyodide._module.monitorRunDependencies;
           const packageList = Array.from(Object.keys(toLoad)).join(', ');
@@ -160,6 +173,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   // Rearrange namespace for public API
   let PUBLIC_API = [
     'loadPackage',
+    'loadedPackages',
     'pyimport',
     'repr',
     'runPython',
@@ -232,6 +246,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       // filesystem to install itself. Once that's complete, it will be replaced
       // by the call to `makePublicAPI` with a more limited public API.
       window.pyodide = pyodide(Module);
+      window.pyodide.loadedPackages = new Array();
       window.pyodide.loadPackage = loadPackage;
     };
     document.head.appendChild(script);

--- a/src/python_dev.html
+++ b/src/python_dev.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Python - iodide</title>
+<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180623.css">
+</head>
+<body>
+<script id="jsmd" type="text/jsmd">
+%% meta
+{
+  "title": "Python",
+  "languages": {
+    "js": {
+      "pluginType": "language",
+      "languageId": "js",
+      "displayName": "Javascript",
+      "codeMirrorMode": "javascript",
+      "module": "window",
+      "evaluator": "eval",
+      "keybinding": "j",
+      "url": ""
+    },
+    "py": {
+      "languageId": "py",
+      "displayName": "python",
+      "codeMirrorMode": "python",
+      "keybinding": "p",
+      "url": "./pyodide_dev.js",
+      "module": "pyodide",
+      "evaluator": "runPython",
+      "pluginType": "language"
+    }
+  },
+  "lastExport": "2018-05-04T17:13:00.489Z"
+}
+
+%% md
+# Pyodide dev notebook 🐍
+
+An iodide notebook used for developpement that loads the locally build packages
+
+%% plugin
+{
+  "languageId": "py",
+  "displayName": "python",
+  "codeMirrorMode": "python",
+  "keybinding": "p",
+  "url": "./pyodide_dev.js",
+  "module": "pyodide",
+  "evaluator": "runPython",
+  "pluginType": "language"
+}
+
+%% js
+pyodide.loadPackage('numpy')
+
+%% code {"language":"py"}
+import numpy as np
+
+np.arange(2)
+
+%% js
+</script>
+<div id='page'></div>
+<script src='https://iodide.io/dist/iodide.pyodide-20180623.js'></script>
+</body>
+</html>

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,17 +102,19 @@ class SeleniumWrapper:
             'window.done = false\n' +
             'pyodide.loadPackage({!r})'.format(packages) +
             '.finally(function() { window.done = true; })')
+        __tracebackhide__ = True
         self.wait_until_packages_loaded()
 
     def wait_until_packages_loaded(self):
         from selenium.common.exceptions import TimeoutException
 
+        __tracebackhide__ = True
         try:
             self.wait.until(PackageLoaded())
         except TimeoutException as exc:
             _display_driver_logs(self.browser, self.driver)
             print(self.logs)
-            raise TimeoutException()
+            raise TimeoutException('wait_until_packages_loaded timed out')
 
     @property
     def urls(self):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -274,6 +274,11 @@ def run_web_server(q, log_filepath):
                      *self.client_address,
                      format_ % args))
 
+        def end_headers(self):
+            # Enable Cross-Origin Resource Sharing (CORS)
+            self.send_header('Access-Control-Allow-Origin', '*')
+            super().end_headers()
+
     Handler.extensions_map['.wasm'] = 'application/wasm'
 
     with socketserver.TCPServer(("", 0), Handler) as httpd:

--- a/tools/buildpkg.py
+++ b/tools/buildpkg.py
@@ -126,6 +126,7 @@ def package_files(buildpath, srcpath, pkg, args):
         'python',
         Path(ROOTDIR) / 'file_packager.py',
         name + '.data',
+        '--lz4',
         '--preload',
         '{}@/'.format(install_prefix),
         '--js-output={}'.format(name + '.js'),

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -721,8 +721,8 @@ if has_preloaded:
       Module.finishedDataFileDownloads++;
       arrayBuffer = arrayBuffer instanceof ArrayBuffer ? arrayBuffer : arrayBuffer.buffer;
       assert(arrayBuffer, 'Loading data file failed.');
-      assert(arrayBuffer instanceof ArrayBuffer, 'bad input to processPackageData');
-      var byteArray = new Uint8Array(arrayBuffer);
+      assert((arrayBuffer instanceof ArrayBuffer || arrayBuffer.buffer instanceof ArrayBuffer), 'bad input to processPackageData');
+      var byteArray = new Uint8Array(arrayBuffer instanceof ArrayBuffer ? arrayBuffer : arrayBuffer.buffer);
       var curr;
       %s
     };

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -700,13 +700,13 @@ if has_preloaded:
             total = Math.ceil(total * Module.expectedDataFileDownloads / num);
             if (Module['setStatus']) {
               Module['setStatus']('Downloading data... (' + loaded + '/' + total + ')');
-              console.log(`Downloaded ${packageName} data... (${loaded}/${total})`);
+              console.log('Downloaded ' + packageName + ' data... (' + loaded + '/' + total + ')');
             }
           }
           callback(packageData);
         }).catch(function(err) {
-            console.error(`Something wrong happened ${err}`);
-            throw new Error(`Something wrong happened ${err}`);
+            console.error('Something wrong happened ' + err);
+            throw new Error('Something wrong happened ' + err);
         });
       }
     };

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -721,8 +721,8 @@ if has_preloaded:
       Module.finishedDataFileDownloads++;
       arrayBuffer = arrayBuffer instanceof ArrayBuffer ? arrayBuffer : arrayBuffer.buffer;
       assert(arrayBuffer, 'Loading data file failed.');
-      assert((arrayBuffer instanceof ArrayBuffer || arrayBuffer.buffer instanceof ArrayBuffer), 'bad input to processPackageData');
-      var byteArray = new Uint8Array(arrayBuffer instanceof ArrayBuffer ? arrayBuffer : arrayBuffer.buffer);
+      assert(arrayBuffer instanceof ArrayBuffer, 'bad input to processPackageData');
+      var byteArray = new Uint8Array(arrayBuffer);
       var curr;
       %s
     };

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -466,8 +466,8 @@ if has_preloaded:
     use_data = '''
           var compressedData = %s;
           compressedData.data = byteArray;
-          assert(typeof LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
-          LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
+          assert(typeof Module.LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
+          Module.LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
           Module['removeRunDependency']('datafile_%s');
     ''' % (meta, shared.JS.escape_for_js_string(data_target))
 


### PR DESCRIPTION
## Changes

- where it sets the Module `var Module = ...`, added a check to look for `process[%(EXPORT_NAME)s]` which is where PyodideNode.js stores its `pyodide` Module. 

- where it tries to set `PACKAGE_PATH`, added support for nodejs and stopped throwing errors if not in a browser, now the error is thrown if the user is on some mysterious environment that is not browser, worker or nodejs.

- changed the `fetchRemotePackage` method to check for `XMLHttpRequest` before trying to fetch anything, if user is not on a browser, use `nodejs` `isomorphic-fetch`/`fs` to fetch remote/local packages

- after the data has been fetched, there are some problematic asserts for `nodejs`, sometimes the buffer is not the `arrayBuffer`, but the `arrayBuffer.buffer`
- it was necessary to change from
*line 700* `assert(arrayBuffer instanceof ArrayBuffer, 'bad input to processPackageData');`
to 
`assert((arrayBuffer instanceof ArrayBuffer || arrayBuffer.buffer instanceof ArrayBuffer), 'bad input to processPackageData');`
- and from *line 701* `var byteArray = new Uint8Array(arrayBuffer);` 
to `var byteArray = new Uint8Array(arrayBuffer instanceof ArrayBuffer ? arrayBuffer : arrayBuffer.buffer);`

this format was tested using `PyodideNode.js` on `pyodide.asm.data.js` and `numpy.js` and works fine.