### PR TITLE
Add package freesasa and add biopython missing requirement

### DIFF
--- a/packages/biopython/meta.yaml
+++ b/packages/biopython/meta.yaml
@@ -4,6 +4,9 @@ package:
 source:
   sha256: 5060e4ef29c2bc214749733634051be5b8d11686c6590fa155c3443dcaa89906
   url: https://files.pythonhosted.org/packages/33/55/becf2b99556588d22b542f3412990bfc79b674e198d9bc58f7bbc333439e/biopython-1.75.tar.gz
+requirements:
+  run:
+    - numpy
 test:
   imports:
-  - Bio
+    - Bio

--- a/packages/freesasa/meta.yaml
+++ b/packages/freesasa/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: freesasa
+  version: 2.0.5.post2
+source:
+  sha256: 742ab294028ca3892bb3d6c36d59f7c4f3874357571d4cd3cb0705d2f98a201f
+  url: https://files.pythonhosted.org/packages/2b/99/a3e11d5cfe3e8f54ff721acfa75fa62a97ffc572a2b4ba6bfb022cc02526/freesasa-2.0.5.post2.tar.gz
+test:
+  imports:
+  - freesasa


### PR DESCRIPTION
Solving Issue #691 

No patch required to function correctly.

![image](https://user-images.githubusercontent.com/8457324/85916413-9354e200-b88b-11ea-8034-00208cb209ec.png)

Executed on the iodide/pyodide-env docker container