### PR TITLE
Fix iodide/#1151: PyDict_GetItem returns a borrowed reference

### DIFF
--- a/src/pyimport.c
+++ b/src/pyimport.c
@@ -19,7 +19,6 @@ _pyimport(char* name)
 
   Py_DECREF(pyname);
   int idval = python2js(pyval);
-  Py_DECREF(pyval);
   return idval;
 }
 

--- a/src/python2js.c
+++ b/src/python2js.c
@@ -297,7 +297,6 @@ _python2js_cache(PyObject* x, PyObject* map)
     if (result != HW_ERROR) {
       result = hiwire_incref(result);
     }
-    Py_DECREF(val);
   } else {
     result = _python2js(x, map);
   }

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -183,6 +183,13 @@ def test_import_js(selenium):
     assert result == 'Foo'
 
 
+def test_pyimport_multiple(selenium):
+    """See #1151"""
+    selenium.run("v = 0.123")
+    selenium.run_js("pyodide.pyimport('v')")
+    selenium.run_js("pyodide.pyimport('v')")
+
+
 def test_pyproxy(selenium):
     selenium.run(
         """


### PR DESCRIPTION
As reported in https://github.com/iodide-project/iodide/issues/1151, you can't import the same variable twice using `pyodide.pyimport`.  It turns out `PyDict_GetItem` returns a borrowed reference, so it isn't necessary to call `Py_DECREF` on it.  This was free'ing the Python object without removing it from the global namespace dictionary and then it all fell apart.