### PR TITLE
removed iodide.evalQueue from languagePluginLoader

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -187,10 +187,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
                                '_importlib.invalidate_caches()\n');
     });
 
-    if (window.iodide !== undefined) {
-      window.iodide.evalQueue.await([ promise ]);
-    }
-
     return promise;
   };
 


### PR DESCRIPTION
First-time contributor to pyodide, so please let me know if there's anything else I can do to get this landed!

Iodide will be deprecating the `iodide.evalQueue` api, since we've moved away from the cell paradigm entirely. As a prerequisite to deprecation we'll need to remove usage elsewhere. As of right now, `iodide.evalQueue.await` (used in `pyodide.js`) defaults to `Promise.all`, so it effectively doesn't do anything anyway.