### PR TITLE
Automatically rebuild packages if any patches or extra files change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ $(CLAPACK): $(CPYTHONLIB)
 	make -C CLAPACK
 
 
-build/packages.json: FORCE
+build/packages.json: $(CLAPACK) FORCE
 	make -C packages
 
 emsdk/emsdk/.complete:

--- a/Makefile
+++ b/Makefile
@@ -221,8 +221,10 @@ $(CLAPACK): $(CPYTHONLIB)
 	make -C CLAPACK
 
 
-build/packages.json: $(CPYTHONLIB) $(CLAPACK)
+build/packages.json: FORCE
 	make -C packages
 
 emsdk/emsdk/.complete:
 	make -C emsdk
+
+FORCE:

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -19,9 +19,7 @@ def build_package(pkgname, dependencies, packagesdir, outputdir, args):
     # Make sure all of the package's requirements are built first
     for req in reqs:
         build_package(req, dependencies, packagesdir, outputdir, args)
-    if not (packagesdir / pkgname / 'build' / '.packaged').is_file():
-        print("BUILDING PACKAGE: " + pkgname)
-        buildpkg.build_package(packagesdir / pkgname / 'meta.yaml', args)
+    buildpkg.build_package(packagesdir / pkgname / 'meta.yaml', args)
     shutil.copyfile(
         packagesdir / pkgname / 'build' / (pkgname + '.data'),
         outputdir / (pkgname + '.data'))


### PR DESCRIPTION
As reported on gitter by @QiuZhiFeng, editing the `wasm_backend.py` file in matplotlib doesn't cause the matplotlib package to be rebuilt.

This looks at all of the patches and extra files defined in a package to see if the package needs to be rebuilt.