### PR TITLE
Add NLTK: Natural Language Toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- The built-in `sqlite3** module of Python is now enabled.
+
+- New package: `nltk`
+
 ## Version 0.13.0
 
 - Tagged versions of Pyodide are now deployed to Netlify.

--- a/packages/nltk/meta.yaml
+++ b/packages/nltk/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: nltk
+  version: '3.4'
+source:
+  sha256: 286f6797204ffdb52525a1d21ec0a221ec68b8e3fa4f2d25f412ac8e63c70e8d
+  url: https://files.pythonhosted.org/packages/6f/ed/9c755d357d33bc1931e157f537721efb5b88d2c583fe593cc09603076cc3/nltk-3.4.zip
+test:
+  imports:
+  - nltk

--- a/packages/nltk/test_nltk.py
+++ b/packages/nltk/test_nltk.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+def test_nltk_edit_distance(selenium):
+    selenium.load_package('nltk')
+    selenium.run('import nltk')
+    edit_distance = selenium.run("nltk.edit_distance('foo', 'food')")
+    assert edit_distance == 1
+
+
+def test_nltk_jaccard_distance(selenium):
+    selenium.load_package('nltk')
+    selenium.run('import nltk')
+    jaccard_distance = selenium.run("""
+        nltk.jaccard_distance(set('mapping'), set('mappings'))
+    """)
+    assert jaccard_distance == pytest.approx(0.1428571)
+
+
+def test_nltk_ngrams(selenium):
+    selenium.load_package('nltk')
+    selenium.run('import nltk')
+    ngrams = selenium.run("list(nltk.ngrams('master', n=3))")
+    assert len(ngrams) == 4
+    assert ngrams[0] == ['m', 'a', 's']
+    assert ngrams[1] == ['a', 's', 't']
+    assert ngrams[2] == ['s', 't', 'e']
+    assert ngrams[3] == ['t', 'e', 'r']


### PR DESCRIPTION
[NLTK](https://www.nltk.org/) depends on sqlite3, so this can be merged after https://github.com/iodide-project/pyodide/pull/352

Cc: @madhur-tandon 