### PR TITLE
MAINT Refactor test web server to allow multiple instances and log capture

### DIFF
--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -1,9 +1,10 @@
 import pytest
 
 
-def test_load_from_url(selenium_standalone, web_server):
+def test_load_from_url(selenium_standalone):
 
-    url, port = web_server
+    url = selenium_standalone.server_hostname
+    port = selenium_standalone.server_port
 
     selenium_standalone.load_package(f"http://{url}:{port}/pyparsing.js")
     assert "Invalid package name or URI" not in selenium_standalone.logs

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1,3 +1,6 @@
+import pathlib
+
+
 def test_pytest(selenium):
     selenium.load_package(['pytest', 'numpy', 'nose'])
 
@@ -15,3 +18,9 @@ def test_pytest(selenium):
 
     logs = '\n'.join(selenium.logs)
     assert 'INTERNALERROR' not in logs
+
+
+def test_web_server_secondary(selenium, web_server_secondary):
+    host, port, logs = web_server_secondary
+    assert pathlib.Path(logs).exists()
+    assert selenium.server_port != port


### PR DESCRIPTION
As part of fixing https://github.com/iodide-project/pyodide/issues/167 this refactors the web server used for tests with the aim of
 - allowing to launch multiple instances of the web-server on different ports (to check that the correct one is used for resources loaded by URL)
 - capturing the web-server log 

Incidentally this also,
 - removes the use of a global `PORT` variable
 - instead of starting the web-server when `test/conftest.py` is run as a part of test collection, a session scoped fixture is used. It is only run once per test session.

It is still possible to manually start the server with,
```
python test/conftest.py
```
though we should probably move this functionality to a separate script (once https://github.com/iodide-project/pyodide/pull/107 is done).