### PR TITLE
Add deployment setup for pyodide-cdn2.iodide.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,18 +148,18 @@ jobs:
           command: |
             apk add --no-cache --update python3
             python3 -m pip install awscli
-      - run:
-          name: Deploy Github Releases
-          command: |
-            pushd build
-            tar cjf ../pyodide-build-${CIRCLE_TAG}.tar.bz2 *
-            popd
-            ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
+      #- run:
+      #    name: Deploy Github Releases
+      #    command: |
+      #      pushd build
+      #      tar cjf ../pyodide-build-${CIRCLE_TAG}.tar.bz2 *
+      #      popd
+      #      ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
 
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
           command: |
-            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --cache-control max-age=30758400  # 1 year
+            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/v0.14.3/full/" --cache-control max-age=30758400  # 1 year
             # update 301 redirect for the /latest/* route.
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
@@ -180,11 +180,11 @@ jobs:
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
             aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/dev/full/" --cache-control max-age=3600  # 1 hour
-      - run:
-          name: Deploy to netlify
-          command: |
-            cp src/_headers build
-            netlify deploy --prod --dir=build -m "Deployed from CircleCI"
+      #- run:
+      #    name: Deploy to netlify
+      #    command: |
+      #      cp src/_headers build
+      #      netlify deploy --prod --dir=build -m "Deployed from CircleCI"
 
 workflows:
   version: 2
@@ -215,17 +215,17 @@ workflows:
           requires:
             - test-firefox
             - test-python
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
+          #filters:
+          #  branches:
+          #    ignore: /.*/
+          #  tags:
+          #    only: /^\d+\.\d+\.\d+$/
       - deploy-netlify:
           requires:
             - test-firefox
             - test-python
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
+          #filters:
+          #  branches:
+          #    ignore: /.*/
+          #  tags:
+          #    only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,7 @@ jobs:
             python3 -m pip install awscli
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
+          command: |
             aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/dev/full/" --cache-control max-age=3600  # 1 hour
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,11 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Install requirements
+          command: |
+            apk add --no-cache --update python3
+            python3 -m pip install awscli
+      - run:
           name: Deploy Github Releases
           command: |
             pushd build
@@ -154,10 +159,9 @@ jobs:
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
           command: |
-            pip install awscli
-            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/${CIRCLE_TAG}/full/" --cache-control max-age=30758400
+            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --cache-control max-age=30758400  # 1 year
             # update 301 redirect for the /latest/* route.
-            aws s3api put-bucket-website --cli-input-json .circleci/s3-website-config.json
+            aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
   deploy-netlify:
     docker:
@@ -168,18 +172,19 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Install netlify-cli
+          name: Install requirements
           command: |
             sudo npm install netlify-cli -g
+            sudo apt install -y python3-pip
+            python3 -m pip install awscli
+      - run:
+          name: Deploy to pyodide-cdn2.iodide.io
+            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/dev/full/" --cache-control max-age=3600  # 1 hour
       - run:
           name: Deploy to netlify
           command: |
             cp src/_headers build
             netlify deploy --prod --dir=build -m "Deployed from CircleCI"
-      - run:
-          name: Deploy to pyodide-cdn2.iodide.io
-            pip install awscli
-            aws s3 sync --delete . "s3://pyodide-cdn2.iodide.io/dev/full/" --cache-control max-age=60
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,19 +172,30 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Install requirements
+          name: Install netlify-cli
           command: |
             sudo npm install netlify-cli -g
-            sudo apt install -y python3-pip
+      - run:
+          name: Deploy to netlify
+          command: |
+            cp src/_headers build
+            netlify deploy --prod --dir=build -m "Deployed from CircleCI"
+
+  deploy-s3:
+    docker:
+      - image: circleci/python:3.3.7
+
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install requirements
+          command: |
             python3 -m pip install awscli
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
             aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/dev/full/" --cache-control max-age=3600  # 1 hour
-      #- run:
-      #    name: Deploy to netlify
-      #    command: |
-      #      cp src/_headers build
-      #      netlify deploy --prod --dir=build -m "Deployed from CircleCI"
 
 workflows:
   version: 2
@@ -224,8 +235,15 @@ workflows:
           requires:
             - test-firefox
             - test-python
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+      - deploy-s3:
+          requires:
+            - test-firefox
+            - test-python
           #filters:
           #  branches:
-          #    ignore: /.*/
-          #  tags:
-          #    only: /^\d+\.\d+\.\d+$/
+          #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,14 @@ jobs:
             popd
             ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
 
