### PR TITLE
Reduce the number of mandatory imports in matplotlib

### DIFF
--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -11,6 +11,7 @@ source:
     - patches/force_malloc_free.patch
     - patches/hardcoded_font_cache.patch
     - patches/reduce_cpp_exceptions.patch
+    - patches/reduce-imports.patch
 
   extras:
     -

--- a/packages/matplotlib/patches/reduce-imports.patch
+++ b/packages/matplotlib/patches/reduce-imports.patch
@@ -1,0 +1,208 @@
+diff --git a/lib/matplotlib/__init__.py b/lib/matplotlib/__init__.py
+index c5accc3c3..472680fe6 100644
+--- a/lib/matplotlib/__init__.py
++++ b/lib/matplotlib/__init__.py
+@@ -130,7 +130,6 @@ from matplotlib.compat import subprocess
+ from matplotlib.rcsetup import defaultParams, validate_backend, cycler
+ 
+ import numpy
+-from six.moves.urllib.request import urlopen
+ from six.moves import reload_module as reload
+ 
+ # Get the version from the _version.py versioneer file. For a git checkout,
+@@ -1023,6 +1022,7 @@ def _url_lines(f):
+ @contextlib.contextmanager
+ def _open_file_or_url(fname):
+     if is_url(fname):
++        from six.moves.urllib.request import urlopen
+         f = urlopen(fname)
+         yield _url_lines(f)
+         f.close()
+diff --git a/lib/matplotlib/_layoutbox.py b/lib/matplotlib/_layoutbox.py
+index cb6f03158..0cc6bdf88 100644
+--- a/lib/matplotlib/_layoutbox.py
++++ b/lib/matplotlib/_layoutbox.py
+@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function,
+                         unicode_literals)
+ 
+ import itertools
+-import kiwisolver as kiwi
+ import logging
+ import numpy as np
+ import warnings
+@@ -58,6 +57,8 @@ class LayoutBox(object):
+                  tightheight=False, artist=None,
+                  lower_left=(0, 0), upper_right=(1, 1), pos=False,
+                  subplot=False, h_pad=None, w_pad=None):
++        import kiwisolver as kiwi
++
+         Variable = kiwi.Variable
+         self.parent = parent
+         self.name = name
+diff --git a/lib/matplotlib/backends/backend_agg.py b/lib/matplotlib/backends/backend_agg.py
+index aff6cddf4..c4d2d0713 100644
+--- a/lib/matplotlib/backends/backend_agg.py
++++ b/lib/matplotlib/backends/backend_agg.py
+@@ -46,7 +46,6 @@ from matplotlib.transforms import Bbox, BboxBase
+ from matplotlib import colors as mcolors
+ 
+ from matplotlib.backends._backend_agg import RendererAgg as _RendererAgg
+-from matplotlib import _png
+ 
+ try:
+     from PIL import Image
+@@ -514,6 +513,8 @@ class FigureCanvasAgg(FigureCanvasBase):
+     print_rgba = print_raw
+ 
+     def print_png(self, filename_or_obj, *args, **kwargs):
++        from matplotlib import _png
++
+         FigureCanvasAgg.draw(self)
+         renderer = self.get_renderer()
+         original_dpi = renderer.dpi
+diff --git a/lib/matplotlib/cbook/__init__.py b/lib/matplotlib/cbook/__init__.py
+index dcb2d0549..3dfc49589 100644
+--- a/lib/matplotlib/cbook/__init__.py
++++ b/lib/matplotlib/cbook/__init__.py
+@@ -16,7 +16,6 @@ import datetime
+ import errno
+ import functools
+ import glob
+-import gzip
+ import io
+ from itertools import repeat
+ import locale
+@@ -597,6 +596,7 @@ def to_filehandle(fname, flag='rU', return_opened=False, encoding=None):
+             flag=flag, return_opened=return_opened, encoding=encoding)
+     if isinstance(fname, six.string_types):
+         if fname.endswith('.gz'):
++            import gzip
+             # get rid of 'U' in flag for gzipped files.
+             flag = flag.replace('U', '')
+             fh = gzip.open(fname, flag)
+diff --git a/lib/matplotlib/contour.py b/lib/matplotlib/contour.py
+index f6fdfd61c..c06431910 100644
+--- a/lib/matplotlib/contour.py
++++ b/lib/matplotlib/contour.py
+@@ -11,7 +11,6 @@ import warnings
+ import matplotlib as mpl
+ import numpy as np
+ from numpy import ma
+-import matplotlib._contour as _contour
+ import matplotlib.path as mpath
+ import matplotlib.ticker as ticker
+ import matplotlib.cm as cm
+@@ -1469,6 +1468,8 @@ class QuadContourSet(ContourSet):
+             self._mins = args[0]._mins
+             self._maxs = args[0]._maxs
+         else:
++            import matplotlib._contour as contour
++
+             self._corner_mask = kwargs.pop('corner_mask', None)
+             if self._corner_mask is None:
+                 self._corner_mask = mpl.rcParams['contour.corner_mask']
+diff --git a/lib/matplotlib/font_manager.py b/lib/matplotlib/font_manager.py
+index 5900fc9b1..f23f5a438 100644
+--- a/lib/matplotlib/font_manager.py
++++ b/lib/matplotlib/font_manager.py
+@@ -55,7 +55,7 @@ except ImportError:
+ import warnings
+ import logging
+ 
+-from matplotlib import afm, cbook, ft2font, rcParams, get_cachedir
++from matplotlib import cbook, ft2font, rcParams, get_cachedir
+ from matplotlib.compat import subprocess
+ from matplotlib.fontconfig_pattern import (
+     parse_fontconfig_pattern, generate_fontconfig_pattern)
+@@ -569,6 +569,7 @@ def createFontList(fontfiles, fontext='ttf'):
+         else:
+             seen.add(fname)
+         if fontext == 'afm':
++            from matplotlib import afm
+             try:
+                 fh = open(fpath, 'rb')
+             except EnvironmentError:
+diff --git a/lib/matplotlib/image.py b/lib/matplotlib/image.py
+index 3ea0cb70d..5b3056a18 100644
+--- a/lib/matplotlib/image.py
++++ b/lib/matplotlib/image.py
+@@ -26,7 +26,6 @@ import matplotlib.cbook as cbook
+ 
+ # For clarity, names from _image are given explicitly in this module:
+ import matplotlib._image as _image
+-import matplotlib._png as _png
+ 
+ # For user convenience, the names from _image are also imported into
+ # the image namespace:
+@@ -623,6 +622,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
+ 
+     def write_png(self, fname):
+         """Write the image to png file with fname"""
++        from matplotlib import _png
+         im = self.to_rgba(self._A[::-1] if self.origin == 'lower' else self._A,
+                           bytes=True, norm=True)
+         _png.write_png(im, fname)
+@@ -1335,7 +1335,11 @@ def imread(fname, format=None):
+         with Image.open(fname) as image:
+             return pil_to_array(image)
+ 
+-    handlers = {'png': _png.read_png, }
++    def read_png(*args, **kwargs):
++        from matplotlib import _png
++        return _png.read_png(*args, **kwargs)
++
++    handlers = {'png': read_png, }
+     if format is None:
+         if isinstance(fname, six.string_types):
+             parsed = urlparse(fname)
+diff --git a/lib/matplotlib/mathtext.py b/lib/matplotlib/mathtext.py
+index dee778b0d..428582ace 100644
+--- a/lib/matplotlib/mathtext.py
++++ b/lib/matplotlib/mathtext.py
+@@ -35,7 +35,7 @@ from pyparsing import (
+ 
+ ParserElement.enablePackrat()
+ 
+-from matplotlib import _png, colors as mcolors, get_data_path, rcParams
++from matplotlib import colors as mcolors, get_data_path, rcParams
+ from matplotlib.afm import AFM
+ from matplotlib.cbook import Bunch, get_realpath_and_stat, maxdict
+ from matplotlib.ft2font import FT2Image, KERNING_DEFAULT, LOAD_NO_HINTING
+@@ -3379,6 +3379,7 @@ class MathTextParser(object):
+         Returns the offset of the baseline from the bottom of the
+         image in pixels.
+         """
++        from matplotlib import _png
+         rgba, depth = self.to_rgba(texstr, color=color, dpi=dpi, fontsize=fontsize)
+         _png.write_png(rgba, filename)
+         return depth
+diff --git a/lib/matplotlib/tri/triangulation.py b/lib/matplotlib/tri/triangulation.py
+index b80aaf87b..45bf9eb5c 100644
+--- a/lib/matplotlib/tri/triangulation.py
++++ b/lib/matplotlib/tri/triangulation.py
+@@ -3,8 +3,6 @@ from __future__ import (absolute_import, division, print_function,
+ 
+ import six
+ 
+-import matplotlib._tri as _tri
+-import matplotlib._qhull as _qhull
+ import numpy as np
+ 
+ 
+@@ -39,6 +37,8 @@ class Triangulation(object):
+     triangles formed from colinear points, or overlapping triangles.
+     """
+     def __init__(self, x, y, triangles=None, mask=None):
++        from matplotlib import _qhull
++
+         self.x = np.asarray(x, dtype=np.float64)
+         self.y = np.asarray(y, dtype=np.float64)
+         if self.x.shape != self.y.shape or self.x.ndim != 1:
+@@ -103,6 +103,7 @@ class Triangulation(object):
+     def get_cpp_triangulation(self):
+         # Return the underlying C++ Triangulation object, creating it
+         # if necessary.
++        from matplotlib import _tri
+         if self._cpp_triangulation is None:
+             self._cpp_triangulation = _tri.Triangulation(
+                 self.x, self.y, self.triangles, self.mask, self._edges,

--- a/packages/matplotlib/patches/reduce-imports.patch
+++ b/packages/matplotlib/patches/reduce-imports.patch
@@ -96,7 +96,7 @@ index f6fdfd61c..c06431910 100644
              self._mins = args[0]._mins
              self._maxs = args[0]._maxs
          else:
-+            import matplotlib._contour as contour
++            import matplotlib._contour as _contour
 +
              self._corner_mask = kwargs.pop('corner_mask', None)
              if self._corner_mask is None:


### PR DESCRIPTION
The time savings isn't enormous: 5.2s down from 5.9s, so it may not be the maintenance burden of this patch.  But I thought it would be worth sharing some of the low-hanging fruit anyway.