### PR TITLE
allow micropip to function in a web worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - New package: `nltk`
 
+- `micropip` can now be used from web workers.
+
 ## Version 0.13.0
 
 - Tagged versions of Pyodide are now deployed to Netlify.

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -1,7 +1,7 @@
 try:
-    from js import Promise, window, XMLHttpRequest
+    from js import Promise, XMLHttpRequest
 except ImportError:
-    window = None
+    XMLHttpRequest = None
 from js import pyodide as js_pyodide
 
 import hashlib
@@ -20,7 +20,7 @@ def _nullop(*args):
 
 # Provide implementations of HTTP fetching for in-browser and out-of-browser to
 # make testing easier
-if window is not None:
+if XMLHttpRequest is not None:
     import pyodide
 
     def _get_url(url):

--- a/test/test_webworker.py
+++ b/test/test_webworker.py
@@ -67,3 +67,17 @@ def test_runwebworker_exception_after_import(selenium_standalone):
         assert "ZeroDivisionError" in str(e)
     else:
         assert False
+
+
+def test_runwebworker_micropip(selenium_standalone):
+    output = selenium_standalone.run_webworker(
+        """
+        def stem(*args):
+            import snowballstemmer
+            stemmer = snowballstemmer.stemmer('english')
+            return stemmer.stemWords('go goes going gone'.split())[0]
+        import micropip
+        micropip.install('snowballstemmer').then(stem)
+        """
+    )
+    assert output == 'go'


### PR DESCRIPTION
Without this change, `micropip.install('snowballstemmer')` would fail with
```
uncaught exception: <urlopen error unknown url type: https>