### PR TITLE
Fix Chrome Tests failing inside Docker

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -204,6 +204,7 @@ class ChromeWrapper(SeleniumWrapper):
 
         options = Options()
         options.add_argument('--headless')
+        options.add_argument('--no-sandbox')
 
         self.JavascriptException = WebDriverException
 


### PR DESCRIPTION
The tests related to the Chromium driver do not run inside the Docker environment.
Although the option ``--no-sandbox`` is less secure, but it is of no harm for the current context.