### PR TITLE
Ignores source files for Jedi and Parso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ ccache
 /lz4/lz4-1.8.3
 CLAPACK/CLAPACK-WA
 CLAPACK/clapack.tgz
+jedi/jedi-0.15.1
+parso/parso-0.5.1
 *.egg-info/


### PR DESCRIPTION
These folders are created as part of the build.