### PR TITLE
Build Astropy 3.2.3 for Pyodide

### DIFF
--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: astropy
-  version: 3.1.2
+  version: 3.2.3
 
 source:
-  url: https://pypi.io/packages/source/a/astropy/astropy-3.1.2.tar.gz
-  sha256: 4a78a8ec9666d0a51a37f03494aaa5012e241ba37053e6c913c039cddee89ede
+  url: https://pypi.io/packages/source/a/astropy/astropy-3.2.3.tar.gz
+  sha256: 47f00816c2978fdd10f448c8f0337d6dca7b8cbeaab4bf272b5fd37cb4b890d3
 
 requirements:
   run:

--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -6,6 +6,9 @@ source:
   url: https://pypi.io/packages/source/a/astropy/astropy-3.1.2.tar.gz
   sha256: 4a78a8ec9666d0a51a37f03494aaa5012e241ba37053e6c913c039cddee89ede
 
+requirements:
+  run:
+    - numpy
 
 test:
   imports:

--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -1,0 +1,12 @@
+package:
+  name: astropy
+  version: 3.1.2
+
+source:
+  url: https://pypi.io/packages/source/a/astropy/astropy-3.1.2.tar.gz
+  sha256: 4a78a8ec9666d0a51a37f03494aaa5012e241ba37053e6c913c039cddee89ede
+
+
+test:
+  imports:
+    - astropy


### PR DESCRIPTION
The good news is, the build succeeds!

The bad news is, it doesn't seem to chain importing NumPy:

```
>>> import astropy.units
Error: Traceback (most recent call last):
  File "/lib/python3.7/site-packages/pyodide.py", line 42, in eval_code
    exec(compile(mod, '<exec>', mode='exec'), ns, ns)
  File "<exec>", line 1, in <module>
  File "/lib/python3.7/site-packages/astropy/__init__.py", line 121, in <module>
    _check_numpy()
  File "/lib/python3.7/site-packages/astropy/__init__.py", line 115, in _check_numpy
    raise ImportError(msg)
ImportError: Numpy version 1.13.0 or later must be installed to use Astropy
```

And depending on how you import things, they could work:

```
>>> import numpy 
>>> from astropy import units as u 
>>> u.m
Error: Traceback (most recent call last):
 File "/lib/python3.7/site-packages/pyodide.py", line 44, in eval_code 
     return eval(compile(expr, '<eval>', mode='eval'), ns, ns)
  File "<eval>", line 1, in <module>
NameError: name 'u' is not defined
>>> import astropy.units
>>> astropy.units.m
Unit("m")
```

Or *really* not:

```
Welcome to the Pyodide terminal emulator 🐍
>>> import astropy
Error: Out of bounds memory access (evaluating 'Module["asm"]["__runPython"].apply(null,arguments)')
>>> import astropy
[USER]: Out of bounds memory access (evaluating 'Module["asm"]["__pyproxy_apply"].apply(null,arguments)')
<?>.wasm-function[12245]@[wasm code]
<?>.wasm-function[12248]@[wasm code]
<?>.wasm-function[1748]@[wasm code]
<?>.wasm-function[15459]@[wasm code]
<?>.wasm-function[456]@[wasm code]
<?>.wasm-function[463]@[wasm code]
<?>.wasm-function[492]@[wasm code]
<?>.wasm-function[491]@[wasm code]
<?>.wasm-function[3224]@[wasm code]
<?>.wasm-function[3225]@[wasm code]
<?>.wasm-function[2681]@[wasm code]
<?>.wasm-function[15871]@[wasm code]
<?>.wasm-function[839]@[wasm code]
<?>.wasm-function[840]@[wasm code]
<?>.wasm-function[2749]@[wasm code]
<?>.wasm-function[2744]@[wasm code]
<?>.wasm-function[20461]@[wasm code]
<?>.wasm-function[835]@[wasm code]
<?>.wasm-function[831]@[wasm code]
<?>.wasm-function[830]@[wasm code]
<?>.wasm-function[847]@[wasm code]
<?>.wasm-function[1977]@[wasm code]
<?>.wasm-function[15600]@[wasm code]
<?>.wasm-function[837]@[wasm code]
<?>.wasm-function[2749]@[wasm code]
<?>.wasm-function[2744]@[wasm code]
<?>.wasm-function[20461]@[wasm code]
<?>.wasm-function[835]@[wasm code]
<?>.wasm-function[838]@[wasm code]
<?>.wasm-function[2749]@[wasm code]
<?>.wasm-function[2744]@[wasm code]
<?>.wasm-function[20461]@[wasm code]
<?>.wasm-function[2739]@[wasm code]
<?>.wasm-function[831]@[wasm code]
<?>.wasm-function[830]@[wasm code]
<?>.wasm-function[847]@[wasm code]
<?>.wasm-function[1977]@[wasm code]
<?>.wasm-function[15600]@[wasm code]
<?>.wasm-function[837]@[wasm code]
<?>.wasm-function[2749]@[wasm code]
<?>.wasm-function[2744]@[wasm code]
<?>.wasm-function[20461]@[wasm code]
<?>.wasm-function[2739]@[wasm code]
<?>.wasm-function[838]@[wasm code]
<?>.wasm-function[2749]@[wasm code]
<?>.wasm-function[2744]@[wasm code]
<?>.wasm-function[20461]@[wasm code]
<?>.wasm-function[835]@[wasm code]
<?>.wasm-function[831]@[wasm code]
<?>.wasm-function[830]@[wasm code]
<?>.wasm-function[847]@[wasm code]
<?>.wasm-function[873]@[wasm code]
<?>.wasm-function[14957]@[wasm code]
<?>.wasm-function[842]@[wasm code]
<?>.wasm-function[354]@[wasm code]
wasm-stub@[wasm code]
__pyproxy_apply@[native code]
http://localhost:8000/pyodide.asm.js:8:2021341
apply@http://localhost:8000/pyodide.asm.js:8:42063
[native code]
pushCode@http://localhost:8000/console.html:15:30
o@https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js:44:91014
T@https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js:44:91831
ENTER@https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js:44:18151
ze@https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js:44:33861
dispatch@https://code.jquery.com/jquery-latest.js:4641:14
handle@https://code.jquery.com/jquery-latest.js:4309:33
```