### PR TITLE
MAINT Optimize the pyodide-env docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: rthz/pyodide-env:0.3.0
+    - image: iodide/pyodide-env:0.3.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: iodide/pyodide-env:0.2.0
+    - image: rthz/pyodide-env:0.3.0
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM circleci/python:3.7.0-stretch-browsers
+FROM circleci/python:3.7.0-stretch
 
 # We need at least g++-8, but stretch comes with g++-6
 # Set up the Debian testing repo, and then install g++ from there...
 RUN sudo bash -c "echo \"deb http://ftp.us.debian.org/debian testing main contrib non-free\" >> /etc/apt/sources.list" \
   && sudo apt-get update \
   && sudo apt-get install node-less cmake build-essential clang-format-6.0 uglifyjs chromium ccache libncurses6 \
+  # for extracting firefox and running chrome, respectively
+  && sudo apt-get install -y bzip2 libgconf-2-4 \
   && sudo apt-get install -t testing g++-8 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
@@ -14,7 +16,8 @@ RUN sudo bash -c "echo \"deb http://ftp.us.debian.org/debian testing main contri
   && sudo ln -s /usr/bin/clang-format-6.0 /usr/bin/clang-format \
   && sudo bash -c "echo 'application/wasm wasm' >> /etc/mime.types"
 
-RUN sudo pip install pytest pytest-xdist pytest-instafail selenium PyYAML flake8
+RUN sudo pip install pytest pytest-xdist pytest-instafail selenium PyYAML flake8 \
+    && sudo rm -rf /root/.cache/pip
 
 # Get recent version of Firefox and geckodriver
 RUN sudo wget --quiet -O firefox.tar.bz2 https://download.mozilla.org/\?product\=firefox-latest-ssl\&os\=linux64\&lang\=en-US \
@@ -22,11 +25,25 @@ RUN sudo wget --quiet -O firefox.tar.bz2 https://download.mozilla.org/\?product\
   && sudo rm -f /usr/local/bin/firefox \
   && sudo ln -s $PWD/firefox/firefox /usr/local/bin/firefox \
   && sudo wget --quiet https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz \
-  && sudo tar zxf geckodriver-v0.21.0-linux64.tar.gz -C /usr/local/bin
+  && sudo tar zxf geckodriver-v0.21.0-linux64.tar.gz -C /usr/local/bin \
+  && sudo rm -f firefox.tar.bz2 geckodriver-v0.21.0-linux64.tar.gz
 
 # Get recent version of chromedriver
 RUN sudo wget --quiet https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip \
   && sudo unzip chromedriver_linux64.zip \
-  && sudo mv $PWD/chromedriver /usr/local/bin
+  && sudo mv $PWD/chromedriver /usr/local/bin \
+  && sudo rm -f chromedriver_linux64.zip
 
+
+# start xvfb automatically to avoid needing to express in circle.yml
+ENV DISPLAY :99
+RUN printf '#!/bin/sh\nXvfb :99 -screen 0 1280x1024x24 &\nexec "$@"\n' > /tmp/entrypoint \
+  && chmod +x /tmp/entrypoint \
+        && sudo mv /tmp/entrypoint /docker-entrypoint.sh
+
+# ensure that the build agent doesn't override the entrypoint
+LABEL com.circleci.preserve-entrypoint=true
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/bin/sh"]
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ FROM circleci/python:3.7.0-stretch
 # Set up the Debian testing repo, and then install g++ from there...
 RUN sudo bash -c "echo \"deb http://ftp.us.debian.org/debian testing main contrib non-free\" >> /etc/apt/sources.list" \
   && sudo apt-get update \
-  && sudo apt-get install node-less cmake build-essential clang-format-6.0 uglifyjs chromium ccache libncurses6 \
-  # for extracting firefox and running chrome, respectively
-  && sudo apt-get install -y bzip2 libgconf-2-4 \
+  # bzip2 and libgconf-2-4 are necessary for extracting firefox and running chrome, respectively
+  && sudo apt-get install bzip2 libgconf-2-4 node-less cmake build-essential clang-format-6.0 uglifyjs chromium ccache libncurses6 \
   && sudo apt-get install -t testing g++-8 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \


### PR DESCRIPTION
This optimizes a bit the `pyodide-env` Docker image, by basing it on `circleci/python:3.7.0-stretch` instead of `circleci/python:3.7.0-stretch-browsers` and removing some other temporary files. The result should be an image smaller by  600MB,
```
$ docker images 
REPOSITORY           TAG                      IMAGE ID            CREATED             SIZE
rthz/pyodide-env     0.3                      2f27ffd09982        42 minutes ago      2.34GB
circleci/python      3.7.0-stretch-browsers   ea601b5f31d7        11 hours ago        2.04GB
circleci/python      3.7.0-stretch            5f28a9c1f025        5 days ago          1.34GB
iodide/pyodide-env   0.2.0                    e906e09bbd6c        5 days ago          2.92GB
```

For now it's using this image uploaded to a temporary location, once this PR is approved and ideally https://github.com/iodide-project/pyodide/pull/219 merged I'll push the updated docker image to `iodide/pyodide-env` and update the `.circleci/config.yaml` in this PR accordingly.