### PR TITLE
Fix patch against library_lz4.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v7-
+          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v8-
 
       - run:
           name: build
@@ -62,7 +62,7 @@ jobs:
           paths:
             - ./emsdk/emsdk
             - ~/.ccache
-          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v7-{{ .BuildNum }}
+          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v8-{{ .BuildNum }}
 
       - persist_to_workspace:
           root: .

--- a/emsdk/patches/lz4_c.patch
+++ b/emsdk/patches/lz4_c.patch
@@ -1,7 +1,7 @@
 diff --git a/emsdk/emscripten/tag-1.38.12/src/library_lz4.js b/emsdk/emscripten/tag-1.38.12/src/library_lz4.js
 index 4c3f583b7..5291002a4 100644
---- a/src/library_lz4.js
-+++ b/src/library_lz4.js
+--- a/emsdk/emscripten/tag-1.38.12/src/library_lz4.js
++++ b/emsdk/emscripten/tag-1.38.12/src/library_lz4.js
 @@ -5,26 +5,14 @@ mergeInto(LibraryManager.library, {
      DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
      FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,


### PR DESCRIPTION
In response to:

https://github.com/iodide-project/pyodide/pull/203#issuecomment-426314446

I'm not sure why this passed CI in the first place.  I've bumped the emsdk cache key for good measure.

