### PR TITLE
Simplify traceback on package load timeout

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -83,7 +83,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.patched
 	cp config.site $(BUILD)/
 	( \
 		cd $(BUILD); \
-		CONFIG_SITE=./config.site READELF=true emconfigure ./configure --without-threads --without-pymalloc --disable-shared --disable-ipv6 --without-gcc --host=asmjs-unknown-emscripten --build=$(shell $(BUILD)/config.guess) --prefix=$(INSTALL) ; \
+		CONFIG_SITE=./config.site READELF=true emconfigure ./configure --without-pymalloc --disable-shared --disable-ipv6 --without-gcc --host=asmjs-unknown-emscripten --build=$(shell $(BUILD)/config.guess) --prefix=$(INSTALL) ; \
 	)
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,17 +102,19 @@ class SeleniumWrapper:
             'window.done = false\n' +
             'pyodide.loadPackage({!r})'.format(packages) +
             '.finally(function() { window.done = true; })')
+        __tracebackhide__ = True
         self.wait_until_packages_loaded()
 
     def wait_until_packages_loaded(self):
         from selenium.common.exceptions import TimeoutException
 
+        __tracebackhide__ = True
         try:
             self.wait.until(PackageLoaded())
         except TimeoutException as exc:
             _display_driver_logs(self.browser, self.driver)
             print(self.logs)
-            raise TimeoutException()
+            raise TimeoutException('wait_until_packages_loaded timed out')
 
     @property
     def urls(self):


### PR DESCRIPTION
Related to https://github.com/iodide-project/pyodide/issues/124 

This removes irrelevant traceback when loading packages time-out (all we care about is that the timeout happened).

Also removes the CPython `--without-threads` configure option, as with Python 3.7 that was producing,
```
configure: WARNING: unrecognized options: --without-threads
```