### PR TITLE
Adds regex package.

### DIFF
--- a/packages/regex/meta.yaml
+++ b/packages/regex/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: regex
+  version: 2019.08.19
+source:
+  sha256: 587b62d48ca359d2d4f02d486f1f0aa9a20fbaf23a9d4198c4bed72ab2f6c849
+  url: https://files.pythonhosted.org/packages/6f/a6/99eeb5904ab763db87af4bd71d9b1dfdd9792681240657a4c0a599c10a81/regex-2019.08.19.tar.gz
+test:
+  imports:
+  - regex


### PR DESCRIPTION
[regex](https://pypi.org/project/regex/) provides more powerful regexes for Python while maintaining compatibility with `re` (package source is [here](https://bitbucket.org/mrabarnett/mrab-regex/src/default/)).

The package is written in C, exposing Python bindings, so it cannot be installed through micropip. However, it had no external dependencies, which made it an easy first port.

Feel free to ignore the PR if you're not interested in the package (or don't think it's a good fit for the project). I'm working on porting an existing Python project to Pyodide and wanted to give you guys the option to upstream anything you think might be useful.

