### PR TITLE
Assume length 1 for objects having no length set

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -279,6 +279,12 @@ EM_JS(int, hiwire_new, (int idobj, int idargs), {
 });
 
 EM_JS(int, hiwire_get_length, (int idobj), {
+  // clang-format off
+  // In case there is no length on the object, return a length of 1
+  if (Module.hiwire_get_value(idobj).length === undefined)
+    return 1;
+  // clang-format on
+
   return Module.hiwire_get_value(idobj).length;
 });
 


### PR DESCRIPTION
To make bool() check on objects without a length attribute possible, this changereturns 1 on any length request to an object without a length attribute.

This should resolve the problem reported with issue #513.