### PR TITLE
Add python tests for handle_command in pywasmcross.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - run:
           name: test
           command: |
-            pytest test -v -k firefox
+            pytest test pyodide_build -v -k firefox
 
   test-chrome:
     <<: *defaults
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: test
           command: |
-            pytest test -v -k chrome
+            pytest test pyodide_build -v -k chrome
 
   test-python:
     <<: *defaults
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: test
           command: |
-            pytest test -v -k 'not (chrome or firefox)' --cov=pyodide_build --cov=pyodide
+            pytest test pyodide_build -v -k 'not (chrome or firefox)' --cov=pyodide_build --cov=pyodide
 
   benchmark:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: deps
+          command: |
+            sudo pip install pytest-cov
+      - run:
           name: test
           command: |
-            pytest test -v -k 'not (chrome or firefox)'
+            pytest test -v -k 'not (chrome or firefox)' --cov=pyodide_build --cov=pyodide
 
   benchmark:
     <<: *defaults

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -105,7 +105,7 @@ def capture_compile(args):
         sys.exit(result.returncode)
 
 
-def handle_command(line, args):
+def handle_command(line, args, pretend=False):
     # This is a special case to skip the compilation tests in numpy that aren't
     # actually part of the build
     for arg in line:
@@ -156,9 +156,10 @@ def handle_command(line, args):
 
     print(' '.join(new_args))
 
-    result = subprocess.run(new_args)
-    if result.returncode != 0:
-        sys.exit(result.returncode)
+    if not pretend:
+        result = subprocess.run(new_args)
+        if result.returncode != 0:
+            sys.exit(result.returncode)
 
     # Emscripten .so files shouldn't have the native platform slug
     if shared:
@@ -169,7 +170,9 @@ def handle_command(line, args):
             if renamed.endswith(ext):
                 renamed = renamed[:-len(ext)] + '.so'
                 break
-        os.rename(output, renamed)
+        if not pretend:
+            os.rename(output, renamed)
+    return new_args
 
 
 def replay_compile(args):

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -105,7 +105,29 @@ def capture_compile(args):
         sys.exit(result.returncode)
 
 
-def handle_command(line, args, pretend=False):
+def handle_command(line, args, dryrun=False):
+    """Handle a compilation command
+
+    Parameters
+    ----------
+    line : iterable
+       an iterable with the compilation arguments
+    args : {object, namedtuple}
+       an container with additional compilation options,
+       in particular containing ``args.cflags`` and ``args.ldflags``
+    dryrun : bool, default=False
+       if True do not run the resulting command, only return it
+
+    Examples
+    --------
+
+    >>> from collections import namedtuple
+    >>> Args = namedtuple('args', ['cflags', 'ldflags'])
+    >>> args = Args(cflags='', ldflags='')
+    >>> handle_command(['gcc', 'test.c'], args, dryrun=True)
+    emcc test.c
+    ['emcc', 'test.c']
+    """
     # This is a special case to skip the compilation tests in numpy that aren't
     # actually part of the build
     for arg in line:
@@ -156,7 +178,7 @@ def handle_command(line, args, pretend=False):
 
     print(' '.join(new_args))
 
-    if not pretend:
+    if not dryrun:
         result = subprocess.run(new_args)
         if result.returncode != 0:
             sys.exit(result.returncode)
@@ -170,7 +192,7 @@ def handle_command(line, args, pretend=False):
             if renamed.endswith(ext):
                 renamed = renamed[:-len(ext)] + '.so'
                 break
-        if not pretend:
+        if not dryrun:
             os.rename(output, renamed)
     return new_args
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 addopts =
     -r sxX
     --instafail
+    --doctest-modules

