### PR TITLE
Build the _decimal C module.

### DIFF
--- a/benchmark/benchmarks/large_decimal_list.py
+++ b/benchmark/benchmarks/large_decimal_list.py
@@ -1,0 +1,6 @@
+# setup: from decimal import Decimal ; A = [Decimal('2.1') for i in range(1000)] ; B = [Decimal('3.2') for i in range(1000)]  # noqa
+# run: large_decimal_list(A, B)
+
+
+def large_decimal_list(A, B):
+    return [a * b for a, b in zip(A, B)]

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -49,3 +49,5 @@ _codecs_kr cjkcodecs/_codecs_kr.c
 _codecs_tw cjkcodecs/_codecs_tw.c
 
 _lsprof _lsprof.c rotatingtree.c
+
+_decimal _decimal/_decimal.c _decimal/libmpdec/basearith.c _decimal/libmpdec/constants.c _decimal/libmpdec/context.c _decimal/libmpdec/convolute.c _decimal/libmpdec/crt.c _decimal/libmpdec/difradix2.c _decimal/libmpdec/fnt.c _decimal/libmpdec/fourstep.c _decimal/libmpdec/io.c _decimal/libmpdec/memory.c _decimal/libmpdec/mpdecimal.c _decimal/libmpdec/numbertheory.c _decimal/libmpdec/sixstep.c _decimal/libmpdec/transpose.c -I$(srcdir)/Modules/_decimal/libmpdec

--- a/cpython/pyconfig.undefs.h
+++ b/cpython/pyconfig.undefs.h
@@ -29,3 +29,6 @@
 
 /* Unsupported functionality */
 #undef HAVE_PTHREAD_H
+
+#define CONFIG_32
+#define ANSI


### PR DESCRIPTION
Fixes #315.  This makes the long_decimal_list benchmark only 6x slower than native.

Cc: @jstafford 