### PR TITLE
Allow specifying list of packages

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -17,6 +17,8 @@ export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/includ
 
 export PYODIDE_PACKAGE_ABI=1
 
+export PACKAGES=*
+
 export SIDE_LDFLAGS=\
 	-O3 \
   -s "BINARYEN_METHOD='native-wasm'" \

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -17,7 +17,7 @@ export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/includ
 
 export PYODIDE_PACKAGE_ABI=1
 
-export PACKAGES=*
+export PACKAGES="*"
 
 export SIDE_LDFLAGS=\
 	-O3 \

--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -148,3 +148,9 @@ Shell commands to run after building the library. These are run inside of
 A list of required packages.
 
 (Unlike conda, this only supports package names, not versions).
+
+## Building specific packages
+
+Instead of building all packages in `packages` folder, you can also specify a list of packages
+to build. To do this, you can specify a comma-separated list of packages to `bin/pyodide buildall`
+command as `packages` argument or as `PACKAGES` environment variables.

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.envs
 
 all: deps
 	../bin/pyodide buildall . ../build \
-		--packages=$(PACKAGES) --package_abi=$(PYODIDE_PACKAGE_ABI) --ldflags="$(SIDE_LDFLAGS)" --host=$(HOSTPYTHONROOT) --target=$(TARGETPYTHONROOT)
+		--packages="$(PACKAGES)" --package_abi=$(PYODIDE_PACKAGE_ABI) --ldflags="$(SIDE_LDFLAGS)" --host=$(HOSTPYTHONROOT) --target=$(TARGETPYTHONROOT)
 deps:
 	# Install build dependencies
 	$(HOSTPYTHON) -m pip install Cython Tempita

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.envs
 
 all: deps
 	../bin/pyodide buildall . ../build \
-		--package_abi=$(PYODIDE_PACKAGE_ABI) --ldflags="$(SIDE_LDFLAGS)" --host=$(HOSTPYTHONROOT) --target=$(TARGETPYTHONROOT)
+		--packages=$(PACKAGES) --package_abi=$(PYODIDE_PACKAGE_ABI) --ldflags="$(SIDE_LDFLAGS)" --host=$(HOSTPYTHONROOT) --target=$(TARGETPYTHONROOT)
 deps:
 	# Install build dependencies
 	$(HOSTPYTHON) -m pip install Cython Tempita

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -37,7 +37,7 @@ def build_packages(packagesdir, outputdir, args):
     dependencies = {}
     import_name_to_package_name = {}
     for pkgdir in packagesdir.iterdir():
-        if pkgdir not in packages:
+        if packages != '*' and pkgdir not in packages:
             continue
 
         pkgpath = pkgdir / 'meta.yaml'

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -29,11 +29,17 @@ def build_package(pkgname, dependencies, packagesdir, outputdir, args):
 
 
 def build_packages(packagesdir, outputdir, args):
+    # Store list of packages we want to build
+    packages = args.packages.split()
+
     # We have to build the packages in the correct order (dependencies first),
     # so first load in all of the package metadata and build a dependency map.
     dependencies = {}
     import_name_to_package_name = {}
     for pkgdir in packagesdir.iterdir():
+        if pkgdir not in packages:
+            continue
+
         pkgpath = pkgdir / 'meta.yaml'
         if pkgdir.is_dir() and pkgpath.is_file():
             pkg = common.parse_package(pkgpath)

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -30,7 +30,7 @@ def build_package(pkgname, dependencies, packagesdir, outputdir, args):
 
 def build_packages(packagesdir, outputdir, args):
     # Store list of packages we want to build
-    packages = args.packages.split()
+    packages = args.packages.split(',')
 
     # We have to build the packages in the correct order (dependencies first),
     # so first load in all of the package metadata and build a dependency map.
@@ -73,6 +73,9 @@ def make_parser(parser):
     parser.add_argument(
         'output', type=str, nargs=1,
         help='Output directory in which to put all built packages')
+    parser.add_argument(
+        '--packages', type=str, nargs='?', default='*',
+        help='The comma-separated list of packages to build')
     parser.add_argument(
         '--package_abi', type=int, required=True,
         help='The ABI number for the packages to be built')


### PR DESCRIPTION
This allows specifying a list of packages you want to build. It adds `PACKAGES` to ` Makefile.envs` which is then forwarded to `pyodide_build/buildall.py` which then skips packages which are not in that list. By default, it includes all packages but it is possible to change this by the user.

Note that I haven't tested this yet. I'm also not sure how will this handle if package's dependencies are not included in the list, so this should also be tested.

It is related to #579, but I wouldn't close it as I would still like some way to build just packages, without building CPython, Emscripten SDK and Pyodide.

@rth Can you check this?