### PR TITLE
Fix #316: Add convenience function for converting from nested Arrays

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -42,6 +42,21 @@ some preprocessing on the Python code first.
 
 Either the resulting object or `None`.
 
+### pyodide.as_nested_list(obj)
+
+Converts Javascript nested arrays to Python nested lists. This conversion can not
+be performed automatically, because Javascript Arrays and Objects can be combined
+in ways that are ambiguous.
+
+*Parameters*
+
+| name   | type  | description           |
+|--------|-------|-----------------------|
+| *obj*  | JS Object | The object to convert |
+
+*Returns*
+
+The object as nested Python lists.
 
 ## Javascript API
 

--- a/src/pyodide.py
+++ b/src/pyodide.py
@@ -67,4 +67,16 @@ def find_imports(code):
     return list(imports)
 
 
-__all__ = ['open_url', 'eval_code', 'find_imports']
+def as_nested_list(obj):
+    """
+    Assumes a Javascript object is made of (possibly nested) arrays and
+    converts them to nested Python lists.
+    """
+    try:
+        it = iter(obj)
+        return [as_nested_list(x) for x in it]
+    except TypeError:
+        return obj
+
+
+__all__ = ['open_url', 'eval_code', 'find_imports', 'as_nested_list']


### PR DESCRIPTION
Since we can't automatically determine that a Javascript object might be made of nested arrays, and Numpy will also have this difficulty, we need a convenience function to declare what we mean to do with this kind of object.

Cc: @jstafford 