--- a/test/pyodide_build/test_pywasmcross.py
+++ b/test/pyodide_build/test_pywasmcross.py
@@ -1,0 +1,44 @@
+from collections import namedtuple
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).parents[2]))
+
+from pyodide_build.pywasmcross import handle_command  # noqa: E402
+
+
+def _args_wrapper(func):
+    """Convert function to take as input / return a string instead of a
+    list of arguments
+
+    Also sets pretend=True
+    """
+    def _inner(line, *pargs):
+        args = line.split()
+        res = func(args, *pargs, pretend=True)
+        if hasattr(res, '__len__'):
+            return ' '.join(res)
+        else:
+            return res
+    return _inner
+
+
+handle_command_wrap = _args_wrapper(handle_command)
+# TODO: add f2c here
+
+
+def test_handle_command():
+    Args = namedtuple('args', ['cflags', 'ldflags'])
+    args = Args(cflags='', ldflags='')
+    assert handle_command_wrap('gcc -print-multiarch', args) is None
+    assert handle_command_wrap('gcc test.c', args) == 'emcc test.c'
+    assert handle_command_wrap('gcc -shared -c test.o -o test.so', args) == \
+        'emcc -shared -c test.bc -o test.wasm'
+
+    # check ldflags injection
+    args = Args(cflags='', ldflags='-lm')
+    assert handle_command_wrap('gcc -shared -c test.o -o test.so', args) == \
+        'emcc -lm -shared -c test.bc -o test.wasm'
+
+    # compilation checks in numpy
+    assert handle_command_wrap('gcc /usr/file.c', args) is None

--- a/test/pyodide_build/test_pywasmcross.py
+++ b/test/pyodide_build/test_pywasmcross.py
@@ -11,11 +11,11 @@ def _args_wrapper(func):
     """Convert function to take as input / return a string instead of a
     list of arguments
 
-    Also sets pretend=True
+    Also sets dryrun=True
     """
     def _inner(line, *pargs):
         args = line.split()
-        res = func(args, *pargs, pretend=True)
+        res = func(args, *pargs, dryrun=True)
         if hasattr(res, '__len__'):
             return ' '.join(res)
         else:


### PR DESCRIPTION
This adds a mechanism for testing arguments conversion in `handle_command` within `pywasmcross.py`. An optional argument `pretend=False` is added to skip any OS-level operations. The tests are by no mean exhaustive, and are more intended to help contributors understand the expected behavior without running a build that would trigger some particular input command. New assertions could be added in the future as we run into more edge cases.

This also computes some code coverage in the `test-python` CI job. It's not very meaningful, but still gives an idea of how much code in `pyodide_build` and `src/pyodide.py` is covered by pure python tests without running build. The main idea is again to allow to fail as soon as possible. Current output can be found below,
```
pytest -v test/ -k 'not (firefox or chrome)' --cov=pyodide_build --cov=pyodide                      [pywasmcross-tests] 
==================================================================== test session starts ====================================================================
platform linux -- Python 3.7.0, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /home/rth/.miniconda3/envs/pyodide-env/bin/python
cachedir: .pytest_cache
rootdir: /home/rth/src/pyodide, inifile: setup.cfg
plugins: instafail-0.4.0, cov-2.6.0
collected 904 items / 902 deselected                                                                                                                        

test/pyodide_build/test_pywasmcross.py::test_handle_command PASSED                                                                                    [ 50%]
test/src/test_pyodide.py::test_find_imports PASSED                                                                                                    [100%]

----------- coverage: platform linux, python 3.7.0-final-0 -----------
Name                           Stmts   Miss  Cover
--------------------------------------------------
pyodide_build/__init__.py          1      0   100%
pyodide_build/__main__.py         14     14     0%
pyodide_build/_fixes.py           11      9    18%
pyodide_build/buildall.py         51     51     0%
pyodide_build/buildpkg.py        104    104     0%
pyodide_build/common.py           10      3    70%
pyodide_build/pywasmcross.py     139     81    42%
src/pyodide.py                    33     15    55%
--------------------------------------------------
TOTAL                            363    277    24%


========================================================= 2 passed, 902 deselected in 0.27 seconds ==========================================================
```