### PR TITLE
Fix versioning for tags starting with a "v"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ root/.built: \
 	cp src/pyodide.py root/lib/python$(PYMINOR)/site-packages
 	if command -v git > /dev/null 2>&1 \
 			&& git describe --tags > /dev/null 2>&1; then \
-	sed -i "s/__version__ =.*/__version__ = '$(shell git describe --tags)'/g" \
+	sed -i "s/__version__ =.*/__version__ = '$(shell git describe --tags | sed -r 's/^v//')'/g" \
 		root/lib/python$(PYMINOR)/site-packages/pyodide.py; \
 	fi
 	( \


### PR DESCRIPTION
In a follow up of https://github.com/iodide-project/pyodide/pull/166,  this fixes the versioning for tags that start with a "v" (e.g. `v0.1.0`).
