### PR TITLE
Set TOTAL_MEMORY via self.TOTAL_MEMORY if present

### DIFF
--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -32,6 +32,11 @@ languagePluginLoader.then(() => {
 });
 ```
 
+Pyodide will allocate memory on initialization for itself, and will dynamically
+allocate more memory as necessary. If you wish to increase the amount of initial
+memory, set `self.TOTAL_MEMORY` appropriately. `self.TOTAL_MEMORY` must be a
+multiple of 64KB.
+
 ## Running Python code
 
 Python code is run using the `pyodide.runPython` function. It takes as input a

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -298,6 +298,9 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   Module.noAudioDecoding = true;
   Module.noWasmDecoding = true;
   Module.preloadedWasm = {};
+  if (self.TOTAL_MEMORY !== undefined) {
+    Module.TOTAL_MEMORY = self.TOTAL_MEMORY;
+  }
   let isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
   let wasm_promise;


### PR DESCRIPTION
This allows an application of pyodide to override the amount of memory
initially allocated. Combining this with reduction of the overall memory
allocated by default allows an application using pyodide to have more
explicit control over how much memory it is using.

Related to #600.