### PR TITLE
Update changelog, minor doc fixes and CDN URL updates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.14.3
 commit = True
 tag = True
 tag_name = {new_version}
@@ -8,3 +8,10 @@ tag_name = {new_version}
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
+[bumpversion:file:docs/pypi.md]
+search = iodide.io/v'{current_version}'
+replace = iodide.io/v'{new_version}'
+
+[bumpversion:file:docs/using_pyodide_from_javascript.md]
+search = iodide.io/v'{current_version}'
+replace = iodide.io/v'{new_version}'

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,6 +1,6 @@
-# IODIDE CODE of CONDUCT
+# Iodide Code of Conduct
 
-## CONDUCT
+## Conduct
 
 We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 
@@ -13,7 +13,7 @@ We are committed to providing a friendly, safe and welcoming environment for all
 - Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the IODIDE core team members immediately. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
-## MODERATION
+## Moderation
 
 These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs moderation, please contact the IODIDE core team.
 
@@ -29,4 +29,4 @@ These are the policies for upholding our community’s standards of conduct. If 
 10. And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could’ve communicated better — remember that it’s your responsibility to make your fellow IODIDE community members comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about science and cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 11. The enforcement policies listed above apply to all official IODIDE venues.  If you wish to use this code of conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your own moderation policy so as to avoid confusion.
 
