### PR TITLE
Fix load .data files from the same base URL as .js

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -80,8 +80,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
       }
     }
 
-    console.log(`Trying to load ${Object.keys(toLoad)}`);
-
     window.pyodide._module.locateFile = (path) => {
       // handle packages loaded from custom URLs
       let package = path.replace(/\.data$/, "");

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -272,6 +272,11 @@ def run_web_server(q, log_filepath):
                      *self.client_address,
                      format_ % args))
 
+        def end_headers(self):
+            # Enable Cross-Origin Resource Sharing (CORS)
+            self.send_header('Access-Control-Allow-Origin', '*')
+            super().end_headers()
+
     Handler.extensions_map['.wasm'] = 'application/wasm'
 
     with socketserver.TCPServer(("", 0), Handler) as httpd:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -112,7 +112,7 @@ class SeleniumWrapper:
         except TimeoutException as exc:
             _display_driver_logs(self.browser, self.driver)
             print(self.logs)
-            raise TimeoutException()
+            raise TimeoutException('wait_until_packages_loaded timed out')
 
     @property
     def urls(self):

--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -11,8 +11,8 @@ def test_load_from_url(selenium_standalone, web_server_secondary):
             log_main.open('r') as fh_main:
 
         # skip existing log lines
-        fh_main.read()
-        fh_secondary.read()
+        fh_main.seek(0, 2)
+        fh_secondary.seek(0, 2)
 
         selenium_standalone.load_package(f"http://{url}:{port}/pyparsing.js")
         assert "Invalid package name or URI" not in selenium_standalone.logs
@@ -30,6 +30,16 @@ def test_load_from_url(selenium_standalone, web_server_secondary):
 
     selenium_standalone.load_package(f"http://{url}:{port}/numpy.js")
     selenium_standalone.run("import numpy as np")
+
+
+def test_list_loaded_urls(selenium_standalone):
+    selenium = selenium_standalone
+
+    selenium.load_package('pyparsing')
+    assert selenium.run_js(
+            'return Object.keys(pyodide.loadedPackages)') == ['pyparsing']
+    assert selenium.run_js(
+            "return pyodide.loadedPackages['pyparsing']") == "default channel"
 
 
 def test_uri_mismatch(selenium_standalone):


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/167

Fixes a bug where the `.data` file was not loaded from the correct location when using custom URLs.

@mdboom I'm not sure if this is in line with what you suggested  in https://github.com/iodide-project/pyodide/issues/167#issuecomment-422037872 .

This PR indeed modifies `Module.locateFile` to use the mapping we already have between the package name and URL. This exposes a global,
```
pyodide._toLoadPackages
pyodide.loadedPackages
```
the first is necessary for this workaround to work. The second is just useful to have in general IMO, it's not used here directly. Do you think this is acceptable?

This will probably need some small refactoring once https://github.com/iodide-project/pyodide/pull/176 is merged.