### PR TITLE
Add bzip2 and mmap modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ LDFLAGS=\
 	-s USE_LIBPNG=1 \
 	-std=c++14 \
   -L$(wildcard $(CPYTHONROOT)/build/sqlite*/.libs) -lsqlite3 \
+  $(wildcard $(CPYTHONROOT)/build/bzip2*/libbz2.a) \
   -lstdc++ \
   --memory-init-file 0 \
   -s "BINARYEN_TRAP_MODE='clamp'" \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -24,6 +24,10 @@ SQLITETARBALL=$(ROOT)/downloads/sqlite-autoconf-3270200.tar.gz
 SQLITEBUILD=$(ROOT)/build/sqlite-autoconf-3270200
 SQLITEURL=https://www.sqlite.org/2019/sqlite-autoconf-3270200.tar.gz
 
+BZIP2TARBALL=$(ROOT)/downloads/bzip2-1.0.2.tar.gz
+BZIP2BUILD=$(ROOT)/build/bzip2-1.0.2
+BZIP2URL=ftp://sources.redhat.com/pub/bzip2/v102/bzip2-1.0.2.tar.gz
+
 
 all: $(INSTALL)/lib/$(LIB)
 
@@ -62,6 +66,11 @@ $(SQLITETARBALL):
 	wget -q -O $@ $(SQLITEURL)
 
 
+$(BZIP2TARBALL):
+	[ -d $(ROOT)/downloads ] || mkdir $(ROOT)/downloads
+	wget -q -O $@ $(BZIP2URL)
+
+
 $(HOSTPYTHON) $(HOSTPGEN): $(TARBALL)
 	mkdir -p $(HOSTINSTALL)
 	[ -d $(HOSTBUILD) ] || tar -C $(HOSTINSTALL) -xf $(TARBALL)
@@ -98,21 +107,30 @@ $(SQLITEBUILD)/libsqlite3.la: $(SQLITETARBALL)
 	)
 
 
-$(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.patched $(SQLITEBUILD)/libsqlite3.la
+$(BZIP2BUILD)/libbz2.a: $(BZIP2TARBALL)
+	[ -d $(ROOT)/build ] || (mkdir $(ROOT)/build)
+	tar -C $(ROOT)/build/ -xf $(BZIP2TARBALL)
+	( \
+		cd $(BZIP2BUILD); \
+		emmake make CC=emcc CFLAGS="-Wall -Winline -O2 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64" AR=emar RANLIB=emranlib libbz2.a; \
+	)
+
+
+$(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.patched $(SQLITEBUILD)/libsqlite3.la $(BZIP2BUILD)/libbz2.a
 	cp config.site $(BUILD)/
 	( \
 		cd $(BUILD); \
-		CONFIG_SITE=./config.site READELF=true LD_RUN_PATH=$(SQLITEBUILD) emconfigure \
+		CONFIG_SITE=./config.site READELF=true LD_RUN_PATH="$(SQLITEBUILD):$(BZIP2BUILD)" emconfigure \
 		  ./configure \
-			  CPPFLAGS="-I$(SQLITEBUILD)" \
-				LDFLAGS="-L$(SQLITEBUILD)" \
-				--without-pymalloc \
-				--disable-shared \
-				--disable-ipv6 \
-				--without-gcc \
-				--host=asmjs-unknown-emscripten \
-				--build=$(shell $(BUILD)/config.guess) \
-				--prefix=$(INSTALL) ; \
+			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD)" \
+			  LDFLAGS="-L$(SQLITEBUILD) -L$(BZIP2BUILD)" \
+			  --without-pymalloc \
+			  --disable-shared \
+			  --disable-ipv6 \
+			  --without-gcc \
+			  --host=asmjs-unknown-emscripten \
+			  --build=$(shell $(BUILD)/config.guess) \
+			  --prefix=$(INSTALL) ; \
 	)
 
 

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -37,6 +37,7 @@ _blake2 _blake2/blake2module.c _blake2/blake2b_impl.c ../../host/Python-3.7.0/Mo
 
 _sqlite3 _sqlite/cache.c _sqlite/connection.c _sqlite/cursor.c _sqlite/microprotocols.c _sqlite/module.c _sqlite/prepare_protocol.c _sqlite/row.c _sqlite/statement.c _sqlite/util.c -I$(SQLITEBUILD) -L$(SQLITEBUILD) -lsqlite3
 _crypt _cryptmodule.c
+_bz2 _bz2module.c -I$(BZIP2BUILD) -L$(BZIP2BUILD) -lbz2
 
 _queue _queuemodule.c
 

--- a/test/python_tests.txt
+++ b/test/python_tests.txt
@@ -81,7 +81,7 @@ test_buffer
 test_bufio
 test_builtin  floating point
 test_bytes
-test_bz2
+test_bz2 threading
 test_c_locale_coercion
 test_calendar
 test_call

--- a/test/test_bz2.py
+++ b/test/test_bz2.py
@@ -1,0 +1,10 @@
+def test_bz2(selenium):
+    selenium.run("""
+        import bz2
+
+        text = "Hello test test test test this is a test test test"
+        some_compressed_bytes = bz2.compress(text.encode('utf-8'))
+        assert some_compressed_bytes != text
+        decompressed_bytes = bz2.decompress(some_compressed_bytes)
+        assert decompressed_bytes.decode('utf-8') == text
+    """)


### PR DESCRIPTION
The built-in Python modules [`bzip2`](https://docs.python.org/3/library/bz2.html) and [`mmap`](https://docs.python.org/3/library/mmap.html) are necessary for [`nibabel`](https://nipy.org/nibabel/) (#362 from @madhur-tandon).

This has the sqlite changes in it too (#352), since I hope that will get merged soon.