### PR TITLE
Add support for bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,9 @@
+[bumpversion]
+current_version = 0.1.11
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:src/pyodide.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'

--- a/Makefile
+++ b/Makefile
@@ -169,11 +169,6 @@ root/.built: \
 	cp src/_testcapi.py	root/lib/python$(PYMINOR)
 	cp src/pystone.py root/lib/python$(PYMINOR)
 	cp src/pyodide.py root/lib/python$(PYMINOR)/site-packages
-	if command -v git > /dev/null 2>&1 \
-			&& git describe --tags > /dev/null 2>&1; then \
-	sed -i "s/__version__ =.*/__version__ = '$(shell git describe --tags | sed -r 's/^v//')'/g" \
-		root/lib/python$(PYMINOR)/site-packages/pyodide.py; \
-	fi
 	( \
 		cd root/lib/python$(PYMINOR); \
 		rm -fr `cat ../../../remove_modules.txt`; \

--- a/src/pyodide.py
+++ b/src/pyodide.py
@@ -5,7 +5,7 @@ A library of helper utilities for connecting Python to the browser environment.
 import ast
 import io
 
-__version__ = '0.1.0'
+__version__ = '0.1.11'
 
 
 def open_url(url):


### PR DESCRIPTION
The current method of inserting the version at build time is feeling a little magical to me, and it's a little easy to miss if there's no files that actually changed in the build directory.

This adds support for bumpversion to update the explicit version and tag a commit in the same step.  It has the added benefit that you get explicit commits just for applying a version tag, which I find slightly nicer.

Feedback on all of this is of course welcome if anyone has any strong contrary feelings.