### PR TITLE
Update to numpy 1.15.4 and pandas 1.0.5

### DIFF
--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: numpy
-  version: 1.15.1
+  version: 1.15.4
 
 source:
-  url: https://files.pythonhosted.org/packages/65/ab/4dfcc20234fae12ee40c714b98077d6e3a10652496bd1488fa4828529b22/numpy-1.15.1.zip
-  sha256: 7b9e37f194f8bcdca8e9e6af92e2cbad79e360542effc2dd6b98d63955d8d8a3
+  url: https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip
+  sha256: 3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7
 
   patches:
     - patches/add-emscripten-cpu.patch

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pandas
-  version: 0.23.4
+  version: 0.25.3
 
 source:
-  url: https://files.pythonhosted.org/packages/e9/ad/5e92ba493eff96055a23b0a1323a9a803af71ec859ae3243ced86fcbd0a4/pandas-0.23.4.tar.gz
-  sha256: 5b24ca47acf69222e82530e89111dd9d14f9b970ab2cd3a1c2c78f0c4fbba4f4
+  url: https://files.pythonhosted.org/packages/b7/93/b544dd08092b457d88e10fc1e0989d9397fd32ca936fdfcbb2584178dd2b/pandas-0.25.3.tar.gz
+  sha256: 52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4
 
 build:
   cflags: -Wno-implicit-function-declaration

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pandas
-  version: 0.25.3
+  version: 1.0.5
 
 source:
-  url: https://files.pythonhosted.org/packages/b7/93/b544dd08092b457d88e10fc1e0989d9397fd32ca936fdfcbb2584178dd2b/pandas-0.25.3.tar.gz
-  sha256: 52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4
+  url: https://files.pythonhosted.org/packages/31/29/ede692aa6547dfc1f07a4d69e8411b35225218bcfbe9787e78b67a35d103/pandas-1.0.5.tar.gz
+  sha256: 69c5d920a0b2a9838e677f78f4dde506b95ea8e4d30da25859db6469ded84fa8
 
 build:
   cflags: -Wno-implicit-function-declaration

--- a/packages/pandas/test_pandas.py
+++ b/packages/pandas/test_pandas.py
@@ -6,7 +6,7 @@ def test_pandas(selenium, request):
         request.applymarker(pytest.mark.xfail(
             run=False, reason='chrome not supported'))
     selenium.load_package("pandas")
-    assert len(selenium.run("import pandas\ndir(pandas)")) == 140
+    assert len(selenium.run("import pandas\ndir(pandas)")) == 142
 
 
 def test_extra_import(selenium, request):


### PR DESCRIPTION
This updates to numpy 1.15.4 (later versions need to adjust patches) and pandas 1.0.5 (latest)