### PR TITLE
Show matplotlib figures in documents other than iodide notebooks

### DIFF
--- a/packages/matplotlib/src/wasm_backend.py
+++ b/packages/matplotlib/src/wasm_backend.py
@@ -107,7 +107,9 @@ class FigureCanvasWasm(backend_agg.FigureCanvasAgg):
             from js import iodide
             return iodide.output.element('div')
         except ImportError:
-            return document.createElement('div')
+            div = document.createElement('div')
+            document.body.appendChild(div)
+            return div
 
     def show(self):
         # If we've already shown this canvas elsewhere, don't create a new one,


### PR DESCRIPTION
The wasm_backend for matplotlib creates a div element by a iodide.output.element('div') call,
if that fails a plain div is created by a document.createElement('div') call. In the latter case the newly created div is never appended to the document and remains therefore invisible. 

This PR fixes that by adding a call to document.body.appendChild(div) after the creation of the div.
