### PR TITLE
Reorg pyodide ns to separate emscripten details from public API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ build/test.data: $(CPYTHONLIB)
 	)
 	( \
 		cd build; \
-		python $(FILEPACKAGER) test.data --preload ../$(CPYTHONLIB)/test@/lib/python3.7/test --js-output=test.js --export-name=pyodide --exclude \*.wasm.pre --exclude __pycache__ \
+		python $(FILEPACKAGER) test.data --preload ../$(CPYTHONLIB)/test@/lib/python3.7/test --js-output=test.js --export-name=pyodide._module --exclude \*.wasm.pre --exclude __pycache__ \
   )
 	uglifyjs build/test.js -o build/test.js
 

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -228,6 +228,9 @@ var languagePluginLoader = new Promise((resolve, reject) => {
     let script = document.createElement('script');
     script.src = `${baseURL}pyodide.asm.js`;
     script.onload = () => {
+      // The emscripten module needs to be at this location for the core
+      // filesystem to install itself. Once that's complete, it will be replaced
+      // by the call to `makePublicAPI` with a more limited public API.
       window.pyodide = pyodide(Module);
       window.pyodide.loadPackage = loadPackage;
     };

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -143,10 +143,10 @@ def test_typed_arrays(selenium, wasm_heap, jstype, pytype):
     else:
         selenium.run_js(
             f"""
-             var buffer = pyodide._malloc(
+             var buffer = pyodide._module._malloc(
                    4 * {jstype}.BYTES_PER_ELEMENT);
              window.array = new {jstype}(
-                   pyodide.HEAPU8.buffer, buffer, 4);
+                   pyodide._module.HEAPU8.buffer, buffer, 4);
              window.array[0] = 1;
              window.array[1] = 2;
              window.array[2] = 3;

--- a/tools/buildpkg.py
+++ b/tools/buildpkg.py
@@ -129,7 +129,7 @@ def package_files(buildpath, srcpath, pkg, args):
         '--preload',
         '{}@/'.format(install_prefix),
         '--js-output={}'.format(name + '.js'),
-        '--export-name=pyodide',
+        '--export-name=pyodide._module',
         '--exclude', '*.wasm.pre',
         '--exclude', '__pycache__',
         '--use-preload-plugins'],


### PR DESCRIPTION
In response to #175.

This makes the pyodide namespace only include deliberately public things, putting the emscripten implementation details inside `pyodide._module`.

Due to the design of emscripten, we can't do this until everything is ready and the core filesystem has been bootstrapped.

Packages need to know how to get to `pyodide._module` to install themselves, so they need to be rebuilt.