### PR TITLE
full nodejs support in file_packager.py v2

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -109,7 +109,7 @@ EM_JS(void, hiwire_push_object_pair, (int idobj, int idkey, int idval), {
 
 EM_JS(int, hiwire_get_global, (int idname), {
   var jsname = UTF8ToString(idname);
-  return Module.hiwire_new_value(window[jsname]);
+  return Module.hiwire_new_value(Module.global[jsname]);
 });
 
 EM_JS(int, hiwire_get_member_string, (int idobj, int idkey), {

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -253,7 +253,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
         .then(instance => receiveInstance(instance));
     return {};
   };
-
+  Module.global = window;
   Module.locateFile = (path) => baseURL + path;
   var postRunPromise = new Promise((resolve, reject) => {
     Module.postRun = () => {

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -700,13 +700,13 @@ if has_preloaded:
             total = Math.ceil(total * Module.expectedDataFileDownloads / num);
             if (Module['setStatus']) {
               Module['setStatus']('Downloading data... (' + loaded + '/' + total + ')');
-              console.log(`Downloaded ${packageName} data... (${loaded}/${total})`);
+              console.log('Downloaded ' + packageName + ' data... (' + loaded + '/' + total + ')');
             }
           }
           callback(packageData);
         }).catch(function(err) {
-            console.error(`Something wrong happened ${err}`);
-            throw new Error(`Something wrong happened ${err}`);
+            console.error('Something wrong happened ' + err);
+            throw new Error('Something wrong happened ' + err);
         });
       }
     };


### PR DESCRIPTION
Continuation of https://github.com/iodide-project/pyodide/pull/164
partially addresses https://github.com/iodide-project/pyodide/issues/14 

## Changes

- where it sets the Module `var Module = ...`, added a check to look for `process[%(EXPORT_NAME)s]` which is where PyodideNode.js stores its `pyodide` Module. 

- where it tries to set `PACKAGE_PATH`, added support for nodejs and stopped throwing errors if not in a browser, now the error is thrown if the user is on some mysterious environment that is not browser, worker or nodejs.

- changed the `fetchRemotePackage` method to check for `XMLHttpRequest` before trying to fetch anything, if user is not on a browser, use `nodejs` `isomorphic-fetch`/`fs` to fetch remote/local packages

- after the data has been fetched, there are some problematic asserts for `nodejs`, sometimes the buffer is not the `arrayBuffer`, but the `arrayBuffer.buffer`
- it was necessary to change from
*line 700* `assert(arrayBuffer instanceof ArrayBuffer, 'bad input to processPackageData');`
to 
`assert((arrayBuffer instanceof ArrayBuffer || arrayBuffer.buffer instanceof ArrayBuffer), 'bad input to processPackageData');`
- and from *line 701* `var byteArray = new Uint8Array(arrayBuffer);` 
to `var byteArray = new Uint8Array(arrayBuffer instanceof ArrayBuffer ? arrayBuffer : arrayBuffer.buffer);`

this format was tested using `PyodideNode.js` on `pyodide.asm.data.js` and `numpy.js` and works fine.