### PR TITLE
Fix preloading on Chrome

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -59,7 +59,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
           if (Module['preloadedWasm'][path] === undefined) {
             promise = promise
               .then(() => Module['loadWebAssemblyModule'](
-                FS.readFile(path), true))
+                FS.readFile(path), {loadAsync: true}))
               .then((module) => {
                 Module['preloadedWasm'][path] = module;
               });


### PR DESCRIPTION
This was inadvertently broken by the recent upgrade of the emscripten version, which changed the API for asynchronously loading WebAssembly modules.