### PR TITLE
Faster js2python string conversion

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -60,7 +60,7 @@ EM_JS(int, hiwire_string_ucs4, (int ptr, int len), {
   var jsstr = "";
   var idx = ptr / 4;
   for (var i = 0; i < len; ++i) {
-    jsstr += String.fromCharCode(Module.HEAPU32[idx + i]);
+    jsstr += String.fromCodePoint(Module.HEAPU32[idx + i]);
   }
   return Module.hiwire_new_value(jsstr);
 });

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -35,6 +35,8 @@ def test_python2js(selenium):
     assert selenium.run_js(
         'return pyodide.runPython("\'碘化物\'") === "碘化物"')
     assert selenium.run_js(
+        'return pyodide.runPython("\'🐍\'") === "🐍"')
+    assert selenium.run_js(
         'let x = pyodide.runPython("b\'bytes\'");\n'
         'return (x instanceof window.Uint8ClampedArray) && '
         '(x.length === 5) && '
@@ -156,7 +158,9 @@ def test_pythonexc2js(selenium):
 def test_js2python(selenium):
     selenium.run_js(
         """
-        window.jsstring = "碘化物";
+        window.jsstring_ucs1 = "pyodidé";
+        window.jsstring_ucs2 = "碘化物";
+        window.jsstring_ucs4 = "🐍";
         window.jsnumber0 = 42;
         window.jsnumber1 = 42.5;
         window.jsundefined = undefined;
@@ -170,8 +174,14 @@ def test_js2python(selenium):
         """
     )
     assert selenium.run(
-        'from js import jsstring\n'
-        'jsstring == "碘化物"')
+        'from js import jsstring_ucs1\n'
+        'jsstring_ucs1 == "pyodidé"')
+    assert selenium.run(
+        'from js import jsstring_ucs2\n'
+        'jsstring_ucs2 == "碘化物"')
+    assert selenium.run(
+        'from js import jsstring_ucs4\n'
+        'jsstring_ucs4 == "🐍"')
     assert selenium.run(
         'from js import jsnumber0\n'
         'jsnumber0 == 42')


### PR DESCRIPTION
As discovered in #301 (thanks, @jstafford), conversion of strings from Javascript to Python involves 3 copies:

- The Javascript string is converted to a TypedArray containing UTF8
- This array is copied to a memory array in the wasm heap
- Python copies and decodes the UTF8 into one of its native formats (ucs1, ucs2 or ucs4)

This changes the conversion so there is a single copy from Javascript directly to a pre-allocated Python string buffer.  This still requires 2 passes through the string to determine the output bytes-per-character, but that seems like an unavoidable side-effect of the design of Python's strings.