### PR TITLE
Add crypt module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 **User improvements:**
 
-- The built-in `sqlite3** module of Python is now enabled.
+- Support for built-in modules:
+  - `crypt`
 
 **Developer improvements:**
 
 - The `mkpkg` command will now select an appropriate archive to use, rather than
   just using the first.
+
 
 ## Version 0.10.0
 

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -36,7 +36,7 @@ _md5 md5module.c
 _blake2 _blake2/blake2module.c _blake2/blake2b_impl.c ../../host/Python-3.7.0/Modules/_blake2/blake2s_impl.c
 
 _sqlite3 _sqlite/cache.c _sqlite/connection.c _sqlite/cursor.c _sqlite/microprotocols.c _sqlite/module.c _sqlite/prepare_protocol.c _sqlite/row.c _sqlite/statement.c _sqlite/util.c -I$(SQLITEBUILD) -L$(SQLITEBUILD) -lsqlite3
-
+_crypt _cryptmodule.c
 
 _queue _queuemodule.c
 


### PR DESCRIPTION
#367 was too optimistic about `fcntl` and `asyncio`, so I pulled out the addition of `crypt` into a separate PR.