### PR TITLE
Add Support for saving PNG files

### DIFF
--- a/packages/matplotlib/src/html5_canvas_backend.py
+++ b/packages/matplotlib/src/html5_canvas_backend.py
@@ -13,9 +13,6 @@ from matplotlib import interactive
 
 from js import document
 
-import base64
-import io
-
 _capstyle_d = {'projecting': 'square', 'butt': 'butt', 'round': 'round'}
 
 interactive(True)
@@ -55,14 +52,15 @@ class NavigationToolbar2HTMLCanvas(NavigationToolbar2Wasm):
         # content, and then virtually clicks it. Kind of magical, but it
         # works...
         element = document.createElement('a')
-        data = io.BytesIO()
-        try:
-            self.canvas.figure.savefig(data, format=format)
-        except Exception:
-            raise
-        element.setAttribute('href', 'data:{};base64,{}'.format(
-            mimetype, base64.b64encode(data.getvalue()).decode('ascii')))
+
+        canvas = self.canvas.get_element('canvas')
+        imgURL = canvas.toDataURL('image/png')
+        element.setAttribute('href', imgURL)
         element.setAttribute('download', 'plot.{}'.format(format))
+        element.dataset.downloadurl = """image/png:{0}:
+                                         {1}""".format(element.download,
+                                                       element.href)
+
         element.style.display = 'none'
         document.body.appendChild(element)
         element.click()

--- a/packages/matplotlib/src/html5_canvas_backend.py
+++ b/packages/matplotlib/src/html5_canvas_backend.py
@@ -46,9 +46,18 @@ class FigureCanvasHTMLCanvas(FigureCanvasWasm):
             self.figure.dpi = orig_dpi
             self._idle_scheduled = False
 
+    def get_pixel_data(self):
+        canvas = self.get_element('canvas')
+        ctx = canvas.getContext("2d")
+        canvas_data = ctx.getImageData(0, 0, int(ctx.width),
+                                       int(ctx.height)).data
+        canvas_data = np.asarray(canvas_data, dtype=np.uint8)
+        pixel_data = np.reshape(canvas_data, (int(ctx.height),
+                                int(ctx.width), 4))
+        return pixel_data
+
     def print_png(self, filename_or_obj, *args,
-                  metadata=None, pil_kwargs=None,
-                  **kwargs):
+                  metadata=None, **kwargs):
 
         from matplotlib import _png
 
@@ -60,16 +69,9 @@ class FigureCanvasHTMLCanvas(FigureCanvasWasm):
             **metadata,
         }
 
-        canvas = self.get_element('canvas')
-        ctx = canvas.getContext("2d")
-        canvas_data = ctx.getImageData(0, 0, int(ctx.width),
-                                       int(ctx.height)).data
-        data = np.reshape(np.uint8(np.asarray(canvas_data)),
-                                  (int(ctx.height), int(ctx.width), -1))
+        data = self.get_pixel_data()
         with cbook.open_file_cm(filename_or_obj, "wb") as fh:
             _png.write_png(data, fh, self.figure.dpi, metadata=metadata)
-
-        return data
 
 
 class NavigationToolbar2HTMLCanvas(NavigationToolbar2Wasm):
@@ -88,6 +90,7 @@ class NavigationToolbar2HTMLCanvas(NavigationToolbar2Wasm):
                 self.canvas.figure.savefig(data, format=format)
             except Exception:
                 raise
+
         element.setAttribute('href', 'data:{};base64,{}'.format(
             mimetype, base64.b64encode(data.getvalue()).decode('ascii')))
         element.setAttribute('download', 'plot.{}'.format(format))


### PR DESCRIPTION
@mdboom For setting up the testing infrastructure, we need some reference images to compare against. The reference images in the matplotlib repository would also have text in them and our new renderer does not support text currently (since `draw_text()` is not implemented). Thus, I thought if we could save images from the HTML5 Canvas Renderer and then use those images as our reference images for the time being rather than the default ones provided by matplotlib (until all functions have been implemented)

Thus, we need to be able to convert the underlying pixel data of the canvas into formats like `png`, `pdf` and `svg`. This serves two purpose:

- The User can save the HTML5 Canvas Renderer generated plots into these various formats.
- We can use the saved Images for our image comparison tests.

Currently, according to my initial investigation, for formats like `pdf` and `svg`. Matplotlib switches to a different renderer than Agg - `backend_pdf` and `backend_svg` respectively. (I am still unsure about how it does `png` stuff).

These file specific backends have functions such as `print_pdf` and `print_svg` respectively. These functions use a `MixedModeRenderer` that takes in 2 renderers (For eg: `RendererPdf` and `Agg` for `print_pdf`).

I speculate that since `Agg` is being used as the default renderer in the `MixedModeRenderer`, we thus get to see the `text` too when we download the plot in any of the formats through the navigation toolbar. (while the plot rendered by our custom renderer doesn't contain text)

To enable functionality of saving plots into these different formats, I think we would need to pass our custom HTML5 Canvas Renderer rather than `Agg` in the above `MixedModeRenderer` object for functions `print_pdf` and `print_svg`. This should (I am not sure though) allow us to use your existing code i.e.

```
data = io.BytesIO()
        try:
            self.canvas.figure.savefig(data, format=format)
        except Exception as e:
            raise
        element.setAttribute('href', 'data:{};base64,{}'.format(
            mimetype, base64.b64encode(data.getvalue()).decode('ascii')))
        element.setAttribute('download', 'plot.{}'.format(format))
element.style.display = 'none'
```

for saving the plots to `pdf` and `svg` and maybe `png` too.

Regardless, Before trying out the above idea - I tried to search if we could directly save the canvas data into formats like `png`, `pdf` and `svg` rather than tinkering with the file specific backends (`backend_pdf` and `backend_svg`). I could only find 1 solution of directly saving to `png`. 

This PR contains that solution. But there's a catch again. When we used to save plots before, their size was `640x480`. The solution implemented in this PR is able to save the canvas data (i.e. no `text` occurs in the plot as expected) but the saved image has a size of `1280x960`. which is 4 times the original.

The questions I want to ask are as follows:
- Is the approach I mentioned above (passing our custom renderer to the `MixedModeRenderer` in different file-specific backends so that we could directly use your code written for the `download` function of `NavigationToolbar2Wasm`) in the right direction?
- Should all this be skipped and maybe we should set up the testing infrastructure with a different aim / goals in mind?
- What could be done to fix the code in this PR so that the saved image (`PNG`) has a size of `640x480` and not `1280x960` as it is doing now.
- Are there any other direct methods to convert to `PDF` and `SVG` (just like there is for `PNG` in this PR) rather than tinkering with the file-specific backends for those formats?

We can probably discuss all this in the meeting tomorrow as well, but I could appreciate some initial insights today. Thanks!