### PR TITLE
Support Fortran compilation with f2c; distutils suport

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -290,7 +290,7 @@ def install_for_distribution(args):
         subprocess.check_call(commands)
     except Exception:
         print(f'Warning: {" ".join(commands)} failed with distutils, possibly '
-              f'due to the use if distutils that does not support the '
+              f'due to the use of distutils that does not support the '
               f'--old-and-unmanageable argument. Re-trying the install '
               f'without this argument.')
         subprocess.check_call(commands[:-1])

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -175,7 +175,6 @@ def handle_command(line, args, dryrun=False):
     emcc test.c
     ['emcc', 'test.c']
     """
-
     # This is a special case to skip the compilation tests in numpy that aren't
     # actually part of the build
     for arg in line:
@@ -184,8 +183,6 @@ def handle_command(line, args, dryrun=False):
         if re.match(r'/tmp/.*/source\.[bco]+', arg):
             return
         if arg == '-print-multiarch':
-            return
-        if arg.startswith('/tmp'):
             return
 
     if line[0] == 'gfortran':
@@ -210,8 +207,6 @@ def handle_command(line, args, dryrun=False):
     elif new_args[0] in ('emcc', 'em++'):
         new_args.extend(args.cflags.split())
 
-    lapack_dir = None
-
     # Go through and adjust arguments
     for arg in line[1:]:
         if arg.startswith('-I'):
@@ -233,15 +228,6 @@ def handle_command(line, args, dryrun=False):
         elif shared and arg.endswith('.so'):
             arg = arg[:-3] + '.wasm'
             output = arg
-        # Fix for scipy to link to the correct BLAS/LAPACK files
-        if arg.startswith('-L') and 'CLAPACK-WA' in arg:
-            lapack_dir = arg.replace('-L', '')
-            for lib_name in ['F2CLIBS/libf2c.bc',
-                             'blas_WA.bc',
-                             'lapack_WA.bc']:
-                arg = os.path.join(lapack_dir, f"{lib_name}")
-                new_args.append(arg)
-            continue
 
         new_args.append(arg)
 
@@ -303,9 +289,10 @@ def install_for_distribution(args):
     try:
         subprocess.check_call(commands)
     except Exception:
-        # XXX: temporary hack to remove --old-and-unmanageable with distutils
-        #      see https://github.com/iodide-project/pyodide/issues/220
-        #      for a better solution.
+        print(f'Warning: {" ".join(commands)} failed with distutils, possibly '
+              f'due to the use if distutils that does not support the '
+              f'--old-and-unmanageable argument. Re-trying the install '
+              f'without this argument.')
         subprocess.check_call(commands[:-1])
 
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -41,6 +41,7 @@ from pyodide_build import common
 
 ROOTDIR = common.ROOTDIR
 symlinks = set(['cc', 'c++', 'ld', 'ar', 'gcc'])
+symlinks = set(['cc', 'c++', 'ld', 'ar', 'gcc', 'gfortran'])
 
 
 def collect_args(basename):
@@ -105,6 +106,24 @@ def capture_compile(args):
         sys.exit(result.returncode)
 
 
+def f2c(args):
+    new_args = []
+    found_source = False
+    for arg in args:
+        if arg.endswith('.f'):
+            filename = os.path.abspath(arg)
+            subprocess.check_call(
+                ['f2c', os.path.basename(filename)],
+                cwd=os.path.dirname(filename))
+            new_args.append(arg[:-2] + '.c')
+            found_source = True
+        else:
+            new_args.append(arg)
+    if not found_source:
+        return None
+    return new_args
+
+
 def handle_command(line, args, dryrun=False):
     """Handle a compilation command
 
@@ -137,8 +156,16 @@ def handle_command(line, args, dryrun=False):
             return
         if arg == '-print-multiarch':
             return
+        if arg.startswith('/tmp'):
+            return
 
-    if line[0] == 'ar':
+    if line[0] == 'gfortran':
+        result = f2c(line)
+        if result is None:
+            return
+        line = result
+        new_args = ['emcc']
+    elif line[0] == 'ar':
         new_args = ['emar']
     elif line[0] == 'c++':
         new_args = ['em++']
@@ -153,6 +180,8 @@ def handle_command(line, args, dryrun=False):
         new_args.extend(args.ldflags.split())
     elif new_args[0] in ('emcc', 'em++'):
         new_args.extend(args.cflags.split())
+    if new_args[0] == 'em++':
+        new_args.append('-std=c++98')
 
     # Go through and adjust arguments
     for arg in line[1:]:
@@ -171,10 +200,15 @@ def handle_command(line, args, dryrun=False):
         arg = re.sub(r'/python([0-9]\.[0-9]+)m', r'/python\1', arg)
         if arg.endswith('.o'):
             arg = arg[:-2] + '.bc'
-        if shared and arg.endswith('.so'):
+            output = arg
+        elif shared and arg.endswith('.so'):
             arg = arg[:-3] + '.wasm'
             output = arg
         new_args.append(arg)
+
+    if os.path.isfile(output):
+        print('SKIPPING: ' + ' '.join(new_args))
+        return
 
     print(' '.join(new_args))
 

--- a/test/pyodide_build/test_pywasmcross.py
+++ b/test/pyodide_build/test_pywasmcross.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append(str(Path(__file__).parents[2]))
 
 from pyodide_build.pywasmcross import handle_command  # noqa: E402
+from pyodide_build.pywasmcross import f2c  # noqa: E402
 
 
 def _args_wrapper(func):
@@ -24,7 +25,7 @@ def _args_wrapper(func):
 
 
 handle_command_wrap = _args_wrapper(handle_command)
-# TODO: add f2c here
+f2c_wrap = _args_wrapper(f2c)
 
 
 def test_handle_command():
@@ -42,3 +43,11 @@ def test_handle_command():
 
     # compilation checks in numpy
     assert handle_command_wrap('gcc /usr/file.c', args) is None
+
+
+def test_f2c():
+    assert f2c_wrap('gfortran test.f') == 'gfortran test.c'
+    assert f2c_wrap('gcc test.c') is None
+    assert f2c_wrap('gfortran --version') is None
+    assert f2c_wrap('gfortran --shared -c test.o -o test.so') == \
+        'gfortran --shared -c test.o -o test.so'


### PR DESCRIPTION
This separates some of the code from the scipy build in https://github.com/iodide-project/pyodide/pull/211 to make review easier. I will squash the corresponding commits there once this is merged.

Adds support for compling fortran files using f2c (as started by @mdboom ). There are some tests and it also works in practice for scipy.

Partially addresses https://github.com/iodide-project/pyodide/issues/184

Also adds partial distutils support by removing the `--old-and-unmanageable` in the install when it fails, then re-trying the install.

Closes https://github.com/iodide-project/pyodide/issues/220