### PR TITLE
Make bin/pyodide display help rather than crash

### DIFF
--- a/pyodide_build/__main__.py
+++ b/pyodide_build/__main__.py
@@ -19,8 +19,11 @@ def main():
         parser.set_defaults(func=module.main)
 
     args = main_parser.parse_args()
-    # run the selected action
-    args.func(args)
+    if hasattr(args, 'func'):
+        # run the selected action
+        args.func(args)
+    else:
+        main_parser.print_help()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a simple fix.  If you run `bin/pyodide`, you get a traceback rather than displaying usage help as one might expect.