### PR TITLE
Make cProfile work

### DIFF
--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -47,3 +47,5 @@ _codecs_iso2022 cjkcodecs/_codecs_iso2022.c
 _codecs_jp cjkcodecs/_codecs_jp.c
 _codecs_kr cjkcodecs/_codecs_kr.c
 _codecs_tw cjkcodecs/_codecs_tw.c
+
+_lsprof _lsprof.c rotatingtree.c


### PR DESCRIPTION
cProfile requires the `_lsprof` module, which this statically compiles in.