### PR TITLE
Make mkpkg command more prominent in the docs

### DIFF
--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -1,9 +1,7 @@
 # Creating a Pyodide package
 
-Pyodide includes a set of automatic tools to make it easier to add new
-third-party Python libraries to the build.
-
-These tools automate the following steps to build a package:
+Pyodide includes a toolchain to make it easier to add new third-party Python
+libraries to the build. We automate the following steps:
 
 - Download a source tarball (usually from PyPI)
 - Confirm integrity of the package by comparing it to a checksum
@@ -26,6 +24,18 @@ Lastly, a `packages.json` file is output containing the dependency tree of all
 packages, so `pyodide.loadPackage` can load a package's dependencies
 automatically.
 
+## mkpkg
+
+If you wish to create a new package for pyodide, the easiest place to start is
+with the `mkpkg` tool. If your package is on PyPI, just run:
+
+`bin/pyodide mkpkg $PACKAGE_NAME`
+
+This will generate a `meta.yaml` (see below) that should work out of the box
+for manypure Python packages. This tool will populate the latest version, download
+link and sha256 hash by querying PyPI. It doesn't currently handle package
+dependencies, so you will need to specify those yourself.
+
 ## The meta.yaml file
 
 Packages are defined by writing a `meta.yaml` file. The format of these files is
@@ -40,13 +50,6 @@ starting point to create Pyodide packages. In general, however, one should not
 expect Conda packages to "just work" with Pyodide. (In the longer term, Pyodide
 may use conda as its packaging system, and this should hopefully ease that
 transition.)
-
-There is a helper tool that will generate a `meta.yaml` for packages on PyPI
-that will work for many pure Python packages. This tool will populate the latest
-version, download link and sha256 hash by querying PyPI. It doesn't currently
-handle package dependencies. To run it, do:
-
-`bin/pyodide mkpkg $PACKAGE_NAME`
 
 The supported keys in the `meta.yaml` file are described below.
 

--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -32,7 +32,7 @@ with the `mkpkg` tool. If your package is on PyPI, just run:
 `bin/pyodide mkpkg $PACKAGE_NAME`
 
 This will generate a `meta.yaml` (see below) that should work out of the box
-for manypure Python packages. This tool will populate the latest version, download
+for many pure Python packages. This tool will populate the latest version, download
 link and sha256 hash by querying PyPI. It doesn't currently handle package
 dependencies, so you will need to specify those yourself.
 


### PR DESCRIPTION
Under "adding new packages", information on the mkpkg command is 
buried under "meta.yaml". To make it easier to find, give this command its own 
section.