### PR TITLE
Fix unknown marker variable

### DIFF
--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -133,7 +133,7 @@ class _PackageManager:
                 'locked': dict(self.installed_packages)
             }
             for requirement in requirements:
-                self.add_requirement(requirement, ctx, transaction)
+                self.add_requirement(requirement, complete_ctx, transaction)
         except Exception as e:
             reject(str(e))
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -6,6 +6,8 @@ def test_install_simple(selenium_standalone):
     selenium_standalone.load_package("micropip")
     selenium_standalone.run("import micropip")
     selenium_standalone.run("micropip.install('pyodide-micropip-test')")
+    # Package 'pyodide-micropip-test' has dependency on 'snowballstemmer'
+    # It is used to test markers support
 
     for i in range(10):
         if selenium_standalone.run(

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -5,7 +5,7 @@ def test_install_simple(selenium_standalone):
     selenium_standalone.run("import os")
     selenium_standalone.load_package("micropip")
     selenium_standalone.run("import micropip")
-    selenium_standalone.run("micropip.install('snowballstemmer')")
+    selenium_standalone.run("micropip.install('pyodide-micropip-test')")
 
     for i in range(10):
         if selenium_standalone.run(


### PR DESCRIPTION
There is a bug in MicroPip which makes installation of packages with markers impossible. One of the main cases when this happen if package has defined `implementation_name == "cpython"`.

Problem is that `distlib.markers` will raise `unknown variable` error. This is because markers like `implementation_name` are not defined in `ctx`.

`ctx` only consists `{'extra': None}`. However, there is also `complete_ctx` which consist of all other variables. I changed `add_requirement` to provide `complete_ctx`˙isntead of just `ctx`.