### PR TITLE
Fix #327: Add sympy support

### DIFF
--- a/packages/mpmath/meta.yaml
+++ b/packages/mpmath/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: mpmath
+  version: 1.1.0
+
+source:
+  sha256: fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6
+  url: 'https://files.pythonhosted.org/packages/ca/63/3384ebb3b51af9610086b23ea976e6d27d6d97bf140a76a365bd77a3eb32/mpmath-1.1.0.tar.gz'
+
+test:
+  imports:
+    - mpmath

--- a/packages/sympy/meta.yaml
+++ b/packages/sympy/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: sympy
+  version: '1.3'
+
+source:
+  sha256: e1319b556207a3758a0efebae14e5e52c648fc1db8975953b05fff12b6871b54
+  url: 'https://files.pythonhosted.org/packages/dd/f6/ed485ff22efdd7b371d0dbbf6d77ad61c3b3b7e0815a83c89cbb38ce35de/sympy-1.3.tar.gz'
+
+requirements:
+  run:
+    - mpmath
+
+test:
+  imports:
+    - sympy


### PR DESCRIPTION
This adds sympy.

Automatic rendering isn't working yet -- we'll need to set up our own hooks to make that work in Iodide, however I would suggest merging this anyway so we can iterate on getting the rendering to work in subsequent PRs.

Cc: @Kreijstal 