### PR TITLE
fix micropip.install packages with dependencies

### DIFF
--- a/packages/micropip/build/micropip-0.1/micropip.py
+++ b/packages/micropip/build/micropip-0.1/micropip.py
@@ -193,9 +193,9 @@ class _PackageManager:
             wheel, ver = self.find_wheel(metadata, req)
             transaction['locked'][req.name] = ver
 
-            reqs = metadata.get('info', {}).get('requires_dist') or []
-            for req in reqs:
-                self.add_requirement(req, ctx, transaction)
+            recurs_reqs = metadata.get('info', {}).get('requires_dist') or []
+            for recurs_req in recurs_reqs:
+                self.add_requirement(recurs_req, ctx, transaction)
 
             transaction['wheels'].append((req.name, wheel, ver))
 


### PR DESCRIPTION
The variable `req` in method `_PackageManager.add_requirement` is erroneously
reused for iterating over recursive requirements, if any.  This causes the
remaining statement to fail.  This patch renames the variable used for the
recursive requirements to `recurs_req`.

Fixes: #413