### PR TITLE
Do nothing if no packages to load

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -138,6 +138,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
     let promise = new Promise((resolve, reject) => {
       if (Object.keys(toLoad).length === 0) {
         resolve('No new packages to load');
+        return;
       }
 
       const packageList = Array.from(Object.keys(toLoad)).join(', ');


### PR DESCRIPTION
This is a small issue that came up in integration testing with iodide.  If after figuring out the dependencies and what to load there is nothing left to do, it should actually resolve and then return and do nothing further.