### PR TITLE
MNT Don't benchmark scipy load time

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -118,7 +118,7 @@ def main(hostpython):
         print_entry("selenium init", b)
 
         # load packages
-        for package_name in ["numpy", "scipy"]:
+        for package_name in ["numpy"]:
             b = {'native': float('NaN')}
             for browser_name, cls in browser_cls:
                 selenium = cls(port)


### PR DESCRIPTION
Removes the benchmark of scipy load time. That's the reason benchmarking CI job fails most of the time, making the rest of the benchmark results unavailable.