### PR TITLE
Add a docs badge to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 
 [![Build Status](https://circleci.com/gh/iodide-project/pyodide.png)](https://circleci.com/gh/iodide-project/pyodide)
+[![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=latest)](https://pyodide.readthedocs.io/?badge=latest)
 
 The Python scientific stack, compiled to WebAssembly.
 


### PR DESCRIPTION
This makes it slightly easier to find the docs from repository's README