### PR TITLE
Convert integer-only doubles to PyLong

### DIFF
--- a/src/js2python.c
+++ b/src/js2python.c
@@ -23,6 +23,11 @@ _js2python_get_ptr(int obj)
 int
 _js2python_number(double val)
 {
+  double i;
+
+  if (modf(val, &i) == 0.0)
+    return (int)PyLong_FromLong(i);
+
   return (int)PyFloat_FromDouble(val);
 }
 

--- a/src/js2python.c
+++ b/src/js2python.c
@@ -26,7 +26,7 @@ _js2python_number(double val)
   double i;
 
   if (modf(val, &i) == 0.0)
-    return (int)PyLong_FromLong(i);
+    return (int)PyLong_FromDouble(i);
 
   return (int)PyFloat_FromDouble(val);
 }

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -224,10 +224,10 @@ def test_js2python(selenium):
         'jsstring_ucs4 == "🐍"')
     assert selenium.run(
         'from js import jsnumber0\n'
-        'jsnumber0 == 42 and str(jsnumber0) == "42"')
+        'jsnumber0 == 42 and isinstance(jsnumber0, int)')
     assert selenium.run(
         'from js import jsnumber1\n'
-        'jsnumber1 == 42.5 and str(jsnumber1) == "42.5"')
+        'jsnumber1 == 42.5 and isinstance(jsnumber1, float)')
     assert selenium.run(
         'from js import jsundefined\n'
         'jsundefined is None')

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -224,10 +224,10 @@ def test_js2python(selenium):
         'jsstring_ucs4 == "🐍"')
     assert selenium.run(
         'from js import jsnumber0\n'
-        'jsnumber0 == 42')
+        'jsnumber0 == 42 and str(jsnumber0) == "42"')
     assert selenium.run(
         'from js import jsnumber1\n'
-        'jsnumber1 == 42.5')
+        'jsnumber1 == 42.5 and str(jsnumber1) == "42.5"')
     assert selenium.run(
         'from js import jsundefined\n'
         'jsundefined is None')


### PR DESCRIPTION
This little change will convert JavaScript numbers containing integers, e.g. "3.0", to a real Python long "3".