### PR TITLE
Add PYODIDE_MINIMAL build option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           no_output_timeout: 1200
           command: |
             ccache -z
-            PYODIDE_PACKAGES='micropip' make
+            PYODIDE_MINIMAL=true PYODIDE_PACKAGES='micropip' make
             ccache -s
 
       - run:

--- a/docs/building_from_sources.md
+++ b/docs/building_from_sources.md
@@ -34,7 +34,7 @@ PYODIDE_MINIMAL=true PYODIDE_PACKAGES="micropip" make
 ```
 
 This will,
- - not include freetype and libpng libraries, meaning that matplotlib cannot be built
+ - not include freetype and libpng libraries (it won't be possible to build matplotlib)
  - not include the jedi library, disabling auto-completion in iodide
 
 As as a result the size will of the core pyodide binaries will be ~15% smaller.

--- a/docs/building_from_sources.md
+++ b/docs/building_from_sources.md
@@ -24,3 +24,17 @@ micropip and package is generally always included for any non empty value of
 
 If scipy is included in `PYODIDE_PACKAGES`, BLAS/LAPACK must be manually built
 first with `make -c CLAPACK`.
+
+## Minimal build
+
+Minimal pyodide build can be enabled by setting the `PYODIDE_MINIMAL`
+environment variable.  For instance,
+```
+PYODIDE_MINIMAL=true PYODIDE_PACKAGES="micropip" make
+```
+
+This will,
+ - not include freetype and libpng libraries, meaning that matplotlib cannot be built
+ - not include the jedi library, disabling auto-completion in iodide
+
+As as a result the size will of the core pyodide binaries will be ~15% smaller.


### PR DESCRIPTION
From the added documentation,

> Minimal pyodide build can be enabled by setting the `PYODIDE_MINIMAL`
environment variable.  For instance,
> ```            
> PYODIDE_MINIMAL=true PYODIDE_PACKAGES="micropip" make
> ```            
>                
> This will,
>  - not include freetype and libpng libraries (it won't be possible to build matplotlib)
>  - not include the jedi library, disabling auto-completion in iodide
> 
> As as a result the size will of the core pyodide binaries will be ~15% smaller.

Addresses two points from https://github.com/iodide-project/pyodide/issues/646

Before (master),
```
6,6M  pyodide.asm.data
310K  pyodide.asm.data.js
2,8M  pyodide.asm.js
 11M  pyodide.asm.wasm
 16K  pyodide.js
 16K  pyodide_dev.js

Total: 20.7 MB
```
after (this PR with PYODIDE_MINIMAL=true)
```
5,1M  build/pyodide.asm.data
124K  build/pyodide.asm.data.js
2,6M  build/pyodide.asm.js
9,9M  build/pyodide.asm.wasm
 16K  build/pyodide.js
 16K  build/pyodide_dev.js

Total: 17.7 MB
```

so it's not that different (14% less), but it's start. 

Draft PR for now, as I think I need to go in a bit more details through tests that are run in the minimal build CI job.