### PR TITLE
Upgrade to Python 3.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           root: .
           paths:
             - ./build
-            - ./cpython/build/3.7.0/host
+            - ./cpython/build/3.7.1/host
 
       - store_artifacts:
           path: /home/circleci/repo/build/
@@ -94,7 +94,7 @@ jobs:
       - run:
           name: benchmark
           command: |
-            python benchmark/benchmark.py cpython/build/3.7.0/host/bin/python3 build/benchmarks.json
+            python benchmark/benchmark.py cpython/build/3.7.1/host/bin/python3 build/benchmarks.json
       - store_artifacts:
           path: /home/circleci/repo/build/benchmarks.json
 

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -8,7 +8,7 @@ export EM_CACHE = $(PYODIDE_ROOT)/emsdk/emsdk/.emscripten_cache
 export EMSCRIPTEN = $(PYODIDE_ROOT)/emsdk/emsdk/emscripten/tag-$(EMSCRIPTEN_VERSION)
 export BINARYEN_ROOT = $(PYODIDE_ROOT)/emsdk/emsdk/binaryen/tag-$(EMSCRIPTEN_VERSION)_64bit_binaryen
 
-export PYVERSION=3.7.0
+export PYVERSION=3.7.1
 export PYMINOR=$(basename $(PYVERSION))
 export HOSTPYTHONROOT=$(PYODIDE_ROOT)/cpython/build/$(PYVERSION)/host
 export HOSTPYTHON=$(HOSTPYTHONROOT)/bin/python3

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -33,7 +33,7 @@ _sha256 sha256module.c
 _sha512 sha512module.c
 _sha3 _sha3/sha3module.c
 _md5 md5module.c
-_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c ../../host/Python-3.7.0/Modules/_blake2/blake2s_impl.c
+_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c ../../host/Python-3.7.1/Modules/_blake2/blake2s_impl.c
 
 _sqlite3 _sqlite/cache.c _sqlite/connection.c _sqlite/cursor.c _sqlite/microprotocols.c _sqlite/module.c _sqlite/prepare_protocol.c _sqlite/row.c _sqlite/statement.c _sqlite/util.c -I$(SQLITEBUILD) -L$(SQLITEBUILD) -lsqlite3
 _crypt _cryptmodule.c

--- a/cpython/checksums
+++ b/cpython/checksums
@@ -1,1 +1,1 @@
-41b6595deb4147a1ed517a7d9a580271  downloads/Python-3.7.0.tgz
+99f78ecbfc766ea449c4d9e7eda19e83  downloads/Python-3.7.1.tgz

--- a/cpython/patches/testing.patch
+++ b/cpython/patches/testing.patch
@@ -82,3 +82,30 @@ index 1fc4de11e1..e6c91707ae 100644
  import time
  import unittest
  import unittest.mock as mock
+diff --git a/Lib/test/test_gzip.py b/Lib/test/test_gzip.py
+--- a/Lib/test/test_gzip.py
++++ b/Lib/test/test_gzip.py
+@@ -13,6 +13,7 @@
+ from test import support
+ from test.support import _4G, bigmemtest
+ from test.support.script_helper import assert_python_ok
++import unittest
+ 
+ gzip = support.import_module('gzip')
+ 
+@@ -691,6 +692,7 @@
+     data = b'This is a simple test with gzip'
+ 
+     def test_decompress_stdin_stdout(self):
++        raise unittest.SkipTest('no subprocess')
+         with io.BytesIO() as bytes_io:
+             with gzip.GzipFile(fileobj=bytes_io, mode='wb') as gzip_file:
+                 gzip_file.write(self.data)
+@@ -727,6 +729,7 @@
+ 
+     @create_and_remove_directory(TEMPDIR)
+     def test_compress_stdin_outfile(self):
++        raise unittest.SkipTest('no subprocess')
+         args = sys.executable, '-m', 'gzip'
+         with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
+             out, err = proc.communicate(self.data)

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 
 ROOTDIR = Path(__file__).parents[1].resolve() / 'tools'
-HOSTPYTHON = ROOTDIR / '..' / 'cpython' / 'build' / '3.7.0' / 'host'
-TARGETPYTHON = ROOTDIR / '..' / 'cpython' / 'installs' / 'python-3.7.0'
+HOSTPYTHON = ROOTDIR / '..' / 'cpython' / 'build' / '3.7.1' / 'host'
+TARGETPYTHON = ROOTDIR / '..' / 'cpython' / 'installs' / 'python-3.7.1'
 DEFAULTCFLAGS = ''
 DEFAULTLDFLAGS = ' '.join([
     '-O3',

--- a/test/make_test_list.py
+++ b/test/make_test_list.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 TEST_DIR = (Path(__file__).parent
-            / "cpython/build/3.7.0/host/lib/python3.7/test")
+            / "cpython/build/3.7.1/host/lib/python3.7/test")
 
 
 def collect_tests(base_dir):

--- a/test/python_tests.txt
+++ b/test/python_tests.txt
@@ -48,13 +48,17 @@ test_ast
 test_asyncgen async
 test_asynchat async
 test_asyncio.test_base_events async
+test_asyncio.test_buffered_proto
+test_asyncio.test_context
 test_asyncio.test_events      async
 test_asyncio.test_futures     async
 test_asyncio.test_locks       async
 test_asyncio.test_pep492
 test_asyncio.test_proactor_events
 test_asyncio.test_queues
+test_asyncio.test_runners
 test_asyncio.test_selector_events async segfault-socketcall
+test_asyncio.test_server
 test_asyncio.test_sslproto
 test_asyncio.test_streams         async
 test_asyncio.test_subprocess      async

--- a/test/python_tests.txt
+++ b/test/python_tests.txt
@@ -48,17 +48,17 @@ test_ast
 test_asyncgen async
 test_asynchat async
 test_asyncio.test_base_events async
-test_asyncio.test_buffered_proto
-test_asyncio.test_context
-test_asyncio.test_events      async
-test_asyncio.test_futures     async
-test_asyncio.test_locks       async
+test_asyncio.test_buffered_proto  async
+test_asyncio.test_context         async
+test_asyncio.test_events          async
+test_asyncio.test_futures         async
+test_asyncio.test_locks           async
 test_asyncio.test_pep492
 test_asyncio.test_proactor_events
 test_asyncio.test_queues
 test_asyncio.test_runners
 test_asyncio.test_selector_events async segfault-socketcall
-test_asyncio.test_server
+test_asyncio.test_server          async
 test_asyncio.test_sslproto
 test_asyncio.test_streams         async
 test_asyncio.test_subprocess      async


### PR DESCRIPTION
https://github.com/iodide-project/pyodide/pull/594 tries to upgrade from Python 3.7.0 to 3.7.6.  The direct path results in a bunch of tests failing for what I believe are multiple different reasons.  

I'm not familiar enough with this codebase to feel comfortable tackling all of those issues in one shot myself.  So I propose to take a more incremental approach.

Several of the patch versions between 3.7.0 and 3.7.6 appear to introduce distinct test failures.  So, one at a time?

This PR upgrades from Python 3.7.0 to 3.7.1.  It also handles two test failures that are introduced by this upgrade.  If y'all would be willing, I would appreciate a review on whether this is the correct approach.