### PR TITLE
Serve local pyodide build-folder with `make serve`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ test: all
 	pytest test packages pyodide_build -v
 
 
+serve: all
+	./serve.py
+
+
 lint:
 	flake8 src test tools pyodide_build benchmark
 	clang-format -output-replacements-xml src/*.c src/*.h src/*.js | (! grep '<replacement ')

--- a/serve.py
+++ b/serve.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import os
+import socketserver
+from http.server import SimpleHTTPRequestHandler
+
+PORT = 8181
+os.chdir("build")
+
+
+class pyodideHttpServer(SimpleHTTPRequestHandler):
+
+    def __init__(self, request, client_address, server):
+        self.extensions_map.update({
+            '.wasm': 'application/wasm',
+        })
+
+        super().__init__(request, client_address, server)
+
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+
+Handler = pyodideHttpServer
+
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    httpd.allow_reuse_address = True
+    print("serving at port", PORT)
+    httpd.serve_forever()


### PR DESCRIPTION
Hi there,

I'm developing with Pyodide on a raw Linux box without using Docker. Therefore, I created this `make serve` and related `serve.py` script to serve the local Pyodide build/ folder directly with the correct mime-types.

I'm not sure if this is a valid pull request but maybe some others find it useful. It currently serves on port 8181, maybe it is wanted to make this configurable?