### PR TITLE
Configure matplotlib to use the new HTML5 Canvas Backend [ci skip]

### DIFF
--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -15,8 +15,8 @@ source:
 
   extras:
     -
-      - src/wasm_backend.py
-      - lib/matplotlib/backends/wasm_backend.py
+      - src/html5_canvas_backend.py
+      - lib/matplotlib/backends/html5_canvas_backend.py
     -
       - src/setup.cfg
       - ./setup.cfg

--- a/packages/matplotlib/src/setup.cfg
+++ b/packages/matplotlib/src/setup.cfg
@@ -1,2 +1,2 @@
 [rc_options]
-backend=module://matplotlib.backends.wasm_backend
+backend=module://matplotlib.backends.html5_canvas_backend


### PR DESCRIPTION
Setup `matplotlib` to use the new backend. This is probably not ready to manually test yet, but I think we should probably merge this so that we wouldn't have to care later about this.