### PR TITLE
Hotfix selenium ConnectionError issue

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -7,7 +7,7 @@ import sys
 sys.path.insert(
     0, str((Path(__file__).resolve().parents[1] / 'test')))
 
-import conftest  # noqa
+import conftest  # noqa: E402
 
 
 SKIP = set(['fft', 'hyantes', 'README'])

--- a/pyodide_build/_fixes.py
+++ b/pyodide_build/_fixes.py
@@ -1,0 +1,22 @@
+import socket
+
+
+# Temporary fix from https://github.com/SeleniumHQ/selenium/pull/6480
+# to avoid ConnectionError in selenium
+
+def _selenium_is_connectable(port, host="localhost"):
+    """
+    Tries to connect to the server at port to see if it is running.
+    :Args:
+     - port - The port to connect.
+    """
+    socket_ = None
+    try:
+        socket_ = socket.create_connection((host, port), 1)
+        result = True
+    except (socket.error, ConnectionError):
+        result = False
+    finally:
+        if socket_:
+            socket_.close()
+    return result

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,15 @@ import shutil
 TEST_PATH = pathlib.Path(__file__).parents[0].resolve()
 BUILD_PATH = TEST_PATH / '..' / 'build'
 
+sys.path.append(TEST_PATH / '..')
+
+from pyodide_build._fixes import _selenium_is_connectable  # noqa: E402
+import selenium.webdriver.common.utils  # noqa: E402
+
+# XXX: Temporary fix for ConnectionError in selenium
+
+selenium.webdriver.common.utils.is_connectable = _selenium_is_connectable
+
 try:
     import pytest
 


### PR DESCRIPTION
Currently we have ~20% of chance that any given CI test job will fail with a `ConnectionError` and it will get worse as the number of tests increase. So any given  CI run has >40% chance of failing, which as a result also show the overall CI status on master as broken half of the time.

It's a known issue in selenium and a fix was proposed in https://github.com/SeleniumHQ/selenium/pull/6480

Meanwhile, this aims to apply the above mentioned fix now, as a temporary solution. Monkeypatching is not great, but selenium uses a single multi-language repo that weights 1.5GB, so installing selenium from github directly (with this fix applied) is not an option either. This should work for a relatively large range of selenium versions. 

I'm not sure if there is a better alternative.

(Lately we have also been seeing other unrelated intermittent failures..)