### PR TITLE
Remove CORS proxy in micropip

### DIFF
--- a/docs/pypi.md
+++ b/docs/pypi.md
@@ -2,15 +2,6 @@
 
 Pyodide has experimental support for installing pure Python wheels from PyPI.
 
-**IMPORTANT:** Since the packages hosted at `files.pythonhosted.org` don't
-support CORS requests, we use a CORS proxy at `cors-anywhere.herokuapp.com` to
-get package contents. This makes a man-in-the-middle attack on the package
-contents possible. However, this threat is minimized by the fact that the
-integrity of each package is checked using a hash obtained directly from
-`pypi.org`. We hope to have this improved in the future, but for now, understand
-the risks and don't use any sensitive data with the packages installed using
-this method.
-
 For use in Iodide:
 
 ```

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -93,7 +93,7 @@ class _WheelInstaller:
 
 class _RawWheelInstaller(_WheelInstaller):
     def fetch_wheel(self, name, fileinfo):
-        return 'https://cors-anywhere.herokuapp.com/' + fileinfo['url']
+        return fileinfo['url']
 
 
 class _PackageManager:
@@ -229,15 +229,6 @@ def install(requirements):
 
     Returns a Promise that resolves when all packages have downloaded and
     installed.
-
-    **IMPORTANT:** Since the packages hosted at `files.pythonhosted.org` don't
-    support CORS requests, we use a CORS proxy at `cors-anywhere.herokuapp.com`
-    to get package contents. This makes a man-in-the-middle attack on the
-    package contents possible. However, this threat is minimized by the fact
-    that the integrity of each package is checked using a hash obtained
-    directly from `pypi.org`. We hope to have this improved in the future, but
-    for now, understand the risks and don't use any sensitive data with the
-    packages installed using this method.
     """
     def do_install(resolve, reject):
         PACKAGE_MANAGER.install(

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -12,7 +12,7 @@ def test_install_simple(selenium_standalone):
     for i in range(10):
         if selenium_standalone.run(
                 "os.path.exists"
-                "('/lib/python3.6/site-packages/snowballstemmer')"
+                "('/lib/python3.7/site-packages/snowballstemmer')"
         ):
             break
         else:


### PR DESCRIPTION
This removes the use of a third party CORS proxy to install packages from PyPi, since `files.pythonhosted.org` now sets `access-control-allow-origin: *` following https://github.com/pypa/conveyor/issues/5

I have also checked locally that's it's working as expected. This is a good news security wise.

Closes https://github.com/iodide-project/pyodide/issues/649