### PR TITLE
Add dev python notebook python_dev.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ all: build/pyodide.asm.js \
 	build/pyodide.js \
 	build/pyodide_dev.js \
 	build/python.html \
+	build/python_dev.html \
 	build/matplotlib.html \
 	build/matplotlib-sideload.html \
 	build/renderedhtml.css \
@@ -84,6 +85,10 @@ build/pyodide.js: src/pyodide.js
 
 
 build/python.html: src/python.html
+	cp $< $@
+
+
+build/python_dev.html: src/python_dev.html
 	cp $< $@
 
 

--- a/src/python_dev.html
+++ b/src/python_dev.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Python - iodide</title>
+<link rel="stylesheet" type="text/css" href="https://iodide.io/dist/iodide.pyodide-20180623.css">
+</head>
+<body>
+<script id="jsmd" type="text/jsmd">
+%% meta
+{
+  "title": "Python",
+  "languages": {
+    "js": {
+      "pluginType": "language",
+      "languageId": "js",
+      "displayName": "Javascript",
+      "codeMirrorMode": "javascript",
+      "module": "window",
+      "evaluator": "eval",
+      "keybinding": "j",
+      "url": ""
+    },
+    "py": {
+      "languageId": "py",
+      "displayName": "python",
+      "codeMirrorMode": "python",
+      "keybinding": "p",
+      "url": "./pyodide_dev.js",
+      "module": "pyodide",
+      "evaluator": "runPython",
+      "pluginType": "language"
+    }
+  },
+  "lastExport": "2018-05-04T17:13:00.489Z"
+}
+
+%% md
+# Pyodide dev notebook 🐍
+
+An iodide notebook used for developpement that loads the locally build packages
+
+%% plugin
+{
+  "languageId": "py",
+  "displayName": "python",
+  "codeMirrorMode": "python",
+  "keybinding": "p",
+  "url": "./pyodide_dev.js",
+  "module": "pyodide",
+  "evaluator": "runPython",
+  "pluginType": "language"
+}
+
+%% js
+pyodide.loadPackage('numpy')
+
+%% code {"language":"py"}
+import numpy as np
+
+np.arange(2)
+
+%% js
+</script>
+<div id='page'></div>
+<script src='https://iodide.io/dist/iodide.pyodide-20180623.js'></script>
+</body>
+</html>


### PR DESCRIPTION
When testing a branch or some code changes locally, it's convenient test the behavior in a iodide notebook. 

This can be done with `src/python.html` but the issue is that, 
 - the "url" for `pyodide.js` need to be changed to the local path
 - to use local packages `pyodide_dev.js` should be used.

When the notebook crashes etc, these changes need to re-applied anew, which can become quite tedious.  Also despite knowing the above, sometimes I tend to forget to change one of the two, leading to results that are misleading (e.g. testing packages on the demo server instead of the local ones).

This adds a very short `src/python_dev.html` with the correct `pyodide_dev.js` url for testing. Maybe there is a better way of doing it... 