### PR TITLE
MAINT Allow re-creating broken symlinks under tools/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM circleci/python:3.7.0-stretch-browsers
 # Set up the Debian testing repo, and then install g++ from there...
 RUN sudo bash -c "echo \"deb http://ftp.us.debian.org/debian testing main contrib non-free\" >> /etc/apt/sources.list" \
   && sudo apt-get update \
-  && sudo apt-get install node-less cmake build-essential clang-format-6.0 uglifyjs chromium ccache \
+  && sudo apt-get install node-less cmake build-essential clang-format-6.0 uglifyjs chromium ccache libncurses6 \
   && sudo apt-get install -t testing g++-8 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -77,6 +77,9 @@ def make_symlinks(env):
     exec_path = Path(__file__).resolve()
     for symlink in symlinks:
         symlink_path = ROOTDIR / symlink
+        if os.path.lexists(symlink_path) and not symlink_path.exists():
+            # remove broken symlink so it can be re-created
+            symlink_path.unlink()
         if not symlink_path.exists():
             symlink_path.symlink_to(exec_path)
         if symlink == 'c++':


### PR DESCRIPTION
Fixes https://github.com/iodide-project/pyodide/pull/107#issuecomment-425226038

I run into this error again when switching between Dockerized and regular environments. This detects broken symlinks in `tools/` and removes those so that they can be re-generated during build.


This prevents the build from producing errors of the form,
```py
  File "/src/pyodide_build/pywasmcross.py", line 92, in capture_compile
    make_symlinks(env)
  File "/src/pyodide_build/pywasmcross.py", line 82, in make_symlinks
    symlink_path.symlink_to(exec_path)
  File "/src/cpython/build/3.7.0/host/lib/python3.7/pathlib.py", line 1309, in symlink_to
    self._accessor.symlink(target, self, target_is_directory)
  File "/src/cpython/build/3.7.0/host/lib/python3.7/pathlib.py", line 418, in symlink
    return os.symlink(a, b)
FileExistsError: [Errno 17] File exists: '/src/pyodide_build/pywasmcross.py' -> '/src/tools/ld'
```
