### PR TITLE
Update to use sdk-fastcomp-tag-<version> for emscripten

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ defaults: &defaults
   working_directory: ~/repo
   docker:
     - image: iodide/pyodide-env:0.3.1
+  environment:
+    - EMSDK_NUM_CORES: 4
+      EMCC_CORES: 4
 
 jobs:
   build:

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,6 +1,6 @@
 export EMSCRIPTEN_VERSION = 1.38.30
 
-export PATH := $(PYODIDE_ROOT)/ccache:$(PYODIDE_ROOT)/emsdk/emsdk:$(PYODIDE_ROOT)/emsdk/emsdk/clang/tag-e$(EMSCRIPTEN_VERSION)/build_tag-e$(EMSCRIPTEN_VERSION)_64/bin:$(PYODIDE_ROOT)/emsdk/emsdk/node/8.9.1_64bit/bin:$(PYODIDE_ROOT)/emsdk/emsdk/emscripten/tag-$(EMSCRIPTEN_VERSION):$(PYODIDE_ROOT)/emsdk/emsdk/binaryen/tag-$(EMSCRIPTEN_VERSION)_64bit_binaryen/bin:$(PATH)
+export PATH := $(PYODIDE_ROOT)/ccache:$(PYODIDE_ROOT)/emsdk/emsdk:$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp-clang/tag-e$(EMSCRIPTEN_VERSION)/build_tag-e$(EMSCRIPTEN_VERSION)_64/bin:$(PYODIDE_ROOT)/emsdk/emsdk/node/8.9.1_64bit/bin:$(PYODIDE_ROOT)/emsdk/emsdk/emscripten/tag-$(EMSCRIPTEN_VERSION):$(PYODIDE_ROOT)/emsdk/emsdk/binaryen/tag-$(EMSCRIPTEN_VERSION)_64bit_binaryen/bin:$(PATH)
 
 export EMSDK = $(PYODIDE_ROOT)/emsdk/emsdk
 export EM_CONFIG = $(PYODIDE_ROOT)/emsdk/emsdk/.emscripten

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -18,7 +18,7 @@ emsdk/.complete:
 		cd emsdk/binaryen/tag-$(EMSCRIPTEN_VERSION)_64bit_binaryen/ && \
     make && \
 	  cd ../../.. && \
-		cd emsdk/clang/tag-e$(EMSCRIPTEN_VERSION)/build_tag-e$(EMSCRIPTEN_VERSION)_64/ && \
+		cd emsdk/fastcomp-clang/tag-e$(EMSCRIPTEN_VERSION)/build_tag-e$(EMSCRIPTEN_VERSION)_64/ && \
     make && \
     cd ../../.. && \
 		./emsdk activate --embedded --build=Release sdk-fastcomp-tag-$(EMSCRIPTEN_VERSION)-64bit binaryen-tag-$(EMSCRIPTEN_VERSION)-64bit && \

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -12,7 +12,7 @@ emsdk/.complete:
 	sed -i -e "s#CPU_CORES = max(multiprocessing.cpu_count()-1, 1)#CPU_CORES = 3#g" emsdk/emsdk
 	( \
 		cd emsdk && \
-		./emsdk install --build=Release sdk-tag-$(EMSCRIPTEN_VERSION)-64bit binaryen-tag-$(EMSCRIPTEN_VERSION)-64bit && \
+		./emsdk install --build=Release sdk-fastcomp-tag-$(EMSCRIPTEN_VERSION)-64bit binaryen-tag-$(EMSCRIPTEN_VERSION)-64bit && \
 		cd .. && \
 		(cat patches/*.patch | patch -p1) && \
 		cd emsdk/binaryen/tag-$(EMSCRIPTEN_VERSION)_64bit_binaryen/ && \
@@ -21,7 +21,7 @@ emsdk/.complete:
 		cd emsdk/clang/tag-e$(EMSCRIPTEN_VERSION)/build_tag-e$(EMSCRIPTEN_VERSION)_64/ && \
     make && \
     cd ../../.. && \
-		./emsdk activate --embedded --build=Release sdk-tag-$(EMSCRIPTEN_VERSION)-64bit binaryen-tag-$(EMSCRIPTEN_VERSION)-64bit && \
+		./emsdk activate --embedded --build=Release sdk-fastcomp-tag-$(EMSCRIPTEN_VERSION)-64bit binaryen-tag-$(EMSCRIPTEN_VERSION)-64bit && \
     touch .complete \
 	)
 

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -3,13 +3,9 @@ include ../Makefile.envs
 
 all: emsdk/.complete
 
-# We hack the CPU_CORES, because if you use all of the cores on Circle-CI, you
-# run out of memory.
-
 emsdk/.complete:
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone https://github.com/juj/emsdk.git
-	sed -i -e "s#CPU_CORES = max(multiprocessing.cpu_count()-1, 1)#CPU_CORES = 3#g" emsdk/emsdk
 	( \
 		cd emsdk && \
 		./emsdk install --build=Release sdk-fastcomp-tag-$(EMSCRIPTEN_VERSION)-64bit binaryen-tag-$(EMSCRIPTEN_VERSION)-64bit && \

--- a/emsdk/clean_for_dist.sh
+++ b/emsdk/clean_for_dist.sh
@@ -5,7 +5,7 @@ find . -name "*.a" -type f -delete
 find -type d -name .git -prune -exec rm -rf {} \;
 find -type d -name CMakeFiles -prune -exec rm -rf {} \;
 rm -rf emsdk/emscripten/incoming/tests
-rm -rf emsdk/clang/fastcomp/src
+rm -rf emsdk/emsdk/fastcomp-clang/fastcomp/src
 rm -rf emsdk/zips
 rm -rf emsdk/binaryen/master/test
 rm -rf emsdk/.emscripten_cache

--- a/emsdk/patches/callHandlers.patch
+++ b/emsdk/patches/callHandlers.patch
@@ -1,8 +1,8 @@
 From https://github.com/emscripten-core/emscripten-fastcomp/pull/25 6
-diff --git a/emsdk/clang/tag-e1.38.30/src/lib/Target/JSBackend/CallHandlers.h b/emsdk/clang/tag-e1.38.30/src/lib/Target/JSBackend/CallHandlers.h
+diff --git a/emsdk/fastcomp-clang/tag-e1.38.30/src/lib/Target/JSBackend/CallHandlers.h b/emsdk/fastcomp-clang/tag-e1.38.30/src/lib/Target/JSBackend/CallHandlers.h
 index e414c0444a7..9c3ae3bf288 100644
---- a/emsdk/clang/tag-e1.38.80/src/lib/Target/JSBackend/CallHandlers.h
-+++ b/emsdk/clang/tag-e1.38.30/src/lib/Target/JSBackend/CallHandlers.h
+--- a/emsdk/fastcomp-clang/tag-e1.38.80/src/lib/Target/JSBackend/CallHandlers.h
++++ b/emsdk/fastcomp-clang/tag-e1.38.30/src/lib/Target/JSBackend/CallHandlers.h
 @@ -843,17 +843,21 @@ DEF_CALL_HANDLER(emscripten_asm_const_async_on_main_thread, {
  
  DEF_CALL_HANDLER(emscripten_atomic_exchange_u8, {


### PR DESCRIPTION
Because sdk-tag-<version> is no longer available upstream.