### PR TITLE
languagePluginLoader is a Promise, not function

### DIFF
--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -9,7 +9,7 @@ Iodide](using_pyodide_from_iodide.md).
 Include `pyodide.js` in your project.
 
 This has a single `Promise` object which bootstraps the Python environment:
-`languagePluginLoader`. Since this must happen asynchronously, it returns a
+`languagePluginLoader`. Since this must happen asynchronously, it is a
 `Promise`, which you must call `then` on to complete initialization. When the
 promise resolves, pyodide will have installed a namespace in global scope:
 `pyodide`.

--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -8,14 +8,14 @@ Iodide](using_pyodide_from_iodide.md).
 
 Include `pyodide.js` in your project.
 
-This has a single function which bootstraps the Python environment:
+This has a single `Promise` object which bootstraps the Python environment:
 `languagePluginLoader`. Since this must happen asynchronously, it returns a
 `Promise`, which you must call `then` on to complete initialization. When the
 promise resolves, pyodide will have installed a namespace in global scope:
 `pyodide`.
 
 ```javascript
-languagePluginLoader().then(() => {
+languagePluginLoader.then(() => {
   // pyodide is now ready to use...
   console.log(pyodide.runPython('import sys\nsys.version'));
 });


### PR DESCRIPTION
Hi, current documentation about `languagePluginLoader` does not match the implementation https://github.com/iodide-project/pyodide/blob/master/src/pyodide.js#L5 , I try to fix the documentation.

But it could be also fixed with the other way around - by changing `languagePluginLoader` into a function, I think it would be even better.
