### PR TITLE
Add ``Humor Sans`` font for ``xkcd`` plots.

### DIFF
--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -25,6 +25,7 @@ build:
   cflags: -s USE_FREETYPE=1 -s USE_LIBPNG=1 -s USE_ZLIB=1
   ldflags: ../../../../emsdk/emsdk/.emscripten_cache/asmjs/libpng.bc
   post: |
+    wget -O $SITEPACKAGES/matplotlib/mpl-data/fonts/ttf/Humor-Sans.ttf http://antiyawn.com/uploads/Humor-Sans-1.0.ttf
     rm -rf $SITEPACKAGES/matplotlib/backends/qt_editor
     rm -rf $SITEPACKAGES/matplotlib/backends/web_backend
     rm -rf $SITEPACKAGES/sphinxext

--- a/packages/matplotlib/src/fontList.json
+++ b/packages/matplotlib/src/fontList.json
@@ -40,7 +40,8 @@
     "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/DejaVuSans-Oblique.ttf",
     "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/DejaVuSansDisplay.ttf",
     "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/DejaVuSerif.ttf",
-    "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/STIXSizOneSymBol.ttf"
+    "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/STIXSizOneSymBol.ttf",
+    "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/Humor-Sans.ttf"
   ],
   "defaultFamily": {
     "ttf": "DejaVu Sans",
@@ -427,6 +428,16 @@
       "style": "normal",
       "variant": "normal",
       "weight": "bold",
+      "stretch": "normal",
+      "size": "scalable",
+      "_class": "FontEntry"
+    },
+    {
+      "fname": "/lib/python3.7/site-packages/matplotlib/mpl-data/fonts/ttf/Humor-Sans.ttf",
+      "name": "Humor Sans",
+      "style": "normal",
+      "variant": "normal",
+      "weight": 400,
       "stretch": "normal",
       "size": "scalable",
       "_class": "FontEntry"


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/35

The downloading and renaming of the ``Humor-Sans-1.0.ttf`` asset is done in the ``post`` entry of the ``build`` section. This is done due to the following reasons:

- Using the ``script`` entry as suggested by @rth would mean also modifying the ``compile`` function of the ``buildpkg.py`` script which is extra work.

- The environment variable ``SITEPACKAGES`` can be directly used inside the ``post`` entry to relocate the asset to its appropriate location.

Screenshot that it works:

<img width="609" alt="screenshot 2019-01-05 at 3 04 08 am" src="https://user-images.githubusercontent.com/20173739/50712217-ad4aa580-1096-11e9-9eb9-30886d4eb794.png">