### PR TITLE
Fixup symlinks

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -40,7 +40,6 @@ from pyodide_build import common
 
 
 ROOTDIR = common.ROOTDIR
-symlinks = set(['cc', 'c++', 'ld', 'ar', 'gcc'])
 symlinks = set(['cc', 'c++', 'ld', 'ar', 'gcc', 'gfortran'])
 
 


### PR DESCRIPTION
This variable ended up in the code twice, probably due to a merge error.  This just cleans that up.