### PR TITLE
WIP: Use LZ4 filesystem compression, using the canonical C implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ ccache
 /emsdk/emsdk
 
 /six/six-1.11.0
+/lz4/lz4-1.8.3

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build/pyodide.asm.data: root/.built
 		cd build; \
 		python $(FILEPACKAGER) pyodide.asm.data --lz4 --preload ../root/lib@lib --js-output=pyodide.asm.data.js --use-preload-plugins \
   )
-	# uglifyjs build/pyodide.asm.data.js -o build/pyodide.asm.data.js
+	uglifyjs build/pyodide.asm.data.js -o build/pyodide.asm.data.js
 
 
 build/pyodide_dev.js: src/pyodide.js

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,7 @@ LDFLAGS=\
   -lstdc++ \
   --memory-init-file 0 \
   -s TEXTDECODER=0 \
-  -s LZ4=1 \
-  --minify 0 \
-  --profiling
+  -s LZ4=1
 
 SIX_ROOT=six/six-1.11.0/build/lib
 SIX_LIBS=$(SIX_ROOT)/six.py

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ FILEPACKAGER=$(PYODIDE_ROOT)/tools/file_packager.py
 CPYTHONROOT=cpython
 CPYTHONLIB=$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/python$(PYMINOR)
 
+LZ4LIB=lz4/lz4-1.8.3/lib/liblz4.a
+
 CC=emcc
 CXX=em++
 OPTFLAGS=-O3
@@ -20,6 +22,7 @@ LDFLAGS=\
 	-O3 \
 	-s MODULARIZE=1 \
 	$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/libpython$(PYMINOR).a \
+  lz4/lz4-1.8.3/lib/liblz4.a \
   -s "BINARYEN_METHOD='native-wasm'" \
   -s TOTAL_MEMORY=1073741824 \
   -s ALLOW_MEMORY_GROWTH=1 \
@@ -34,7 +37,10 @@ LDFLAGS=\
 	-std=c++14 \
   -lstdc++ \
   --memory-init-file 0 \
-  -s TEXTDECODER=0
+  -s TEXTDECODER=0 \
+  -s LZ4=1 \
+  --minify 0 \
+  --profiling
 
 SIX_ROOT=six/six-1.11.0/build/lib
 SIX_LIBS=$(SIX_ROOT)/six.py
@@ -68,9 +74,9 @@ build/pyodide.asm.js: src/main.bc src/jsimport.bc src/jsproxy.bc src/js2python.b
 build/pyodide.asm.data: root/.built
 	( \
 		cd build; \
-		python $(FILEPACKAGER) pyodide.asm.data --preload ../root/lib@lib --js-output=pyodide.asm.data.js --use-preload-plugins \
+		python $(FILEPACKAGER) pyodide.asm.data --lz4 --preload ../root/lib@lib --js-output=pyodide.asm.data.js --use-preload-plugins \
   )
-	uglifyjs build/pyodide.asm.data.js -o build/pyodide.asm.data.js
+	# uglifyjs build/pyodide.asm.data.js -o build/pyodide.asm.data.js
 
 
 build/pyodide_dev.js: src/pyodide.js
@@ -128,7 +134,7 @@ clean:
 	echo "The Emsdk and CPython are not cleaned. cd into those directories to do so."
 
 
-%.bc: %.c $(CPYTHONLIB)
+%.bc: %.c $(CPYTHONLIB) $(LZ4LIB)
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 
@@ -139,7 +145,7 @@ build/test.data: $(CPYTHONLIB)
 	)
 	( \
 		cd build; \
-		python $(FILEPACKAGER) test.data --preload ../$(CPYTHONLIB)/test@/lib/python3.7/test --js-output=test.js --export-name=pyodide._module --exclude \*.wasm.pre --exclude __pycache__ \
+		python $(FILEPACKAGER) test.data --lz4 --preload ../$(CPYTHONLIB)/test@/lib/python3.7/test --js-output=test.js --export-name=pyodide._module --exclude \*.wasm.pre --exclude __pycache__ \
   )
 	uglifyjs build/test.js -o build/test.js
 
@@ -195,6 +201,10 @@ ccache/em++:
 
 $(CPYTHONLIB): emsdk/emsdk/.complete ccache/emcc ccache/em++
 	make -C $(CPYTHONROOT)
+
+
+$(LZ4LIB):
+	make -C lz4
 
 
 $(SIX_LIBS): $(CPYTHONLIB)

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -3,6 +3,7 @@ all: emsdk/.complete
 # We hack the CPU_CORES, because if you use all of the cores on Circle-CI, you
 # run out of memory
 
