### PR TITLE
Handle multi-line Python strings input in JS

### DIFF
--- a/src/pyodide.py
+++ b/src/pyodide.py
@@ -4,6 +4,7 @@ A library of helper utilities for connecting Python to the browser environment.
 
 import ast
 import io
+from textwrap import dedent
 
 __version__ = '0.1.11'
 
@@ -24,6 +25,9 @@ def eval_code(code, ns):
     """
     Runs a string of code, the last part of which may be an expression.
     """
+    # handle mis-indented input from multi-line strings
+    code = dedent(code)
+
     mod = ast.parse(code)
     if isinstance(mod.body[-1], ast.Expr):
         expr = ast.Expression(mod.body[-1].value)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,17 +102,11 @@ class SeleniumWrapper:
         self.driver.execute_script("window.logs = []")
 
     def run(self, code):
-        if isinstance(code, str) and code.startswith('\n'):
-            # we have a multiline string, fix indentation
-            code = textwrap.dedent(code)
         return self.run_js(
             'return pyodide.runPython({!r})'.format(code))
 
     def run_async(self, code):
         from selenium.common.exceptions import TimeoutException
-        if isinstance(code, str) and code.startswith('\n'):
-            # we have a multiline string, fix indentation
-            code = textwrap.dedent(code)
         self.run_js(
             """
             window.done = false;


### PR DESCRIPTION
In Python tests, we have been using multi-line code strings as more readable than concatentating code line by line. I would like to do the same thing from JS, where ES6 appears to support it, e.g.,
```html
<script>
      languagePluginLoader.then(() => {
          pyodide.loadPackage('numpy').then(() => {
              pyodide.runPython(`
                 import numpy as np
                 x = np.ones(10, 10).sum()
              `);
              let x = pyodide.pyimport('x');
              // do something with x 
          });
      });
</script>
```

The issue with this is that `runPython` gets a code strings that is overindented which results in a syntax error. Running `textwrap.dedent` in `pyodide.py:eval_code` 
is a possible solution. Since we are doing AST parsing there already, I imagine it shouldn't add much overhead.

By removing dedenting in `test/conftest.py` this gets tested directly by existing tests.

IMO this should be more readable than e.g.
```js
              pyodide.runPython(
                 "import numpy as np\n" +
                 "x = np.ones(10, 10).sum()"
              );
```
particularly for longer code snippets that include Python indentation.

