### PR TITLE
WIP Imports hooks mechanism

### DIFF
--- a/src/pyodide.py
+++ b/src/pyodide.py
@@ -4,6 +4,7 @@ A library of helper utilities for connecting Python to the browser environment.
 
 import ast
 import io
+import sys
 
 __version__ = '0.1.11'
 
@@ -55,6 +56,94 @@ def find_imports(code):
             name = node.module
             imports.add(name.split('.')[0])
     return list(imports)
+
+
+_renamed_modules = {}
+
+
+def register_import_hook(mock_modules=None, rename_modules=None,
+                         mock_class=None):
+    """Registed the import hook
+
+    This can be used to either to mock some modules that are missing,
+    or import instead of another.
+
+    Only one such hook can be active at a time. For repeated calls,
+    only the last one is taken into account, except for module renaming which
+    are permanent.
+
+    Parameters
+    ----------
+    mock_modules : list, default=None
+       list of modules names to mock if they cannot be imported.
+       This converts ImportError to an ImportWarning and mock modules.
+
+    rename_modules : dict, default=None
+       a mapping between the requested modules and the actually
+       imported modules
+
+    mock_class : {callable, None}, default=None
+       class used to mock modules, must be a subclass of types.ModuleType
+    """
+
+    import importlib
+    import importlib.abc
+    import importlib.machinery
+    import warnings
+    import types
+
+    if mock_class is None:
+        class PyodideMockModule(types.ModuleType):
+            def __getattr__(self, key):
+                def _raise(*cargs, **kwargs):
+                    """The mocked method is called"""
+                    raise NotImplementedError(
+                            f'{self.name}.{key} is mocked in pyodide..')
+                return _raise
+    else:
+        PyodideMockModule = mock_class
+
+    class PyodidePackageLoader(importlib.abc.Loader):
+        def create_module(self, spec):
+            module = PyodideMockModule(spec.name)
+            module.__spec__ = spec
+            return module
+
+        def exec_module(self, module):
+            pass
+
+    class FallbackFinder(importlib.abc.MetaPathFinder):
+        """This finder will be used if a module is not found by other means
+
+        A module in the whitelist that fails to import will raise an
+        ImportWarning instead of an ImportError, and the corresponding
+        module will be mocked.
+        """
+        def find_spec(self, fullname, path, target=None):
+            if fullname in mock_modules:
+                # only whitelisted modules are mocked
+                warnings.warn(f'Failed to import {fullname}, mocking..',
+                              ImportWarning, stacklevel=2)
+                spec = importlib.machinery.ModuleSpec(
+                        fullname, PyodidePackageLoader())
+                return spec
+
+    warnings.filterwarnings("default", category=ImportWarning)
+
+    # remove existing hooks
+    for finder in list(sys.meta_path):
+        if finder.__class__.__name__ == 'FallbackFinder':
+            sys.meta_path.remove(finder)
+
+    if mock_modules is not None:
+        sys.meta_path.append(FallbackFinder())
+
+    if rename_modules is not None:
+        for source, target in rename_modules.items():
+            print(f'Renaming modules: {source} -> {target}')
+            if target not in sys.modules:
+                sys.modules[target] = importlib.import_module(source)
+                _renamed_modules[source] = target
 
 
 __all__ = ['open_url', 'eval_code', 'find_imports']

--- a/test/src/test_pyodide.py
+++ b/test/src/test_pyodide.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+
 sys.path.append(str(Path(__file__).parents[2] / 'src'))
 
 from pyodide import find_imports  # noqa: E402
@@ -16,3 +18,78 @@ def test_find_imports():
            import matplotlib.pyplot as plt
            """))
     assert set(res) == {'numpy', 'scipy', 'six', 'matplotlib'}
+
+
+def test_register_import_hook_mock_selenium(selenium_standalone):
+    selenium = selenium_standalone
+    from selenium.common.exceptions import JavascriptException
+
+    with pytest.raises(JavascriptException) as err:
+        selenium.run("""
+             import not_existing
+             """)
+        assert ("ModuleNotFoundError: No module "
+                "named 'not_existing'") in str(err)
+
+    selenium.clean_logs()
+
+    selenium.run("""
+        import pyodide
+        import sys
+
+        pyodide.register_import_hook(mock_modules=['not_existing2'])
+
+        import not_existing2
+        not_existing2.some_method
+        """)
+    assert ('ImportWarning: Failed to import not_existing2,'
+            ' mocking') in selenium.logs
+
+
+def test_register_import_hook_mock():
+
+    import pyodide
+
+    n_meta_hooks_init = len(sys.meta_path)
+
+    pyodide.register_import_hook(mock_modules=None, rename_modules=None)
+
+    assert len(sys.meta_path) == n_meta_hooks_init
+
+    with pytest.raises(ImportError):
+        import not_existing  # noqa: F401
+
+    # initialize the import hook
+    pyodide.register_import_hook(mock_modules=['not_existing_a',
+                                               'not_existing_b'])
+
+    assert len(sys.meta_path) == n_meta_hooks_init + 1
+
+    with pytest.warns(ImportWarning):
+        import not_existing_a
+
+    assert 'not_existing_a' in sys.modules
+
+    method_a = not_existing_a.method_a
+
+    assert hasattr(method_a, '__call__')
+
+    with pytest.raises(NotImplementedError):
+        method_a()
+
+    with pytest.warns(ImportWarning):
+        from not_existing_b import method_b
+
+    with pytest.raises(NotImplementedError):
+        method_b()
+
+    # not whitelisted modules still raise ImportError
+    with pytest.raises(ImportError):
+        import not_existing_d  # noqa: F401
+
+    # TODO: support the following
+    # import not_existing_c.some_submodule
+
+    # reset hook
+    pyodide.register_import_hook()
+    assert len(sys.meta_path) == n_meta_hooks_init


### PR DESCRIPTION
An import hook mechanism is something I have worked as part of scipy packaging.

### Motivation

The initial issue this aimed to address is that when building a large package with lots of C extensions, the workflow is often to build, try to import, get some import error, patch the corresponding code in some way, build again, try to import, get another import error and so on. This can be somewhat slow. This aimed to simplify that workflow instead by defining run-time import hooks (e.g. to determine all modules that fail in a given build). After scipy is merged, I'm not sure this will be much use, but I'm posting it here, even if it is not merged, so it may be useful to someone packaging large packages with lots of C extensions (e.g. PyQt or geopandas+dependencies).

### Implementation

The implementation intends to use the import hook mechanism to returns some custom object instead of the module that fails to import. Scikit-learn PR https://github.com/iodide-project/pyodide/pull/226 had an initial version of this (removed since), where we add an import finder to `sys.meta_path` that was used in the module failed to import. This loader returned a mock object. Normally one would have also to write a custom module loader in that case, but because the mock object contaminated everything it touched to also become a mock object, we somehow ended up with an imported module that is a mock object. It was fairly bad, but it worked.

This PR tries to take a more refined approach and properly define both module finder and loader. This currently works for modules but not their submodules. I have not spent more time to make it work, but I think it might be possible. Maybe I'm missing something but I find the Python import hook mechanism cumbersome to work with.

It could also be possible to rename modules with such mechanism I think, e.g. to import `dummy_threading` when `threading` is imported which would help with https://github.com/iodide-project/pyodide/issues/144 that would be difficult to address once the ability to install wheels from PyPi is merged https://github.com/iodide-project/pyodide/pull/147 (since we don't have the ability to patch there).

I'll leave this PR open for a few days (in case someone has an overly positive opinion about its usefulness) and will close afterward.

cc @mdboom 