### PR TITLE
[MRG] Include mne

### DIFF
--- a/packages/mne/meta.yaml
+++ b/packages/mne/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: mne
+  version: 0.17.1
+
+source:
+  sha256: 2b933aead5b3c9cbbcf08574c06385d3304cd76365bf65d1173fe02579941dfe
+  url: https://files.pythonhosted.org/packages/a1/e5/f60f23e3ef10f5b1efa1aabb407f0b2fc64ed12ac166a6e1c16dd7db6e77/mne-0.17.1.tar.gz
+
+requirements:
+  run:
+    - numpy
+    - scipy
+
+test:
+  imports:
+    - mne

--- a/packages/mne/meta.yaml
+++ b/packages/mne/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: mne
-  version: 0.17.1
+  version: 0.17.2
 
 source:
-  sha256: 2b933aead5b3c9cbbcf08574c06385d3304cd76365bf65d1173fe02579941dfe
-  url: https://files.pythonhosted.org/packages/a1/e5/f60f23e3ef10f5b1efa1aabb407f0b2fc64ed12ac166a6e1c16dd7db6e77/mne-0.17.1.tar.gz
+  sha256: 2f40d52a8e3899359c4ecc156642cf772a8aacea206187d139bb0ab864c4b363
+  url: https://files.pythonhosted.org/packages/68/97/fc6be75f8cc9b3f79b7c2558a45b61c6c7d02da20182f0db01ac239858be/mne-0.17.2.tar.gz
 
 requirements:
   run:


### PR DESCRIPTION
the build works. the import with pyodide.runPython breaks because the mne's __init__ has a dependency on its internal utils which has a dependency on multiprocessing. submitted a patch upstream to fix that problem