### PR TITLE
Revert emscripten from 1.38.30 to 1.38.22

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,4 +1,4 @@
-export EMSCRIPTEN_VERSION = 1.38.30
+export EMSCRIPTEN_VERSION = 1.38.22
 
 export PATH := $(PYODIDE_ROOT)/ccache:$(PYODIDE_ROOT)/emsdk/emsdk:$(PYODIDE_ROOT)/emsdk/emsdk/clang/tag-e$(EMSCRIPTEN_VERSION)/build_tag-e$(EMSCRIPTEN_VERSION)_64/bin:$(PYODIDE_ROOT)/emsdk/emsdk/node/8.9.1_64bit/bin:$(PYODIDE_ROOT)/emsdk/emsdk/emscripten/tag-$(EMSCRIPTEN_VERSION):$(PYODIDE_ROOT)/emsdk/emsdk/binaryen/tag-$(EMSCRIPTEN_VERSION)_64bit_binaryen/bin:$(PATH)
 


### PR DESCRIPTION
GH-374 updated `EMSCRIPTEN_VERSION` (which is used to set `PATH`) from
`1.38.22` to `1.38.30`. But the `iodide/pyodide-env:0.3.1` docker image
(uploaded 9 months ago) still provides only `1.38.22`:

```
$ ./run_docker
root@34d1c8c495da:/src/emsdk/emsdk/emscripten# ls -l
total 0
drwxr-xr-x 58 root root 1856 Mar 26 23:33 tag-1.38.22
drwxr-xr-x  8 root root  256 Mar 14 07:36 tag-1.38.22_64bit_optimizer
```

See: https://github.com/iodide-project/pyodide/pull/501#issuecomment-521069250

Without this PR:

```
$ ./run_docker
root@fdb2ca49e776:/src# make
emcc -o src/jsproxy.bc -c src/jsproxy.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
ccache: error: Could not find compiler "emcc" in PATH
Makefile:140: recipe for target 'src/jsproxy.bc' failed
make: *** [src/jsproxy.bc] Error 1
```

With this PR:

```
$ ./run_docker
root@88ebe7615498:/src# make
emcc -o src/jsproxy.bc -c src/jsproxy.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
emcc -o src/pyproxy.bc -c src/pyproxy.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
emcc -o src/runpython.bc -c src/runpython.c -O3 -g -I/src/cpython/installs/python-3.7.0/include/python3.7 -Wno-warn-absolute-paths
...
```