### PR TITLE
feature(package): add biopython

### DIFF
--- a/packages/biopython/meta.yaml
+++ b/packages/biopython/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: biopython
+  version: '1.73'
+
+source:
+  url: https://files.pythonhosted.org/packages/7a/4a/0d4381a60b6e942c6772b01cfb931196f1a9c33910cc43fbd4faccbd7d9f/biopython-1.73.tar.gz
+  sha256: 70c5cc27dc61c23d18bb33b6d38d70edc4b926033aea3b7434737c731c94a5e0
+
+test:
+  imports:
+    - Bio
+


### PR DESCRIPTION
This adds the biopython package.

Allows to `import Bio` and allows to use [_Freely available tools for computational molecular biology._](https://pypi.org/project/biopython/)