### PR TITLE
Add a proxy to get global objects from Python

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -98,6 +98,14 @@ For example, to access the `foo` Python object from Javascript:
 |           |         | types, a Proxy object to the Python   |
 |           |         | object is returned.                   |
 
+### pyodide.globals
+
+An object whose attributes are members of the Python global namespace. This is a
+more convenient alternative to `pyodide.pyimport`.
+
+For example, to access the `foo` Python object from Javascript:
+
+   `pyodide.globals.foo`
 
 ### pyodide.repr(obj)
 
@@ -178,7 +186,7 @@ pyodide.runPythonAsync(code, messageCallback)
 
 Returns the pyodide version.
 
-It can be either the exact release version (e.g. `0.1.0`), or 
+It can be either the exact release version (e.g. `0.1.0`), or
 the latest release version followed by the number of commits since, and
 the git hash of the current commit (e.g. `0.1.0-1-bd84646`).
 
@@ -191,4 +199,3 @@ None
 | name      | type   | description            |
 |-----------|--------|------------------------|
 | *version* | String | Pyodide version string |
-

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -235,6 +235,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   let PUBLIC_API = [
     'loadPackage',
     'loadedPackages',
+    'py',
     'pyimport',
     'repr',
     'runPython',
@@ -277,6 +278,8 @@ var languagePluginLoader = new Promise((resolve, reject) => {
           .then((response) => response.json())
           .then((json) => {
             fixRecursionLimit(window.pyodide);
+            window.pyodide.py =
+                window.pyodide.runPython('import sys\nsys.modules["__main__"]');
             window.pyodide = makePublicAPI(window.pyodide, PUBLIC_API);
             window.pyodide._module.packages = json;
             resolve();

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -233,9 +233,9 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   ////////////////////////////////////////////////////////////
   // Rearrange namespace for public API
   let PUBLIC_API = [
+    'globals',
     'loadPackage',
     'loadedPackages',
-    'py',
     'pyimport',
     'repr',
     'runPython',
@@ -278,7 +278,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
           .then((response) => response.json())
           .then((json) => {
             fixRecursionLimit(window.pyodide);
-            window.pyodide.py =
+            window.pyodide.globals =
                 window.pyodide.runPython('import sys\nsys.modules["__main__"]');
             window.pyodide = makePublicAPI(window.pyodide, PUBLIC_API);
             window.pyodide._module.packages = json;

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -609,4 +609,4 @@ def test_py(selenium_standalone):
         """
     )
 
-    assert selenium_standalone.run_js('return pyodide.py.func()') == 42
+    assert selenium_standalone.run_js('return pyodide.globals.func()') == 42

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -599,3 +599,14 @@ def test_runpythonasync_exception_after_import(selenium_standalone):
         assert "ZeroDivisionError" in str(e)
     else:
         assert False
+
+
+def test_py(selenium_standalone):
+    selenium_standalone.run(
+        """
+        def func():
+            return 42
+        """
+    )
+
+    assert selenium_standalone.run_js('return pyodide.py.func()') == 42


### PR DESCRIPTION
This adds a new way to access Python objects from Javascript that isn't quite as cumbersome as `pyodide.pyimport`.  Instead of

```
pyodide.pyimport('foo')
```

you can do

```
pyodide.py.foo
```

Ideally, this would just be `py.foo`, but I'm wary of polluting the global namespace beyond the single `pyodide` we have now.  The end user can always do `var py = pyodide.py`...