### PR TITLE
Explicitly use python3 for pyodide_build

### DIFF
--- a/bin/pyodide
+++ b/bin/pyodide
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # get the absolute path to the root directory
-ROOTDIR=$(python -c 'import pathlib, sys; \
+ROOTDIR=$(python3 -c 'import pathlib, sys; \
                      print(pathlib.Path(sys.argv[1]).resolve().parents[1])' \
           "${BASH_SOURCE[0]}")
 
 export PYTHONPATH="${PYTHONPATH}:${ROOTDIR}"
-python -m pyodide_build "$@"
+python3 -m pyodide_build "$@"


### PR DESCRIPTION
Had an [issue](https://github.com/iodide-project/pyodide/issues/40#issuecomment-452702087) building pyodide on ubuntu 18.04.
Using `python3` explicitly for python makes sure that all the python scripts are invoked with proper python version.

If we (maybe in future, where only `python3` is shipped as `python`) need to check if there is a command `python3` available on host machine, we can add a checker like [this](https://github.com/iodide-project/pyodide/issues/40#issuecomment-452702087). I'm however not adding this in this PR as suggested by @mdboom 