### PR TITLE
BLD include lz4 in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ clean:
 	make -C six clean
 	make -C jedi clean
 	make -C parso clean
+	make -C lz4 clean
 	echo "The Emsdk, CPython and CLAPACK are not cleaned. cd into those directories to do so."
 
 


### PR DESCRIPTION
Fixes a minor issue where `make clean` didn't clean up the `lz4` folder (and also didn't inform the user it needed to be cleaned manyally).