### PR TITLE
Fix minor typo in code example

### DIFF
--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -40,7 +40,7 @@ of the expression, converted to Javascript objects (See [type
 conversions](type_conversions.md)).
 
 ```javascript
-pyodide.runPython('import sys\nsys.version'));
+pyodide.runPython('import sys\nsys.version');
 ```
 
 ## Loading packages


### PR DESCRIPTION
Just a small fix to remove an extra bracket in the documentation's code example.