### PR TITLE
Implement draw_path() and draw_markers()

### DIFF
--- a/packages/matplotlib/src/html5_canvas_backend.py
+++ b/packages/matplotlib/src/html5_canvas_backend.py
@@ -5,6 +5,10 @@ from matplotlib.backend_bases import (
     GraphicsContextBase, RendererBase,
     FigureManagerBase, _Backend
 )
+
+from matplotlib.colors import colorConverter, rgb2hex
+from matplotlib.transforms import Affine2D
+from matplotlib.path import Path
 from matplotlib import interactive
 
 from js import document
@@ -119,6 +123,75 @@ class RendererHTMLCanvas(RendererBase):
 
     def points_to_pixels(self, points):
         return (points / 72.0) * self.dpi
+
+    def _matplotlib_color_to_CSS(self, color, alpha=None, is_RGB=True):
+        if not is_RGB:
+            R, G, B, alpha = colorConverter.to_rgba(color)
+            color = (R, G, B)
+
+        if (len(color) == 4) and (alpha is None):
+            alpha = color[3]
+
+        if alpha is None:
+            CSS_color = rgb2hex(color[:3])
+
+        else:
+            R = int(color[0] * 255)
+            G = int(color[1] * 255)
+            B = int(color[2] * 255)
+            CSS_color = """rgba({0:d}, {1:d},
+                                {2:d}, {3:.3g})""".format(R, G, B, alpha)
+
+        return CSS_color
+
+    def _set_style(self, gc, rgbFace=None):
+        if rgbFace is not None:
+            self.ctx.fillStyle = self._matplotlib_color_to_CSS(rgbFace,
+                                                               gc.get_alpha())
+
+        if gc.get_capstyle():
+            self.ctx.lineCap = _capstyle_d[gc.get_capstyle()]
+
+        self.ctx.strokeStyle = self._matplotlib_color_to_CSS(gc.get_rgb(),
+                                                             gc.get_alpha())
+        self.ctx.lineWidth = self.points_to_pixels(gc.get_linewidth())
+
+    def _path_helper(self, ctx, path, transform, clip=None):
+        ctx.beginPath()
+        for points, code in path.iter_segments(transform,
+                                               remove_nans=True, clip=clip):
+            points += 0.5
+            if code == Path.MOVETO:
+                ctx.moveTo(points[0], points[1])
+            elif code == Path.LINETO:
+                ctx.lineTo(points[0], points[1])
+            elif code == Path.CURVE3:
+                ctx.quadraticCurveTo(*points)
+            elif code == Path.CURVE4:
+                ctx.bezierCurveTo(*points)
+            elif code == Path.CLOSEPOLY:
+                ctx.closePath()
+
+    def draw_path(self, gc, path, transform, rgbFace=None):
+        self._set_style(gc, rgbFace)
+        if rgbFace is None and gc.get_hatch() is None:
+            figure_clip = (0, 0, self.width, self.height)
+
+        else:
+            figure_clip = None
+
+        transform += Affine2D().scale(1, -1).translate(0, self.height)
+        self._path_helper(self.ctx, path, transform, figure_clip)
+        self.ctx.stroke()
+
+        if rgbFace is not None:
+            self.ctx.fill()
+            self.ctx.fillStyle = '#000000'
+
+    def draw_markers(self, gc, marker_path, marker_trans, path,
+                     trans, rgbFace=None):
+        super().draw_markers(gc, marker_path, marker_trans, path,
+                             trans, rgbFace)
 
 
 class FigureManagerHTMLCanvas(FigureManagerBase):

--- a/packages/matplotlib/src/html5_canvas_backend.py
+++ b/packages/matplotlib/src/html5_canvas_backend.py
@@ -38,7 +38,8 @@ class FigureCanvasHTMLCanvas(FigureCanvasWasm):
             if canvas is None:
                 return
             ctx = canvas.getContext("2d")
-            renderer = RendererHTMLCanvas(ctx, width, height, dpi=72)
+            renderer = RendererHTMLCanvas(ctx, width, height,
+                                          dpi=self.figure.dpi)
             self.figure.draw(renderer)
         finally:
             self.figure.dpi = orig_dpi


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/448

This work builds upon the previous PR of https://github.com/iodide-project/pyodide/pull/450

@mdboom I have added the Implementation of `draw_path()` and `draw_markers()`. This should enable us to draw the basic curves (straight lines, sine, etc) along with plotting histograms. From my testing, this should also have the support for drawing `dashed` lines due to the way we defined our `GraphicsContextHTMLCanvas` class before :)

I do suspect that the default properties in both the backends differ though. For example, the default `linewidth` property of `1` kinda differs as the `HTML5 Canvas` based backend draws lines which are much thinner than what `Agg` draws. Similarly, other properties such as the size of `markers`, `dashes`, etc. will also need some tweaking to make the outputs more similar.