### PR TITLE
TST Fix test_common.py::test_import

### DIFF
--- a/test/test_common.py
+++ b/test/test_common.py
@@ -43,3 +43,4 @@ def test_import(name, selenium_standalone):
             selenium_standalone.run('import %s' % import_name)
         except Exception as e:
             print(selenium_standalone.logs)
+            raise


### PR DESCRIPTION
This fixes `test_common.py:test_import` that appeared to produce false positives (i.e. passing even if a package couldn't be imported).