### PR TITLE
run_docker: Automatically source emsdk_env.sh

### DIFF
--- a/run_docker
+++ b/run_docker
@@ -4,10 +4,11 @@ PYODIDE_DOCKER_PORT=${PYODIDE_DOCKER_PORT:-"8000"}
 PYODIDE_SYSTEM_PORT=${PYODIDE_SYSTEM_PORT:-"8000"}
 PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE:-"iodide/pyodide-env:0.3.1"}
 
+echo 'source emsdk/emsdk/emsdk_env.sh' > docker-bashrc
 exec docker run \
     -p $PYODIDE_SYSTEM_PORT:$PYODIDE_DOCKER_PORT \
     -it --rm \
     -v $PWD:/src \
     --user root -e NB_UID=$UID -e NB_GID=$GID \
     ${PYODIDE_DOCKER_IMAGE} \
-    /bin/bash
+    /bin/bash --rcfile docker-bashrc


### PR DESCRIPTION
so that `emcc` and such work out of the box.

E.g.:

```
$ ./run_docker
Adding directories to PATH:
PATH += /src/emsdk/emsdk
PATH += /src/emsdk/emsdk/clang/tag-e1.38.22/build_tag-e1.38.22_64/bin
PATH += /src/emsdk/emsdk/node/8.9.1_64bit/bin
PATH += /src/emsdk/emsdk/emscripten/tag-1.38.22
PATH += /src/emsdk/emsdk/binaryen/tag-1.38.22_64bit_binaryen/bin

Setting environment variables:
EMSDK = /src/emsdk/emsdk
EM_CONFIG = /src/emsdk/emsdk/.emscripten
EM_CACHE = /src/emsdk/emsdk/.emscripten_cache
LLVM_ROOT = /src/emsdk/emsdk/clang/tag-e1.38.22/build_tag-e1.38.22_64/bin
EMSDK_NODE = /src/emsdk/emsdk/node/8.9.1_64bit/bin/node
EMSCRIPTEN = /src/emsdk/emsdk/emscripten/tag-1.38.22
EMSCRIPTEN_NATIVE_OPTIMIZER = /src/emsdk/emsdk/emscripten/tag-1.38.22_64bit_optimizer/optimizer
BINARYEN_ROOT = /src/emsdk/emsdk/binaryen/tag-1.38.22_64bit_binaryen

root@e4c707d44a16:/src# make
emcc -o src/jsproxy.bc -c src/jsproxy.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
emcc -o src/pyproxy.bc -c src/pyproxy.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
emcc -o src/runpython.bc -c src/runpython.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
...
```