### PR TITLE
Add Pillow recipe.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN sudo bash -c "echo \"deb http://ftp.us.debian.org/debian testing main contri
   && sudo apt-get install bzip2 libgconf-2-4 node-less cmake build-essential clang-format-6.0 \
                   uglifyjs chromium ccache libncurses6 gfortran f2c \
   && sudo apt-get install -t testing g++-8 \
+  # required for pillow/PIL
+  && sudo apt-get install libtiff5-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6 \
   && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
   && sudo update-alternatives --set gcc /usr/bin/gcc-8 \

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -15,6 +15,8 @@ export HOSTPYTHON=$(HOSTPYTHONROOT)/bin/python3
 export TARGETPYTHONROOT=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)
 export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/include/python$(PYMINOR)
 
+export C_INCLUDE_PATH=/usr/include:/usr/include/x86_64-linux-gnu:/usr/include/freetype2:/usr/include/openjpeg-2.3
+
 export PYODIDE_PACKAGE_ABI=1
 
 export SIDE_LDFLAGS=\

--- a/packages/Pillow/meta.yaml
+++ b/packages/Pillow/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: Pillow
+  version: 6.1.0
+
+source:
+  url: https://files.pythonhosted.org/packages/51/fe/18125dc680720e4c3086dd3f5f95d80057c41ab98326877fc7d3ff6d0ee5/Pillow-6.1.0.tar.gz
+  sha256: 0804f77cb1e9b6dbd37601cee11283bba39a8d44b9ddb053400c58e0c0d7d9de
+
+test:
+  imports:
+    - PIL

--- a/packages/Pillow/test_PIL.py
+++ b/packages/Pillow/test_PIL.py
@@ -1,0 +1,19 @@
+from textwrap import dedent
+
+import pytest
+
+
+def test_bool(selenium_standalone, request):
+    selenium = selenium_standalone
+    selenium.load_package("Pillow")
+    selenium.load_package("numpy")
+    cmd = dedent(r"""
+        import numpy as np
+        from PIL import Image
+        a = np.zeros((10, 2), dtype=np.bool)
+        a[0][0] = True
+        im = Image.fromarray(a)
+        assert im.getdata()[0] == 255
+        """)
+
+    selenium.run(cmd)


### PR DESCRIPTION
This adds a pillow recipe.

There are a few issues and workaround to get it working, which I'll list here. There are also some still unresolved issues that I don't know how to fix.

Workarounds
----------------

* I added some apt packages to `Dockerfile` that are needed for pillow. I'm not sure if that is the appropriate place for it?
* I added `C_INCLUDE_PATH` to `Makefile.envs`. Without it, `emcc` errored out because it couldn't find the headers which are directly in those directories.
  * I did try using `build/cflags` in the yaml file, but that places the directories at the start of the `emcc` command which changes the search order, which somehow broke it because it tried to compile for 32 bit, chocked on missing `stub-32.h`, and then failed when I installed the x86 compiler. Using `C_INCLUDE_PATH` fixed it because the compiler looks in the provided paths *after* all the other paths.
  Obviously putting in `Makefile.envs` is not great, but I'm not sure what else I can do. If I could change the env variable just for this recipe it would be great.
* I'm assuming the dockerfile changes will propagate to dockerhub, I just installed these packages manually.

Still broken
-------------

This PR compiles fine, however to actually use it there's still a manual workaround required. Running it in the `Pyodide terminal emulator` from the docker container, I get the following.
```py
>>> import PIL
>>> from PIL import Image
TypeError: Module[prop] is undefined
```

I managed to trace it to the code `{return Module[prop].apply(null,arguments)}` in the middle of the giant `pyodide.asm.js` file. Removing that statement, fixed it. I'm not sure what generates this code so I don't know how to fix it. Would love if someone can look at it.

But, with these changes, I was able to read a image.