### PR TITLE
Add API reference documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 - [Using Pyodide directly from Javascript](using_pyodide_from_javascript.md)
 - [Using Pyodide from Iodide](using_pyodide_from_iodide.md)
 - [Type conversions](type_conversions.md): describes how data types are shared between Python and Javascript
+- [API Reference](api_reference.md)
 
 ## Developing Pyodide
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -21,11 +21,14 @@ Fetches a given *url* and returns a `io.StringIO` to access its contents.
 
 *Returns*
 
-A `io.StringIO` object with the URL contents
+A `io.StringIO` object with the URL contents./
 
 ### pyodide.eval_code(code, ns)
 
-Runs a string of code, the last part of which may be an expression.
+Runs a string of code. The last part of the string may be an expression, in which case, its value is returned.
+
+This function may be overridden to change how `pyodide.runPython` interprets code, for example to perform
+some preprocessing on the Python code first.
 
 *Parameters*
 
@@ -37,15 +40,17 @@ Runs a string of code, the last part of which may be an expression.
 
 *Returns*
 
-Either the resulting object or `None`
+Either the resulting object or `None`.
 
 
 ## Javascript API
 
 ### pyodide.loadPackage(names)
 
-Load a package or a list of packages
+Load a package or a list of packages over the network.
 
+This makes the files for the package available in the virtual filesystem.  
+The package needs to be imported from Python before it can be used.
 
 *Parameters*
 
@@ -56,7 +61,7 @@ Load a package or a list of packages
 
 *Returns*
 
-An evaluated promise.
+Loading is asynchronous, therefore, this returns a promise.
 
 
 ### pyodide.loadedPackage
@@ -69,58 +74,67 @@ install location for a particular `package_name`.
 
 ### pyodide.pyimport(name)
 
-Import a Python package from Javascript.
+Access a Python object from Javascript.  The object must be in the global Python namespace.
 
-Makes `var foo = pyodide.pyimport('foo')` work in Javascript.
+For example, to access the `foo` Python object from Javascript:
+
+   `var foo = pyodide.pyimport('foo')`
 
 *Parameters*
 
-| name    | type  | description         |
-|---------|-------|---------------------|
-| *names* | str   | Python package name |
+| name    | type   | description          |
+|---------|--------|----------------------|
+| *names* | String | Python variable name |
 
 
 *Returns*
 
 | name      | type    | description                           |
 |-----------|---------|---------------------------------------|
-| *package* | Object  | proxy for the imported Python package |
+| *object*  | *any*   | If one of the basic types (string,    |
+|           |         | number, boolean, array, object), the  |
+|           |         | Python object is converted to         |
+|           |         | Javascript and returned.  For other   |
+|           |         | types, a Proxy object to the Python   |
+|           |         | object is returned.                   |
 
 
 ### pyodide.repr(obj)
 
-Gets the string representation of an object
+Gets the Python's string representation of an object.
+
+This is equivalent to calling `repr(obj)` in Python.
 
 *Parameters*
 
 | name    | type   | description         |
 |---------|--------|---------------------|
-| *obj*   | Object | Input object        |
+| *obj*   | *any*  | Input object        |
 
 
 *Returns*
 
 | name       | type    | description                               |
 |------------|---------|-------------------------------------------|
-| *str_repr* | str     | String representation of the input object |
+| *str_repr* | String  | String representation of the input object |
 
 
 ### pyodide.runPython(code)
 
-Gets the string representation of an object
+Runs a string of code. The last part of the string may be an expression, in which case, its value is returned.
 
 *Parameters*
 
 | name    | type   | description                    |
 |---------|--------|--------------------------------|
-| *code*  | str    | Python code to evaluate        |
+| *code*  | String | Python code to evaluate        |
 
 
 *Returns*
 
-| name       | type    | description                    |
-|------------|---------|--------------------------------|
-| *jsresult* | Object  | Results, passed to Javascript  |
+| name       | type    | description                     |
+|------------|---------|---------------------------------|
+| *jsresult* | *any*   | Result, converted to Javascript |
 
 
 ### pyodide.version()
@@ -137,7 +151,7 @@ None
 
 *Returns*
 
-| name      | type | description            |
-|-----------|------|------------------------|
-| *version* | str  | Pyodide version string |
+| name      | type   | description            |
+|-----------|--------|------------------------|
+| *version* | String | Pyodide version string |
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -54,9 +54,9 @@ The package needs to be imported from Python before it can be used.
 
 *Parameters*
 
