### PR TITLE
ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 __pycache__
 geckodriver.log
 firefox/
+.vscode
 
 build
 downloads


### PR DESCRIPTION
VSCode generates the `.vscode` folder which has to be ignored.