+      - run:
+          name: Deploy to pyodide-cdn2.iodide.io
+          command: |
+            pip install awscli
+            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/${CIRCLE_TAG}/full/" --cache-control max-age=30758400
+            # update 301 redirect for the /latest/* route.
+            aws s3api put-bucket-website --cli-input-json .circleci/s3-website-config.json
+
   deploy-netlify:
     docker:
       - image: circleci/node:latest
@@ -168,6 +176,10 @@ jobs:
           command: |
             cp src/_headers build
             netlify deploy --prod --dir=build -m "Deployed from CircleCI"
+      - run:
+          name: Deploy to pyodide-cdn2.iodide.io
+            pip install awscli
+            aws s3 sync --delete . "s3://pyodide-cdn2.iodide.io/dev/full/" --cache-control max-age=60
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
 
   deploy-s3:
     docker:
-      - image: circleci/python:3.3.7
+      - image: circleci/python:3.7.7
 
     steps:
       - checkout
@@ -192,6 +192,7 @@ jobs:
       - run:
           name: Install requirements
           command: |
+            sudo apt-get install -y groff
             python3 -m pip install awscli
       - run:
           name: Deploy to pyodide-cdn2.iodide.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,18 +148,18 @@ jobs:
           command: |
             apk add --no-cache --update python3
             python3 -m pip install awscli
-      #- run:
-      #    name: Deploy Github Releases
-      #    command: |
-      #      pushd build
-      #      tar cjf ../pyodide-build-${CIRCLE_TAG}.tar.bz2 *
-      #      popd
-      #      ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
+      - run:
+          name: Deploy Github Releases
+          command: |
+            pushd build
+            tar cjf ../pyodide-build-${CIRCLE_TAG}.tar.bz2 *
+            popd
+            ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
 
       - run:
           name: Deploy to pyodide-cdn2.iodide.io
           command: |
-            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/v0.14.3/full/" --cache-control max-age=30758400  # 1 year
+            aws s3 sync --delete build/ "s3://pyodide-cdn2.iodide.io/v${CIRCLE_TAG}/full/" --cache-control max-age=30758400  # 1 year
             # update 301 redirect for the /latest/* route.
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
@@ -228,11 +228,11 @@ workflows:
           requires:
             - test-firefox
             - test-python
-          #filters:
-          #  branches:
-          #    ignore: /.*/
-          #  tags:
-          #    only: /^\d+\.\d+\.\d+$/
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - deploy-netlify:
           requires:
             - test-firefox
@@ -246,6 +246,6 @@ workflows:
           requires:
             - test-firefox
             - test-python
-          #filters:
-          #  branches:
-          #    only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,24 +163,6 @@ jobs:
             # update 301 redirect for the /latest/* route.
             aws s3api put-bucket-website --cli-input-json file://.circleci/s3-website-config.json
 
-  deploy-netlify:
-    docker:
-      - image: circleci/node:latest
-
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Install netlify-cli
-          command: |
-            sudo npm install netlify-cli -g
-      - run:
-          name: Deploy to netlify
-          command: |
-            cp src/_headers build
-            netlify deploy --prod --dir=build -m "Deployed from CircleCI"
-
   deploy-s3:
     docker:
       - image: circleci/python:3.7.7
@@ -225,15 +207,6 @@ workflows:
           requires:
             - build
       - deploy-release:
-          requires:
-            - test-firefox
-            - test-python
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-      - deploy-netlify:
           requires:
             - test-firefox
             - test-python

--- a/.circleci/s3-website-config.json
+++ b/.circleci/s3-website-config.json
@@ -1,0 +1,18 @@
+{
+    "Bucket": "pyodide-cdn2.iodide.io",
+    "WebsiteConfiguration": {
+        "IndexDocument": {
+            "Suffix": "index.html"
+        },
+        "RoutingRules": [
+            {
+                "Condition": {
+                    "KeyPrefixEquals": "latest/"
+                },
+                "Redirect": {
+                    "ReplaceKeyPrefixWith": "v0.14.3/"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/651

This aims to deploy to,
 - to `pyodide-cdn2.iodide.io/dev/full/` for each commit on master ~alongside Netlify~
 - to `pyodide-cdn2.iodide.io/<version>/full/` for tags/releases. During releases it also puts in place a 301 redirect from `/latest/full/` to `/<version>/full/`

The idea is to deploy the minimal build at some point in the future under `/<version>/minimal/` as well, but for now only the default build should be enough.