### PR TITLE
Align the matplotlib Figure and Buttons Toolbar to the center.

### DIFF
--- a/packages/matplotlib/src/wasm_backend.py
+++ b/packages/matplotlib/src/wasm_backend.py
@@ -132,7 +132,10 @@ class FigureCanvasWasm(backend_agg.FigureCanvasAgg):
         width *= self._ratio
         height *= self._ratio
         div = self.create_root_element()
-        div.setAttribute('style', 'width: {}px'.format(width / self._ratio))
+        div.setAttribute(
+            'style', 'margin: 0 auto; text-align: center;' +
+            'width: {}px'.format(width / self._ratio)
+        )
         div.id = self._id
 
         # The top bar


### PR DESCRIPTION
- Made the ``matplotlib figure`` align to the center of the body of the text.
- The buttons toolbar is now aligned to the center of the plot.
- Fixes https://github.com/iodide-project/pyodide/issues/304

Although I haven't tested it locally due to the unavailability of ``https://iodide.io/dist/iodide.pyodide-20180623.js``, The changes when done in inspector show the resulting output:

<img width="814" alt="screenshot 2019-02-02 at 3 54 36 pm" src="https://user-images.githubusercontent.com/20173739/52163068-e3fdf500-2702-11e9-9511-e37731016ca6.png">

As suggested by @teonbrooks, The figure now aligns to the centre of the body text too.

Please take a look @mdboom @hamilton  