### PR TITLE
fix iodide-project/iodide#1423: Don't crash if there is no Python code

### DIFF
--- a/src/pyodide.py
+++ b/src/pyodide.py
@@ -29,6 +29,9 @@ def eval_code(code, ns):
     code = dedent(code)
 
     mod = ast.parse(code)
+    if len(mod.body) == 0:
+        return None
+
     if isinstance(mod.body[-1], ast.Expr):
         expr = ast.Expression(mod.body[-1].value)
         del mod.body[-1]

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -645,3 +645,8 @@ def test_py(selenium_standalone):
     )
 
     assert selenium_standalone.run_js('return pyodide.globals.func()') == 42
+
+
+def test_eval_nothing(selenium):
+    assert selenium.run('# comment') is None
+    assert selenium.run('') is None


### PR DESCRIPTION
If there's no executable code, we should just return `None`, rather than assuming there is executable code.