### PR TITLE
Add version information

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,9 @@ jobs:
             - ./pyodide-env
             - ./firefox
 
+      - store_artifacts:
+          path: /home/circleci/repo/build/
+
   test-firefox:
     <<: *defaults
     steps:
@@ -110,9 +113,6 @@ jobs:
             source pyodide-env/bin/activate
             export PATH=$PWD/firefox:$PATH
             pytest test -v -k chrome
-
-      - store_artifacts:
-          path: /home/circleci/repo/build/
 
   deploy:
     machine:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -8,7 +8,7 @@ git add *
 git config --global user.email "deploybot@nowhere.com"
 git config --global user.name "Deploybot"
 git commit -m << END
-Deployed from Circle-CI $CIRCLE_BUILD_NUM"
+Deployed from Circle-CI $CIRCLE_BUILD_NUM
 
 Version $(git describe --tags --always)
 END

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -7,7 +7,11 @@ git checkout --orphan tmp
 git add *
 git config --global user.email "deploybot@nowhere.com"
 git config --global user.name "Deploybot"
-git commit -m "Deployed from Circle-CI $CIRCLE_BUILD_NUM"
+git commit -m << END
+Deployed from Circle-CI $CIRCLE_BUILD_NUM"
+
+Version $(git describe --tags --always)
+END
 git checkout master
 git reset --hard tmp
 git push origin -f master

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ root/.built: \
 	cp src/_testcapi.py	root/lib/python$(PYMINOR)
 	cp src/pystone.py root/lib/python$(PYMINOR)
 	cp src/pyodide.py root/lib/python$(PYMINOR)/site-packages
+	if command -v git > /dev/null 2>&1 \
+			&& git describe --tags > /dev/null 2>&1; then \
+	sed -i "s/__version__ =.*/__version__ = '$(shell git describe --tags)'/g" root/lib/python$(PYMINOR)/site-packages/pyodide.py; \
+	fi
 	( \
 		cd root/lib/python$(PYMINOR); \
 		rm -fr `cat ../../../remove_modules.txt`; \

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,8 @@ root/.built: \
 	cp src/pyodide.py root/lib/python$(PYMINOR)/site-packages
 	if command -v git > /dev/null 2>&1 \
 			&& git describe --tags > /dev/null 2>&1; then \
-	sed -i "s/__version__ =.*/__version__ = '$(shell git describe --tags)'/g" root/lib/python$(PYMINOR)/site-packages/pyodide.py; \
+	sed -i "s/__version__ =.*/__version__ = '$(shell git describe --tags)'/g" \
+		root/lib/python$(PYMINOR)/site-packages/pyodide.py; \
 	fi
 	( \
 		cd root/lib/python$(PYMINOR); \

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ main(int argc, char** argv)
 
   if (js2python_init() || JsImport_init() || JsProxy_init() ||
       pyimport_init() || pyproxy_init() || python2js_init() ||
-      runpython_init_js() || runpython_init_py()) {
+      runpython_init_js() || runpython_init_py() || runpython_finalize_js()) {
     return 1;
   }
 

--- a/src/pyodide.py
+++ b/src/pyodide.py
@@ -7,6 +7,8 @@ from js import XMLHttpRequest
 import ast
 import io
 
+__version__ = '0.1.0'
+
 
 def open_url(url):
     """

--- a/src/runpython.c
+++ b/src/runpython.c
@@ -68,3 +68,12 @@ runpython_init_py()
   Py_DECREF(d);
   return 0;
 }
+
+EM_JS(int, runpython_finalize_js, (), {
+  Module.version = function()
+  {
+    Module.runPython("import pyodide");
+    return Module.runPython("pyodide.__version__");
+  };
+  return 0;
+});

--- a/src/runpython.h
+++ b/src/runpython.h
@@ -10,4 +10,7 @@ runpython_init_js();
 int
 runpython_init_py();
 
+int
+runpython_finalize_js();
+
 #endif /* RUNPYTHON_H */

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 import time
 
-
 import pytest
 
 
@@ -391,3 +390,19 @@ def test_load_package_after_convert_string(selenium):
     selenium.load_package('kiwisolver')
     selenium.run(
         "import kiwisolver")
+
+
+def test_version_info(selenium):
+    from distutils.version import LooseVersion
+
+    version_py_str = selenium.run("""
+            import pyodide
+
+            pyodide.__version__
+            """)
+    version_py = LooseVersion(version_py_str)
+    assert version_py > LooseVersion('0.0.1')
+
+    version_js_str = selenium.run_js("return pyodide.version()")
+    version_js = LooseVersion(version_js_str)
+    assert version_py == version_js


### PR DESCRIPTION
This PR adds version information so that given a iodide notebook with loaded `pyodide.js` it is possible to determine when/with which version it was built.

This adds,
 - `pyodide.__version__` in Python
 - `pyodide.version()` in javascript (I have not managed to make this a property, see below)

By default, the version is hard-coded in `src/pyodide.py`, however when `make` is run on the cloned repo, the `git describe` output is used instead. This assumes that tags are created from time to time (and are consistent with the version in `src/pyodide.py`).

For instance, considering a situation where `0.1.0` tag is created on master (and `src/pyodide.py` contains the same version),
 - for this commit, the deployed `pyodide.__version__` will be `0.1.0`
 - for the next commit it will be `0.1.0-1-724353f` (cf [`git describe` docs](https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-describe.html)) which includes the base tag, number of new commits since then, and the git hash of the commit.

The version displayed in the built resources, solely determined by git tags, will overwrite the value actually put in the the `src/pyodide.py`. If git is not installed or not tags are present, the value in the file will be used. Also the `__version__` information in `src/pyodide.py` should still be incremented for new releases, so that the a version is associated with the the code source for any given commmit.

`git describe` does not fully follow [semantic versioning](https://semver.org) but I am not sure to what extent that can be applied anyway with continuous deployment.

Also this, 
 - deploys the artifacts from the "build" Circle CI job instead of the "test_chrome" job to be more consistent.
 - Puts the version (including commit hash) into commit message for deployments at https://github.com/iodide-project/pyodide-demo  

I hope the proposed system it not too confusing.. WDYT?