### PR TITLE
Fix #406: Correctly convert a raw ArrayBuffer to Python memoryview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 - Calling `dir()` in Python on a JavaScript proxy now works.
 
+- Passing an `ArrayBuffer` from Javascript to Python now correctly creates
+  a `memoryview` object.
+
 ## Version 0.11.0
 
 **User improvements:**

--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -367,7 +367,10 @@ EM_JS(int, hiwire_get_byteLength, (int idobj), {
 
 EM_JS(int, hiwire_copy_to_ptr, (int idobj, int ptr), {
   var jsobj = Module.hiwire_get_value(idobj);
-  Module.HEAPU8.set(new Uint8Array(jsobj.buffer), ptr);
+  if ('buffer' in jsobj) {
+    jsobj = jsobj.buffer;
+  }
+  Module.HEAPU8.set(new Uint8Array(jsobj), ptr);
 });
 
 EM_JS(int, hiwire_get_dtype, (int idobj), {

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -300,6 +300,16 @@ def test_typed_arrays(selenium, wasm_heap, jstype, pytype):
          """)
 
 
+def test_array_buffer(selenium):
+    selenium.run_js(
+        'window.array = new ArrayBuffer(100);\n')
+    assert selenium.run(
+        """
+        from js import array
+        len(array.tobytes())
+        """) == 100
+
+
 def test_import_js(selenium):
     result = selenium.run(
         """


### PR DESCRIPTION
Cc: @vadimkantorov