### PR TITLE
Fix conversion from jsproxy to dict

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -189,7 +189,11 @@ EM_JS(int, hiwire_get_global, (int idname), {
 EM_JS(int, hiwire_get_member_string, (int idobj, int idkey), {
   var jsobj = Module.hiwire_get_value(idobj);
   var jskey = UTF8ToString(idkey);
-  return Module.hiwire_new_value(jsobj[jskey]);
+  if (jskey in jsobj) {
+    return Module.hiwire_new_value(jsobj[jskey]);
+  } else {
+    return -1;
+  }
 });
 
 EM_JS(void, hiwire_set_member_string, (int idobj, int ptrkey, int idval), {
@@ -217,7 +221,11 @@ EM_JS(void, hiwire_set_member_int, (int idobj, int idx, int idval), {
 EM_JS(int, hiwire_get_member_obj, (int idobj, int ididx), {
   var jsobj = Module.hiwire_get_value(idobj);
   var jsidx = Module.hiwire_get_value(ididx);
-  return Module.hiwire_new_value(jsobj[jsidx]);
+  if (jsidx in jsobj) {
+    return Module.hiwire_new_value(jsobj[jsidx]);
+  } else {
+    return -1;
+  }
 });
 
 EM_JS(void, hiwire_set_member_obj, (int idobj, int ididx, int idval), {
@@ -306,10 +314,14 @@ EM_JS(int, hiwire_get_iterator, (int idobj), {
   }
 
   var jsobj = Module.hiwire_get_value(idobj);
-  if (typeof jsobj.next ===  'function') {
+  if (typeof jsobj.next === 'function') {
     return Module.hiwire_new_value(jsobj);
   } else if (typeof jsobj[Symbol.iterator] === 'function') {
-    return Module.hiwire_new_value(jsobj[Symbol.iterator]())
+    return Module.hiwire_new_value(jsobj[Symbol.iterator]());
+  } else {
+    return Module.hiwire_new_value(
+      Object.entries(jsobj)[Symbol.iterator]()
+    );
   }
   return -1;
   // clang-format on

--- a/src/jsproxy.c
+++ b/src/jsproxy.c
@@ -62,6 +62,11 @@ JsProxy_GetAttr(PyObject* o, PyObject* attr_name)
   int idresult = hiwire_get_member_string(self->js, (int)key);
   Py_DECREF(str);
 
+  if (idresult == -1) {
+    PyErr_SetString(PyExc_AttributeError, key);
+    return NULL;
+  }
+
   if (hiwire_is_function(idresult)) {
     hiwire_decref(idresult);
     return JsBoundMethod_cnew(self->js, key);
@@ -250,6 +255,10 @@ JsProxy_subscript(PyObject* o, PyObject* pyidx)
   int ididx = python2js(pyidx);
   int idresult = hiwire_get_member_obj(self->js, ididx);
   hiwire_decref(ididx);
+  if (idresult == -1) {
+    PyErr_SetObject(PyExc_KeyError, pyidx);
+    return NULL;
+  }
   PyObject* pyresult = js2python(idresult);
   hiwire_decref(idresult);
   return pyresult;

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -368,7 +368,7 @@ def test_jsproxy(selenium):
         """
         from js import TEST
         del TEST.y
-        TEST.y""") is None
+        hasattr(TEST, 'y')""") is False
     selenium.run_js(
         """
         class Point {
@@ -382,7 +382,7 @@ def test_jsproxy(selenium):
         """
         from js import TEST
         del TEST['y']
-        TEST['y']""") is None
+        'y' in TEST""") is False
     assert selenium.run(
         """
         from js import TEST
@@ -393,6 +393,16 @@ def test_jsproxy(selenium):
         from js import TEST
         TEST != 'foo'
         """)
+    selenium.run_js(
+        """
+        window.TEST = {foo: 'bar', baz: 'bap'}
+        """)
+    assert selenium.run(
+        """
+        from js import TEST
+        dict(TEST) == {'foo': 'bar', 'baz': 'bap'}
+        """
+    ) is True
 
 
 def test_jsproxy_iter(selenium):


### PR DESCRIPTION
This makes Javascript objects iterable such that converting them to a Python dictionary using `dict()` works.

We can't just treat Javascript objects as dicts automatically since they may have methods etc. that aren't supported by dictionaries, so the explicit `dict()` is still required if you want to use a Javascript object as a dictionary.  (I don't think there's any good way to "guess" there).