### PR TITLE
Use constant hiwire ids for singleton values

### DIFF
--- a/src/hiwire.h
+++ b/src/hiwire.h
@@ -14,6 +14,8 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
+#define HW_ERROR -1
+
 /**
  * Initialize the variables and functions required for hiwire.
  */
@@ -359,7 +361,7 @@ hiwire_greater_than_equal(int ida, int idb);
 /**
  * Calls the `next` function on an iterator.
  *
- * Returns: -1 if `next` function is undefined.
+ * Returns: HW_ERROR if `next` function is undefined.
  */
 int
 hiwire_next(int idobj);


### PR DESCRIPTION
This is an optimization that helps a lot with matplotlib interactive performance.  The most common return value from an event callback is "undefined", and rather than inserting it into the objects dictionary just to pop it back out each time, we can assign it a constant value and leave it in the map permanently.