+
 emsdk/.complete:
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone https://github.com/juj/emsdk.git

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -1,9 +1,7 @@
 all: emsdk/.complete
 
 # We hack the CPU_CORES, because if you use all of the cores on Circle-CI, you
-# run out of memory
-
-
+# run out of memory.
 
 emsdk/.complete:
 	if [ -d emsdk ]; then rm -rf emsdk; fi

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -4,6 +4,7 @@ all: emsdk/.complete
 # run out of memory
 
 
+
 emsdk/.complete:
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone https://github.com/juj/emsdk.git

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -1,0 +1,87 @@
+diff --git a/src/library_lz4.js b/src/library_lz4.js
+index 4c3f583b7..bca230feb 100644
+--- a/emsdk/emscripten/tag-1.38.10/src/library_lz4.js
++++ b/emsdk/emscripten/tag-1.38.10/src/library_lz4.js
+@@ -5,26 +5,15 @@ mergeInto(LibraryManager.library, {
+     DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
+     FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
+     CHUNK_SIZE: -1,
+-    codec: null,
++    buf: null,
+     init: function() {
+-      if (LZ4.codec) return;
+-      LZ4.codec = (function() {
+-        {{{ read('mini-lz4.js') }}};
+-        return MiniLZ4;
+-      })();
+-      LZ4.CHUNK_SIZE = LZ4.codec.CHUNK_SIZE;
++      LZ4.CHUNK_SIZE = 2048;
+     },
+     loadPackage: function (pack) {
+       LZ4.init();
+       var compressedData = pack['compressedData'];
+-      if (!compressedData) compressedData = LZ4.codec.compressPackage(pack['data']);
++      // if (!compressedData) compressedData = LZ4.codec.compressPackage(pack['data']);
+       assert(compressedData.cachedIndexes.length === compressedData.cachedChunks.length);
+-      for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
+-        compressedData.cachedIndexes[i] = -1;
+-        compressedData.cachedChunks[i] = compressedData.data.subarray(compressedData.cachedOffset + i*LZ4.CHUNK_SIZE,
+-                                                                      compressedData.cachedOffset + (i+1)*LZ4.CHUNK_SIZE);
+-        assert(compressedData.cachedChunks[i].length === LZ4.CHUNK_SIZE);
+-      }
+       pack['metadata'].files.forEach(function(file) {
+         var dir = PATH.dirname(file.filename);
+         var name = PATH.basename(file.filename);
+@@ -112,8 +101,16 @@ mergeInto(LibraryManager.library, {
+         //console.log('LZ4 read ' + [offset, length, position]);
+         length = Math.min(length, stream.node.size - position);
+         if (length <= 0) return 0;
++
+         var contents = stream.node.contents;
+         var compressedData = contents.compressedData;
++        if (LZ4.buf === null) {
++          LZ4.buf = Module['_malloc'](LZ4.CHUNK_SIZE);
++          for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
++            compressedData.cachedIndexes[i] = -1;
++            compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE);
++          }
++        }
+         var written = 0;
+         while (written < length) {
+           var start = contents.start + position + written; // start index in uncompressed data
+@@ -138,18 +135,24 @@ mergeInto(LibraryManager.library, {
+                 Module['decompressedChunks'] = (Module['decompressedChunks'] || 0) + 1;
+               }
+               var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
+-              //var t = Date.now();
+-              var originalSize = LZ4.codec.uncompress(compressed, currChunk);
+-              //console.log('decompress time: ' + (Date.now() - t));
++              // var t = Date.now();
++              // var originalSize = LZ4.codec.uncompress(compressed, currChunk);
++              Module.HEAPU8.set(compressed, LZ4.buf);
++              var originalSize = Module['_LZ4_decompress_safe'](LZ4.buf, currChunk, compressedSize, LZ4.CHUNK_SIZE);
++              // console.log('decompress time: ' + (Date.now() - t));
+               if (chunkIndex < compressedData.successes.length-1) assert(originalSize === LZ4.CHUNK_SIZE); // all but the last chunk must be full-size
+             }
+-          } else {
++          }
++          else {
+             // uncompressed
+-            currChunk = compressedData.data.subarray(compressedStart, compressedStart + LZ4.CHUNK_SIZE);
++            var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
++            // var originalSize = LZ4.codec.uncompress(compressed, currChunk);
++            Module.HEAPU8.set(compressed, LZ4.buf);
++            currChunk = LZ4.buf;
+           }
+           var startInChunk = start % LZ4.CHUNK_SIZE;
+           var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);
+-          buffer.set(currChunk.subarray(startInChunk, endInChunk), offset + written);
++          buffer.set(Module.HEAPU8.subarray(currChunk + startInChunk, currChunk + endInChunk), offset + written);
+           var currWritten = endInChunk - startInChunk;
+           written += currWritten;
+         }
+@@ -181,4 +184,3 @@ if (LibraryManager.library['$FS__deps']) {
+   warn('FS does not seem to be in use (no preloaded files etc.), LZ4 will not do anything');
+ }
+ #endif
+-

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -1,8 +1,8 @@
-diff --git a/src/library_lz4.js b/src/library_lz4.js
-index 4c3f583b7..9540a64fb 100644
+diff --git a/emsdk/emscripten/tag-1.38.10/src/library_lz4.js b/emsdk/emscripten/tag-1.38.10/src/library_lz4.js
+index 4c3f583b7..5291002a4 100644
 --- a/src/library_lz4.js
 +++ b/src/library_lz4.js
-@@ -5,26 +5,15 @@ mergeInto(LibraryManager.library, {
+@@ -5,26 +5,14 @@ mergeInto(LibraryManager.library, {
      DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
      FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
      CHUNK_SIZE: -1,
@@ -28,11 +28,23 @@ index 4c3f583b7..9540a64fb 100644
 -                                                                      compressedData.cachedOffset + (i+1)*LZ4.CHUNK_SIZE);
 -        assert(compressedData.cachedChunks[i].length === LZ4.CHUNK_SIZE);
 -      }
-+      compressedData.buf = null;
        pack['metadata'].files.forEach(function(file) {
          var dir = PATH.dirname(file.filename);
          var name = PATH.basename(file.filename);
-@@ -112,8 +101,17 @@ mergeInto(LibraryManager.library, {
+@@ -36,6 +24,12 @@ mergeInto(LibraryManager.library, {
+           end: file.end,
+         });
+       });
++      compressedData.buf = Module['_malloc'](LZ4.CHUNK_SIZE);
++      for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
++        compressedData.cachedIndexes[i] = -1;
++        compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE);
++        assert(compressedData.cachedChunks[i] !== null)
++      }
+     },
+     createNode: function (parent, name, mode, dev, contents, mtime) {
+       var node = FS.createNode(parent, name, mode);
+@@ -112,8 +106,17 @@ mergeInto(LibraryManager.library, {
          //console.log('LZ4 read ' + [offset, length, position]);
          length = Math.min(length, stream.node.size - position);
          if (length <= 0) return 0;
@@ -50,7 +62,16 @@ index 4c3f583b7..9540a64fb 100644
          var written = 0;
          while (written < length) {
            var start = contents.start + position + written; // start index in uncompressed data
-@@ -138,18 +136,23 @@ mergeInto(LibraryManager.library, {
+@@ -122,6 +125,8 @@ mergeInto(LibraryManager.library, {
+           var chunkIndex = Math.floor(start / LZ4.CHUNK_SIZE);
+           var compressedStart = compressedData.offsets[chunkIndex];
+           var compressedSize = compressedData.sizes[chunkIndex];
++          var startInChunk = start % LZ4.CHUNK_SIZE;
++          var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);
+           var currChunk;
+           if (compressedData.successes[chunkIndex]) {
+             var found = compressedData.cachedIndexes.indexOf(chunkIndex);
+@@ -138,18 +143,19 @@ mergeInto(LibraryManager.library, {
                  Module['decompressedChunks'] = (Module['decompressedChunks'] || 0) + 1;
                }
                var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
@@ -63,24 +84,22 @@ index 4c3f583b7..9540a64fb 100644
 +              var originalSize = Module['_LZ4_decompress_safe'](compressedData.buf, currChunk, compressedSize, LZ4.CHUNK_SIZE);
 +              // console.log('decompress time: ' + (Date.now() - t));
                if (chunkIndex < compressedData.successes.length-1) assert(originalSize === LZ4.CHUNK_SIZE); // all but the last chunk must be full-size
++              buffer.set(Module.HEAPU8.subarray(currChunk + startInChunk, currChunk + endInChunk), offset + written);
              }
 -          } else {
 +          }
 +          else {
              // uncompressed
 -            currChunk = compressedData.data.subarray(compressedStart, compressedStart + LZ4.CHUNK_SIZE);
-+            var compressed = compressedData.data.subarray(compressedStart, compressedStart + LZ4.CHUNK_SIZE);
-+            Module.HEAPU8.set(compressed, compressedData.buf);
-+            currChunk = compressedData.buf;
++            buffer.set(compressedData.data.subarray(compressedStart + startInChunk, compressedStart + endInChunk), offset + written);
            }
-           var startInChunk = start % LZ4.CHUNK_SIZE;
-           var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);
+-          var startInChunk = start % LZ4.CHUNK_SIZE;
+-          var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);
 -          buffer.set(currChunk.subarray(startInChunk, endInChunk), offset + written);
-+          buffer.set(Module.HEAPU8.subarray(currChunk + startInChunk, currChunk + endInChunk), offset + written);
            var currWritten = endInChunk - startInChunk;
            written += currWritten;
          }
-@@ -181,4 +184,3 @@ if (LibraryManager.library['$FS__deps']) {
+@@ -181,4 +187,3 @@ if (LibraryManager.library['$FS__deps']) {
    warn('FS does not seem to be in use (no preloaded files etc.), LZ4 will not do anything');
  }
  #endif

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -40,10 +40,10 @@ index 4c3f583b7..9540a64fb 100644
          var contents = stream.node.contents;
          var compressedData = contents.compressedData;
 +        if (compressedData.buf === null) {
-+          compressedData.buf = Module['_malloc'](LZ4.CHUNK_SIZE * 2);
++          compressedData.buf = Module['_malloc'](LZ4.CHUNK_SIZE);
 +          for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
 +            compressedData.cachedIndexes[i] = -1;
-+            compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE * 2);
++            compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE);
 +            assert(compressedData.cachedChunks[i] !== null)
 +          }
 +        }

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -1,13 +1,12 @@
 diff --git a/src/library_lz4.js b/src/library_lz4.js
-index 4c3f583b7..bca230feb 100644
---- a/emsdk/emscripten/tag-1.38.10/src/library_lz4.js
-+++ b/emsdk/emscripten/tag-1.38.10/src/library_lz4.js
+index 4c3f583b7..9540a64fb 100644
+--- a/src/library_lz4.js
++++ b/src/library_lz4.js
 @@ -5,26 +5,15 @@ mergeInto(LibraryManager.library, {
      DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
      FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,
      CHUNK_SIZE: -1,
 -    codec: null,
-+    buf: null,
      init: function() {
 -      if (LZ4.codec) return;
 -      LZ4.codec = (function() {
@@ -29,27 +28,29 @@ index 4c3f583b7..bca230feb 100644
 -                                                                      compressedData.cachedOffset + (i+1)*LZ4.CHUNK_SIZE);
 -        assert(compressedData.cachedChunks[i].length === LZ4.CHUNK_SIZE);
 -      }
++      compressedData.buf = null;
        pack['metadata'].files.forEach(function(file) {
          var dir = PATH.dirname(file.filename);
          var name = PATH.basename(file.filename);
-@@ -112,8 +101,16 @@ mergeInto(LibraryManager.library, {
+@@ -112,8 +101,17 @@ mergeInto(LibraryManager.library, {
          //console.log('LZ4 read ' + [offset, length, position]);
          length = Math.min(length, stream.node.size - position);
          if (length <= 0) return 0;
 +
          var contents = stream.node.contents;
          var compressedData = contents.compressedData;
-+        if (LZ4.buf === null) {
-+          LZ4.buf = Module['_malloc'](LZ4.CHUNK_SIZE);
++        if (compressedData.buf === null) {
++          compressedData.buf = Module['_malloc'](LZ4.CHUNK_SIZE * 2);
 +          for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
 +            compressedData.cachedIndexes[i] = -1;
-+            compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE);
++            compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE * 2);
++            assert(compressedData.cachedChunks[i] !== null)
 +          }
 +        }
          var written = 0;
          while (written < length) {
            var start = contents.start + position + written; // start index in uncompressed data
-@@ -138,18 +135,24 @@ mergeInto(LibraryManager.library, {
+@@ -138,18 +136,23 @@ mergeInto(LibraryManager.library, {
                  Module['decompressedChunks'] = (Module['decompressedChunks'] || 0) + 1;
                }
                var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
@@ -58,8 +59,8 @@ index 4c3f583b7..bca230feb 100644
 -              //console.log('decompress time: ' + (Date.now() - t));
 +              // var t = Date.now();
 +              // var originalSize = LZ4.codec.uncompress(compressed, currChunk);
-+              Module.HEAPU8.set(compressed, LZ4.buf);
-+              var originalSize = Module['_LZ4_decompress_safe'](LZ4.buf, currChunk, compressedSize, LZ4.CHUNK_SIZE);
++              Module.HEAPU8.set(compressed, compressedData.buf);
++              var originalSize = Module['_LZ4_decompress_safe'](compressedData.buf, currChunk, compressedSize, LZ4.CHUNK_SIZE);
 +              // console.log('decompress time: ' + (Date.now() - t));
                if (chunkIndex < compressedData.successes.length-1) assert(originalSize === LZ4.CHUNK_SIZE); // all but the last chunk must be full-size
              }
@@ -68,10 +69,9 @@ index 4c3f583b7..bca230feb 100644
 +          else {
              // uncompressed
 -            currChunk = compressedData.data.subarray(compressedStart, compressedStart + LZ4.CHUNK_SIZE);
-+            var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
-+            // var originalSize = LZ4.codec.uncompress(compressed, currChunk);
-+            Module.HEAPU8.set(compressed, LZ4.buf);
-+            currChunk = LZ4.buf;
++            var compressed = compressedData.data.subarray(compressedStart, compressedStart + LZ4.CHUNK_SIZE);
++            Module.HEAPU8.set(compressed, compressedData.buf);
++            currChunk = compressedData.buf;
            }
            var startInChunk = start % LZ4.CHUNK_SIZE;
            var endInChunk = Math.min(startInChunk + desired, LZ4.CHUNK_SIZE);

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -44,25 +44,15 @@ index 4c3f583b7..5291002a4 100644
      },
      createNode: function (parent, name, mode, dev, contents, mtime) {
        var node = FS.createNode(parent, name, mode);
-@@ -112,8 +106,17 @@ mergeInto(LibraryManager.library, {
+@@ -112,6 +106,7 @@ mergeInto(LibraryManager.library, {
          //console.log('LZ4 read ' + [offset, length, position]);
          length = Math.min(length, stream.node.size - position);
          if (length <= 0) return 0;
 +
          var contents = stream.node.contents;
          var compressedData = contents.compressedData;
-+        if (compressedData.buf === null) {
-+          compressedData.buf = Module['_malloc'](LZ4.CHUNK_SIZE);
-+          for (var i = 0; i < compressedData.cachedIndexes.length; i++) {
-+            compressedData.cachedIndexes[i] = -1;
-+            compressedData.cachedChunks[i] = Module['_malloc'](LZ4.CHUNK_SIZE);
-+            assert(compressedData.cachedChunks[i] !== null)
-+          }
-+        }
          var written = 0;
-         while (written < length) {
-           var start = contents.start + position + written; // start index in uncompressed data
-@@ -122,6 +125,8 @@ mergeInto(LibraryManager.library, {
+@@ -122,6 +117,8 @@ mergeInto(LibraryManager.library, {
            var chunkIndex = Math.floor(start / LZ4.CHUNK_SIZE);
            var compressedStart = compressedData.offsets[chunkIndex];
            var compressedSize = compressedData.sizes[chunkIndex];
@@ -71,7 +61,7 @@ index 4c3f583b7..5291002a4 100644
            var currChunk;
            if (compressedData.successes[chunkIndex]) {
              var found = compressedData.cachedIndexes.indexOf(chunkIndex);
-@@ -138,18 +143,19 @@ mergeInto(LibraryManager.library, {
+@@ -138,18 +135,19 @@ mergeInto(LibraryManager.library, {
                  Module['decompressedChunks'] = (Module['decompressedChunks'] || 0) + 1;
                }
                var compressed = compressedData.data.subarray(compressedStart, compressedStart + compressedSize);
@@ -99,7 +89,7 @@ index 4c3f583b7..5291002a4 100644
            var currWritten = endInChunk - startInChunk;
            written += currWritten;
          }
-@@ -181,4 +187,3 @@ if (LibraryManager.library['$FS__deps']) {
+@@ -181,4 +179,3 @@ if (LibraryManager.library['$FS__deps']) {
    warn('FS does not seem to be in use (no preloaded files etc.), LZ4 will not do anything');
  }
  #endif

--- a/lz4/Makefile
+++ b/lz4/Makefile
@@ -1,0 +1,36 @@
+PYODIDE_ROOT=$(abspath ..)
+include ../Makefile.envs
+
+LZ4VERSION=1.8.3
+
+ROOT=$(abspath .)
+
+SRC=$(ROOT)/lz4-$(LZ4VERSION)
+TARBALL=$(ROOT)/downloads/lz4-$(LZ4VERSION).tgz
+URL=https://github.com/lz4/lz4/archive/v$(LZ4VERSION).tar.gz
+
+
+all: $(SRC)/lib/liblz4.a
+
+
+clean:
+	-rm -fr downloads
+	-rm -fr $(SRC)
+
+
+$(TARBALL):
+	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
+	wget -q -O $@ $(URL)
+#	md5sum --quiet --check checksums || (rm $@; false)
+
+
+$(SRC)/Makefile: $(TARBALL)
+	tar -C . -xf $(TARBALL)
+	touch $(SRC)/Makefile
+
+
+$(SRC)/lib/liblz4.a: $(SRC)/Makefile
+	( \
+		cd $(SRC) ; \
+		emmake make ; \
+	)

--- a/lz4/checksums
+++ b/lz4/checksums
@@ -1,0 +1,1 @@
+d5ce78f7b1b76002bbfffa6f78a5fc4e  downloads/lz4-1.8.3.tgz

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -32,11 +32,12 @@ var languagePluginLoader = new Promise((resolve, reject) => {
     }
   };
 
+  // clang-format off
   let preloadWasm = () => {
-    // On Chrome, we have to instantiate wasm asynchronously. Since that can't
-    // be done synchronously within the call to dlopen, we instantiate every .so
-    // that comes our way up front, caching it in the `preloadedWasm`
-    // dictionary.
+    // On Chrome, we have to instantiate wasm asynchronously. Since that
+    // can't be done synchronously within the call to dlopen, we instantiate
+    // every .so that comes our way up front, caching it in the
+    // `preloadedWasm` dictionary.
 
     let promise = new Promise((resolve) => resolve());
     let FS = pyodide._module.FS;
@@ -55,11 +56,12 @@ var languagePluginLoader = new Promise((resolve, reject) => {
         const path = rootpath + entry;
         if (entry.endsWith('.so')) {
           if (Module['preloadedWasm'][path] === undefined) {
-            promise = promise.then(
-              () => Module['loadWebAssemblyModule'](FS.readFile(path), true)
-            ).then(
-              (module) => { Module['preloadedWasm'][path] = module; }
-            );
+            promise = promise
+              .then(() => Module['loadWebAssemblyModule'](
+                FS.readFile(path), true))
+              .then((module) => {
+                Module['preloadedWasm'][path] = module;
+              });
           }
         } else if (FS.isDir(FS.lookupPath(path).node.mode)) {
           recurseDir(path + '/');
@@ -71,6 +73,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
 
     return promise;
   }
+  // clang-format on
 
   let _loadPackage = (names) => {
     // DFS to find all dependencies of the requested packages
@@ -132,8 +135,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
           delete window.pyodide._module.monitorRunDependencies;
           const packageList = Array.from(Object.keys(toLoad)).join(', ');
           if (!isFirefox) {
-            preloadWasm().then(() => {
-              resolve(`Loaded ${packageList}`) });
+            preloadWasm().then(() => {resolve(`Loaded ${packageList}`)});
           } else {
             resolve(`Loaded ${packageList}`);
           }

--- a/tools/buildpkg.py
+++ b/tools/buildpkg.py
@@ -126,6 +126,7 @@ def package_files(buildpath, srcpath, pkg, args):
         'python',
         Path(ROOTDIR) / 'file_packager.py',
         name + '.data',
+        '--lz4',
         '--preload',
         '{}@/'.format(install_prefix),
         '--js-output={}'.format(name + '.js'),

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -466,8 +466,8 @@ if has_preloaded:
     use_data = '''
           var compressedData = %s;
           compressedData.data = byteArray;
-          assert(typeof LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
-          LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
+          assert(typeof Module.LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
+          Module.LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
           Module['removeRunDependency']('datafile_%s');
     ''' % (meta, shared.JS.escape_for_js_string(data_target))
 


### PR DESCRIPTION
This is an alternative to #152 that uses the canonical upstream lz4 C library instead of a Javascript port.

It's a little hard to measure how much faster it is, because most of the difference seems to come in reduced garbage collection time, but it certainly feels faster.

This still doesn't work for Chrome -- we'll need to make emscripten's LZ4 support work with the preloadPlugins.  I don't see why they can't, they just don't work together right now.