### PR TITLE
Clang format fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,10 +90,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-RawStringFormats:
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true


### PR DESCRIPTION
This just removes some keys that are no longer supported in new versions of clang-format.