### PR TITLE
Fix #283: Handle function pointers in dylib with signatures not in main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v11-
+          - v1-emsdk-{{ checksum "emsdk/Makefile" }}-v12-
 
       - run:
           name: build
@@ -36,7 +36,7 @@ jobs:
           paths:
             - ./emsdk/emsdk
             - ~/.ccache
-          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v11-{{ .BuildNum }}
+          key: v1-emsdk-{{ checksum "emsdk/Makefile" }}-v12-{{ .BuildNum }}
 
       - persist_to_workspace:
           root: .

--- a/emsdk/patches/dynCall_so.patch
+++ b/emsdk/patches/dynCall_so.patch
@@ -1,0 +1,46 @@
+diff --git a/emsdk/emscripten/tag-1.38.12/src/library.js b/emsdk/emscripten/tag-1.38.12/src/library.js
+index 82537bb3e..8e2e43128 100644
+--- a/emsdk/emscripten/tag-1.38.12/src/library.js
++++ b/emsdk/emscripten/tag-1.38.12/src/library.js
+@@ -1781,6 +1781,12 @@ LibraryManager.library = {
+         }
+       }
+ 
++      for (var sym in lib_module) {
++        if (sym.startsWith('dynCall_') && !Module.hasOwnProperty(sym)) {
++          Module[sym] = lib_module[sym];
++        }
++      }
++
+       // Not all browsers support Object.keys().
+       var handle = 1;
+       for (var key in DLFCN.loadedLibs) {
+diff --git a/emsdk/emscripten/tag-1.38.12/src/support.js b/emsdk/emscripten/tag-1.38.12/src/support.js
+index cff68fbe2..3a4e51dca 100644
+--- a/emsdk/emscripten/tag-1.38.12/src/support.js
++++ b/emsdk/emscripten/tag-1.38.12/src/support.js
+@@ -211,9 +211,21 @@ function loadWebAssemblyModule(binary, loadAsync) {
+       if (prop.startsWith('invoke_')) {
+         // A missing invoke, i.e., an invoke for a function type
+         // present in the dynamic library but not in the main JS,
+-        // and the dynamic library cannot provide JS for it. Use
+-        // the generic "X" invoke for it.
+-        return env[prop] = invoke_X;
++        // and the dynamic library cannot provide JS for it. Generate
++        // a closure for it.
++        var dynCallName = 'dynCall_' + prop.slice(7);
++        env[prop] = function() {
++          var sp = stackSave();
++          try {
++            var args = Array.prototype.slice.call(arguments);
++            return Module[dynCallName].apply(null, args);
++          } catch(e) {
++            stackRestore(sp);
++            if (typeof e !== 'number' && e !== 'longjmp') throw e;
++            Module["setThrew"](1, 0);
++          }
++        }
++        return env[prop];
+       }
+       // if not a global, then a function - call it indirectly
+       return env[prop] = function() {

--- a/src/main.c
+++ b/src/main.c
@@ -10,32 +10,6 @@
 #include "python2js.h"
 #include "runpython.h"
 
-/*
-  TODO: This is a workaround for a weird emscripten compiler bug. The
-  matplotlib/_qhull.so extension makes function pointer calls with these
-  signatures, but since nothing with that signature exists in the MAIN_MODULE,
-  it can't link the SIDE_MODULE. Creating these dummy functions here seems to
-  work around the problem.
-*/
-
-void
-__foo(double x)
-{}
-
-void
-__foo2(double x, double y)
-{}
-
-void
-__foo3(double x, double y, double z)
-{}
-
-void
-__foo4(int a, double b, int c, int d, int e)
-{}
-
-/* END WORKAROUND */
-
 int
 main(int argc, char** argv)
 {

--- a/test/test_scipy.py
+++ b/test/test_scipy.py
@@ -1,0 +1,4 @@
+def test_brentq(selenium_standalone):
+    selenium_standalone.load_package("scipy")
+    selenium_standalone.run("from scipy.optimize import brentq")
+    selenium_standalone.run("brentq(lambda x: x, -1, 1)")


### PR DESCRIPTION
There seems to be an issue when emscripten when a `SIDE_MODULE` makes a function pointer call with a signature that doesn't exist in the `MAIN_MODULE`.

In this case, the function pointer call ends up calling the Javascript function `invoke_X`, which then fails with 

```
TypeError: cannot pass i64 to or from JS
invoke_X()@https://extremely-alpha.iodide.app/pyodide-0.4.0/pyodide.asm.js:8:690227
```

The workaround is to instead generate a closure for `invoke_...` that calls `dynCall_...` instead, since the `dynCall` function does actually exist in the `SIDE_MODULE`.

This also removes the need for the existing hack to add a few function signatures to the `MAIN_MODULE` (which obviously doesn't scale because we can't anticipate what all of those signatures may be).

Cc @navytux, @rth, @felixlawrence