### PR TITLE
Remove distutils windows installers in stdlib

### DIFF
--- a/remove_modules.txt
+++ b/remove_modules.txt
@@ -10,3 +10,4 @@ tkinter
 turtle.py
 turtledemo
 venv
+distutils/command/wininst-*.exe


### PR DESCRIPTION
Addresses one point of https://github.com/iodide-project/pyodide/issues/646

Removes, the distutils windows installers included in the stdlib,
```
$ du -sh Lib/distutils/command/wininst-*
220K    Lib/distutils/command/wininst-10.0-amd64.exe
188K    Lib/distutils/command/wininst-10.0.exe
576K    Lib/distutils/command/wininst-14.0-amd64.exe
448K    Lib/distutils/command/wininst-14.0.exe
60K     Lib/distutils/command/wininst-6.0.exe
64K     Lib/distutils/command/wininst-7.1.exe
60K     Lib/distutils/command/wininst-8.0.exe
220K    Lib/distutils/command/wininst-9.0-amd64.exe
192K    Lib/distutils/command/wininst-9.0.exe
```

This reduces the size of `pyodide.asm.data` from 8.1MB to 6.6MB