### PR TITLE
Allow configuring run_docker ports using env vars

### DIFF
--- a/run_docker
+++ b/run_docker
@@ -1,5 +1,13 @@
 #!/bin/sh
-DOCKER_PORT=8000
-SYSTEM_PORT=8000
 
-docker run -p $SYSTEM_PORT:$DOCKER_PORT --rm -v $PWD:/src --user root -e NB_UID=$UID -e NB_GID=$GID -it iodide/pyodide-env:0.3.1 /bin/bash
+PYODIDE_DOCKER_PORT=${PYODIDE_DOCKER_PORT:-"8000"}
+PYODIDE_SYSTEM_PORT=${PYODIDE_SYSTEM_PORT:-"8000"}
+PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE:-"iodide/pyodide-env:0.3.1"}
+
+exec docker run \
+    -p $PYODIDE_SYSTEM_PORT:$PYODIDE_DOCKER_PORT \
+    -it --rm \
+    -v $PWD:/src \
+    --user root -e NB_UID=$UID -e NB_GID=$GID \
+    ${PYODIDE_DOCKER_IMAGE} \
+    /bin/bash


### PR DESCRIPTION
This allows changing various `run_docker` settings using env vars. The
primary one that I wanted was the ability to easily set the system port
used so that I could run two pyodide containers.

Before when running a second instance of `./run_docker`:

```
$ ./run_docker
docker: Error response from daemon: driver failed programming external connectivity on endpoint quirky_banach (45f5dd12606ac5d732a311ef3f3c378e359bbbd406a1c65915a300ec413eaf25): Bind for 0.0.0.0:8000 failed: port is already allocated.
```

With this PR:

```
$ PYODIDE_SYSTEM_PORT=8001 ./run_docker
root@29308e720856:/src#
```

I also broke the `docker run` command on to multiple lines (which I find
more readable; hopefully others agree) and added an `exec` to the
command, so the shell process on the host doesn't have to hang around
waiting for the container to exit.