-_Adapted from the the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html), with further reference from [Digital Ocean Code of Conduct](https://github.com/digitalocean/engineering-code-of-conduct#giving-and-receiving-feedback), the [Recurse Center](https://www.recurse.com/code-of-conduct), the [Citizen Code of Conduct](http://citizencodeofconduct.org/), and the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)._
+Adapted from the the [Rust Code of Conduct](https://www.rust-lang.org/en-US/conduct.html), with further reference from [Digital Ocean Code of Conduct](https://github.com/digitalocean/engineering-code-of-conduct#giving-and-receiving-feedback), the [Recurse Center](https://www.recurse.com/code-of-conduct), the [Citizen Code of Conduct](http://citizencodeofconduct.org/), and the [Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)._

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build/pyodide_dev.js: src/pyodide.js
 
 build/pyodide.js: src/pyodide.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/#g' $@
 
 	sed -i -e "s#{{ABI}}#$(PYODIDE_PACKAGE_ABI)#g" $@
 
@@ -121,7 +121,7 @@ build/renderedhtml.css: src/renderedhtml.less
 
 build/webworker.js: src/webworker.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/#g' $@
 
 build/webworker_dev.js: src/webworker.js
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build/pyodide_dev.js: src/pyodide.js
 
 build/pyodide.js: src/pyodide.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.14.3/full/#g' $@
 
 	sed -i -e "s#{{ABI}}#$(PYODIDE_PACKAGE_ABI)#g" $@
 
@@ -121,7 +121,7 @@ build/renderedhtml.css: src/renderedhtml.less
 
 build/webworker.js: src/webworker.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.14.3/full/#g' $@
 
 build/webworker_dev.js: src/webworker.js
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build/pyodide_dev.js: src/pyodide.js
 
 build/pyodide.js: src/pyodide.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide.cdn.iodide.io/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js/#g' $@
 
 	sed -i -e "s#{{ABI}}#$(PYODIDE_PACKAGE_ABI)#g" $@
 
@@ -121,7 +121,7 @@ build/renderedhtml.css: src/renderedhtml.less
 
 build/webworker.js: src/webworker.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide.cdn.iodide.io/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js/#g' $@
 
 build/webworker_dev.js: src/webworker.js
 	cp $< $@

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ build/pyodide.asm.data: root/.built
 
 build/pyodide_dev.js: src/pyodide.js
 	cp $< $@
-	sed -i -e "s#{{DEPLOY}}##g" $@
+	sed -i -e "s#{{DEPLOY}}#./#g" $@
 	sed -i -e "s#{{ABI}}#$(PYODIDE_PACKAGE_ABI)#g" $@
 
 
@@ -125,7 +125,7 @@ build/webworker.js: src/webworker.js
 
 build/webworker_dev.js: src/webworker.js
 	cp $< $@
-	sed -i -e "s#{{DEPLOY}}##g" $@
+	sed -i -e "s#{{DEPLOY}}#./#g" $@
 	sed -i -e "s#pyodide.js#pyodide_dev.js#g" $@
 
 test: all

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ browser**.
 ## Try Pyodide (no installation needed)
 
 Try the [iodide demo notebook](https://alpha.iodide.io/notebooks/300/) or fire
-up a [Python REPL](https://pyodide.cdn.iodide.io/console.html) directly in your
+up a [Python REPL](https://pyodide-cdn2.iodide.io/latest/full/console.html) directly in your
 browser.
 
 For further information, look through the [documentation](https://pyodide.readthedocs.io/).

--- a/docs/building_from_sources.md
+++ b/docs/building_from_sources.md
@@ -4,6 +4,8 @@ Building is easiest on Linux and relatively straightforward on Mac. For
 Windows, we currently recommend using the Docker image (described below) to
 build Pyodide.
 
+## Build using `make`
+
 Make sure the prerequisites for [emsdk](https://github.com/emscripten-core/emsdk) are
 installed. Pyodide will build a custom, patched version of emsdk, so there is no
 need to build it yourself prior.
@@ -30,7 +32,6 @@ On Mac, you will also need:
 - gfortran (`brew cask install gfortran`)
 - f2c: Install wget (`brew install wget`), and then run the buildf2c script from the root directory (`sudo ./tools/buildf2c`)
 
-#### Build using `make`
 
 After installing the build prerequisites, run from the command line:
 
@@ -38,7 +39,7 @@ After installing the build prerequisites, run from the command line:
 make
 ```
 
-### Using Docker
+## Using Docker
 
 We provide a Debian-based Docker image on Docker Hub with the dependencies
 already installed to make it easier to build Pyodide. Note that building from

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,18 +1,48 @@
 # Release notes
 
-## Unreleased
+## Version 0.15.0
+*May 19, 2020*
+
+- Upgrades pyodide to use CPython 3.7.4.
+- micropip no longer uses a CORS proxy to install pure Python packages from
+  PyPi. Packages are now installed from PyPi directly.
+- micropip can now be used from web workers.
+- Adds support for installing pure Python wheels from arbitrary URLs with micropip. 
+- The CDN URL for pyodide changed to
+  https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js
+  It now supports versioning and should provide faster downloads. The latest release
+  can be accessed via `https://pyodide-cdn2.iodide.io/latest/full/`
+- Adds `messageCallback` and `errorCallback` to `pyodide.loadPackage`.
+- Reduces the initial memory footprint (`TOTAL_MEMORY`) from 1 GiB to 5 MiB. More
+  memory will be allocated as needed.
+- When building from source, only a subset of packages can be built by setting
+  the `PYODIDE_PACKAGES` environment variable. See
+  [partial builds documentation](https://pyodide.readthedocs.io/en/latest/building_from_sources.html#partial-builds)
+  for more details.
+- New packages: future, autograd
+
+## Version 0.14.3
+*Dec 11, 2019*
+
+- Convert JavaScript numbers containing integers, e.g. `3.0`, to a real Python
+  long (e.g. `3`).
+- Adds `__bool__` method to for `JsProxy` objects.
+- Adds a Javascript-side auto completion function for Iodide that uses jedi.
+- New packages: nltk, jeudi, statsmodels, regex, cytoolz, xlrd, uncertainties
+
+## Version 0.14.0
+*Aug 14, 2019*
 
 - The built-in `sqlite` and `bz2` modules of Python are now enabled.
-
-- New package: `nltk`
-
-- `micropip` can now be used from web workers.
+- Adds support for auto-completion based on jedi when used in iodide
 
 ## Version 0.13.0
+*May 31, 2019*
 
 - Tagged versions of Pyodide are now deployed to Netlify.
 
 ## Version 0.12.0
+*May 3, 2019*
 
 **User improvements:**
 
@@ -33,6 +63,7 @@
 - Pyodide now works on Safari.
 
 ## Version 0.11.0
+*Apr 12, 2019*
 
 **User improvements:**
 
@@ -52,6 +83,7 @@
 - New packages: `jinja2`, `MarkupSafe`
 
 ## Version 0.10.0
+*Mar 21, 2019*
 
 **User improvements:**
 

--- a/docs/pypi.md
+++ b/docs/pypi.md
@@ -71,7 +71,11 @@ javascript"](./using_pyodide_from_javascript.html) a complete example would be,
   <meta charset="utf-8">
 </head>
 <body>
-  <script type="text/javascript" src="https://pyodide.cdn.iodide.io/pyodide.js"></script>
+  <script type="text/javascript">
+      // set the pyodide files URL (packages.json, pyodide.asm.data etc)
+      window.languagePluginUrl = 'https://pyodide-cdn2.iodide.io/v0.14.3/full/';
+  </script>
+  <script type="text/javascript" src="https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js"></script>
   <script type="text/javascript">
     pythonCode = `
       def do_work(*args):

--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -6,23 +6,20 @@ Iodide](using_pyodide_from_iodide.md).
 
 ## Startup
 
-Include `pyodide.js` in your project.
+To include Pyodide in your project you can use the following CDN URL,
 
-The recommended way to include Pyodide in your project is to download a release
-from [here](https://github.com/iodide-project/pyodide/releases) and include the
-contents in your distribution, and import the `pyodide.js` file there from a
-`<script>` tag.
+  https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js
 
-For prototyping purposes, you may also use the following CDN URL, though doing
-so is not recommended, since it isn't versioned and could change or be unstable
-at any time:
+You can also download a release from
+[Github releases](https://github.com/iodide-project/pyodide/releases)
+(or build it yourself), include its contents in your distribution, and import
+the `pyodide.js` file there from a `<script>` tag. See the following section on
+[serving pyodide files](./#serving-pyodide-files) for more details.
 
-  https://pyodide.cdn.iodide.io/pyodide.js
-
-This file has a single `Promise` object which bootstraps the Python environment:
-`languagePluginLoader`. Since this must happen asynchronously, it is a
-`Promise`, which you must call `then` on to complete initialization. When the
-promise resolves, pyodide will have installed a namespace in global scope:
+The `pyodide.js` file has a single `Promise` object which bootstraps the Python
+environment: `languagePluginLoader`. Since this must happen asynchronously, it
+is a `Promise`, which you must call `then` on to complete initialization. When
+the promise resolves, pyodide will have installed a namespace in global scope:
 `pyodide`.
 
 ```javascript
@@ -41,6 +38,31 @@ conversions](type_conversions.md)).
 
 ```javascript
 pyodide.runPython('import sys\nsys.version');
+```
+
+## Complete example
+
+Create and save a test `index.html` page with the following contents:
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <script type="text/javascript">
+        // set the pyodide files URL (packages.json, pyodide.asm.data etc)
+        window.languagePluginUrl = 'https://pyodide-cdn2.iodide.io/v0.14.3/full/';
+    </script>
+    <script src="https://pyodide-cdn2.iodide.io/v0.14.3/full/pyodide.js"></script>
+</head>
+<body>
+  Pyodide test page <br>
+  Open your browser console to see pyodide output
+  <script type="text/javascript">
+        languagePluginLoader.then(function () {
+            console.log(pyodide.runPython('import sys\nsys.version'));
+            console.log(pyodide.runPython('print(1 + 2)'));
+        });
+  </script>
+</body>
 ```
 
 ## Loading packages
@@ -73,35 +95,10 @@ pyodide.loadPackage('matplotlib').then(() => {
 });
 ```
 
-## Complete example
+## Serving pyodide files
 
-Grab the latest release tarball from the [releases
-page](https://github.com/iodide-project/pyodide/releases/) and expand its
-contents into a `pyodide_local` directory.
-
-Create and save a test `index.html` page (in the `pyodide_local` directory)
-with the following contents:
-```html
-<!DOCTYPE html>
-<html>
-<head>
-    <script type="text/javascript">
-        // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-        window.languagePluginUrl = 'http://localhost:8000/';
-    </script>
-    <script src="pyodide.js"></script>
-</head>
-<body>
-  Pyodide test page <br>
-  Open your browser console to see pyodide output
-  <script type="text/javascript">
-        languagePluginLoader.then(function () {
-            console.log(pyodide.runPython('import sys\nsys.version'));
-            console.log(pyodide.runPython('print(1 + 2)'));
-        });
-  </script>
-</body>
-```
+If you built your pyodide distribution or downloaded the release tarball
+you need to serve pyodide files with a appropriate headers.
 
 Because browsers require WebAssembly files to have mimetype of
 `application/wasm` we're unable to serve our files using Python's built-in


### PR DESCRIPTION
In preparation for the release https://github.com/iodide-project/pyodide/issues/644,
 - updates changelog 
 - minor documentation improvements
 - uses the new CDN URL.

I'll replace all occurrences of 0.14.3 with 0.15.0 (including the docs) when bumping version.

I think it's OK to suggest using this CDN URL as a first option in the "Using Pyodide with Javascript" guide (updated in this PR), now that we have versioning. Previously we suggested to download the the release from Github as a first option, but then one needs to correctly set content-type and if applicable CORS headers on the server which makes starting more complicated. We are not making any service availability promises, but it should work with mostly no maintenance on our part, and it would be a bit more user friendly.   WDYT @wlach ?