### PR TITLE
Recycling hiwire keys

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -11,11 +11,7 @@
 
 EM_JS(void, hiwire_setup, (), {
   // These ids must match the constants above, but we can't use them from JS
-  var hiwire = {
-    objects : {},
-    recycle : [],
-    counter : 1
-  };
+  var hiwire = { objects : {}, recycle : [], counter : 1 };
 
   // Negative objects are never removed!
   hiwire.objects[-2] = undefined;
@@ -32,8 +28,7 @@ EM_JS(void, hiwire_setup, (), {
     if (hiwire.recycle.length > 0) {
       idval = hiwire.recycle.shift();
       objects[idval] = jsval;
-    }
-    else {
+    } else {
       while (hiwire.counter in objects) {
         hiwire.counter = (hiwire.counter + 1) & 0x7fffffff;
       }


### PR DESCRIPTION
hiwire is frequenly used to interchange values and objects between Python and JavaScript. Even when objects are deleted from hiwire.objects after usage, their key is never used again, and the offset is increased all the time until it might overflow when the site is executed for a very long time and with lots of interchanges.

This little improvement may avoid an overflow by re-using keys which already had been used before, using a list of recycled keys.