-| name    | type         | description                           |
-|---------|--------------|---------------------------------------|
-| *names* | {str, Array} | package name, or URL. Can be either a single element, or an array.          |
+| name    | type            | description                           |
+|---------|-----------------|---------------------------------------|
+| *names* | {String, Array} | package name, or URL. Can be either a single element, or an array.          |
 
 
 *Returns*

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,143 @@
+# API Reference
+
+*pyodide version 0.1.0*
+
+Backward compatibility of the API is not guaranteed at this point.
+
+
+## Python API
+
+
+### pyodide.open_url(url)
+
+Fetches a given *url* and returns a `io.StringIO` to access its contents.
+
+*Parameters*
+
+| name  | type | description     |
+|-------|------|-----------------|
+| *url* | str  | the URL to open |
+
+
+*Returns*
+
+A `io.StringIO` object with the URL contents
+
+### pyodide.eval_code(code, ns)
+
+Runs a string of code, the last part of which may be an expression.
+
+*Parameters*
+
+| name   | type  | description           |
+|--------|-------|-----------------------|
+| *code* | str   | the code to evaluate  |
+| *ns*   | dict  | evaluation name space |
+
+
+*Returns*
+
+Either the resulting object or `None`
+
+
+## Javascript API
+
+### pyodide.loadPackage(names)
+
+Load a package or a list of packages
+
+
+*Parameters*
+
+| name    | type         | description                           |
+|---------|--------------|---------------------------------------|
+| *names* | {str, Array} | package name, or URL. Can be either a single element, or an array.          |
+
+
+*Returns*
+
+An evaluated promise.
+
+
+### pyodide.loadedPackage
+
+`Array` with loaded packages.
+
+Use `Object.keys(pyodide.loadedPackage)` to access the names of the
+loaded packages, and `pyodide.loadedPackage[package_name]` to access
+install location for a particular `package_name`.
+
+### pyodide.pyimport(name)
+
+Import a Python package from Javascript.
+
+Makes `var foo = pyodide.pyimport('foo')` work in Javascript.
+
+*Parameters*
+
+| name    | type  | description         |
+|---------|-------|---------------------|
+| *names* | str   | Python package name |
+
+
+*Returns*
+
+| name      | type    | description                           |
+|-----------|---------|---------------------------------------|
+| *package* | Object  | proxy for the imported Python package |
+
+
+### pyodide.repr(obj)
+
+Gets the string representation of an object
+
+*Parameters*
+
+| name    | type   | description         |
+|---------|--------|---------------------|
+| *obj*   | Object | Input object        |
+
+
+*Returns*
+
+| name       | type    | description                               |
+|------------|---------|-------------------------------------------|
+| *str_repr* | str     | String representation of the input object |
+
+
+### pyodide.runPython(code)
+
+Gets the string representation of an object
+
+*Parameters*
+
+| name    | type   | description                    |
+|---------|--------|--------------------------------|
+| *code*  | str    | Python code to evaluate        |
+
+
+*Returns*
+
+| name       | type    | description                    |
+|------------|---------|--------------------------------|
+| *jsresult* | Object  | Results, passed to Javascript  |
+
+
+### pyodide.version()
+
+Returns the pyodide version.
+
+It can be either the exact release version (e.g. `0.1.0`), or 
+the latest release version followed by the number of commits since, and
+the git hash of the current commit (e.g. `0.1.0-1-bd84646`).
+
+*Parameters*
+
+None
+
+*Returns*
+
+| name      | type | description            |
+|-----------|------|------------------------|
+| *version* | str  | Pyodide version string |
+


### PR DESCRIPTION
As discussed in https://github.com/iodide-project/pyodide/issues/175 this adds the API reference documentation `doc/api_reference.md` 

Together with https://github.com/iodide-project/pyodide/pull/176 this closes https://github.com/iodide-project/pyodide/issues/175

The rendered document can be found in https://github.com/rth/pyodide/blob/api-reference/docs/api_reference.md

This is a first draft, I may have missed a few points.

@mdboom if the general form is fine with you but you want to change the contents, it might be easier to directly edit the above file on Github (I think you should have the permissions to do that, since this PR allows changes from maintainers). Alternatively I can also incorporate comments, as you prefer... 