### PR TITLE
Only call Py_INCREF() once when proxied by PyProxy

### DIFF
--- a/src/hiwire.c
+++ b/src/hiwire.c
@@ -2,13 +2,6 @@
 
 #include "hiwire.h"
 
-// Define special ids for singleton constants. These must be less than -1 to
-// avoid being reused for other values.
-#define HW_UNDEFINED -2
-#define HW_TRUE -3
-#define HW_FALSE -4
-#define HW_NULL -5
-
 EM_JS(void, hiwire_setup, (), {
   // These ids must match the constants above, but we can't use them from JS
   var hiwire = { objects : {}, counter : 1 };

--- a/src/hiwire.h
+++ b/src/hiwire.h
@@ -14,7 +14,13 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
+// Define special ids for singleton constants. These must be less than -1 to
+// avoid being reused for other values.
 #define HW_ERROR -1
+#define HW_UNDEFINED -2
+#define HW_TRUE -3
+#define HW_FALSE -4
+#define HW_NULL -5
 
 /**
  * Initialize the variables and functions required for hiwire.

--- a/src/pyproxy.c
+++ b/src/pyproxy.c
@@ -124,7 +124,7 @@ _pyproxy_destroy(int ptrobj)
   EM_ASM(delete Module.PyProxies[ptrobj];);
 }
 
-EM_JS(int, pyproxy_new, (int ptrobj), {
+EM_JS(int, pyproxy_use, (int ptrobj), {
   // Proxies we've already created are just returned again, so that the
   // same object on the Python side is always the same object on the
   // Javascript side.
@@ -138,6 +138,10 @@ EM_JS(int, pyproxy_new, (int ptrobj), {
     return Module.hiwire_new_value(Module.PyProxies[ptrobj]);
   }
 
+  return -2; /* this means HW_UNDEFINED */
+})
+
+EM_JS(int, pyproxy_new, (int ptrobj), {
   var target = function(){};
   target['$$'] = { ptr : ptrobj, type : 'PyProxy' };
   var proxy = new Proxy(target, Module.PyProxy);

--- a/src/pyproxy.c
+++ b/src/pyproxy.c
@@ -125,15 +125,8 @@ _pyproxy_destroy(int ptrobj)
 }
 
 EM_JS(int, pyproxy_use, (int ptrobj), {
-  // Proxies we've already created are just returned again, so that the
-  // same object on the Python side is always the same object on the
-  // Javascript side.
+  // Checks if there is already an existing proxy on ptrobj
 
-  // Technically, this leaks memory, since we're holding on to a reference
-  // to the proxy forever.  But we have that problem anyway since we don't
-  // have a destructor in Javascript to free the Python object.
-  // _pyproxy_destroy, which is a way for users to manually delete the proxy,
-  // also deletes the proxy from this set.
   if (Module.PyProxies.hasOwnProperty(ptrobj)) {
     return Module.hiwire_new_value(Module.PyProxies[ptrobj]);
   }
@@ -142,6 +135,12 @@ EM_JS(int, pyproxy_use, (int ptrobj), {
 })
 
 EM_JS(int, pyproxy_new, (int ptrobj), {
+  // Technically, this leaks memory, since we're holding on to a reference
+  // to the proxy forever.  But we have that problem anyway since we don't
+  // have a destructor in Javascript to free the Python object.
+  // _pyproxy_destroy, which is a way for users to manually delete the proxy,
+  // also deletes the proxy from this set.
+
   var target = function(){};
   target['$$'] = { ptr : ptrobj, type : 'PyProxy' };
   var proxy = new Proxy(target, Module.PyProxy);

--- a/src/pyproxy.h
+++ b/src/pyproxy.h
@@ -8,6 +8,9 @@
 //     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
 int
+pyproxy_use(int obj);
+
+int
 pyproxy_new(int obj);
 
 int

--- a/src/python2js.c
+++ b/src/python2js.c
@@ -257,13 +257,19 @@ _python2js(PyObject* x, PyObject* map)
   } else if (PyDict_Check(x)) {
     return _python2js_dict(x, map);
   } else {
-    int jsbuff = _python2js_buffer(x);
-    if (jsbuff != HW_ERROR) {
-      return jsbuff;
+    int ret = _python2js_buffer(x);
+
+    if (ret != HW_ERROR) {
+      return ret;
     }
     if (PySequence_Check(x)) {
       return _python2js_sequence(x, map);
     }
+
+    if ((ret = pyproxy_use((int)x)) != HW_UNDEFINED) {
+      return ret;
+    }
+
     Py_INCREF(x);
     return pyproxy_new((int)x);
   }

--- a/src/python2js.c
+++ b/src/python2js.c
@@ -266,10 +266,14 @@ _python2js(PyObject* x, PyObject* map)
       return _python2js_sequence(x, map);
     }
 
+    // Proxies we've already created are just returned again, so that the
+    // same object on the Python side is always the same object on the
+    // Javascript side.
     if ((ret = pyproxy_use((int)x)) != HW_UNDEFINED) {
       return ret;
     }
 
+    // Reference counter is increased only once when a PyProxy is created.
     Py_INCREF(x);
     return pyproxy_new((int)x);
   }

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -422,6 +422,22 @@ def test_pyproxy(selenium):
     assert selenium.run_js("return pyodide.pyimport('f').toString()").startswith("<Foo")
 
 
+def test_pyproxy_refcount(selenium):
+    selenium.run(
+        """
+        import sys
+        from js import document
+
+        def pytest(*args, **kwargs):
+            print(*args, **kwargs)
+
+        document.addEventListener("click", pytest)
+        document.removeEventListener("click", pytest)
+        """
+    )
+    assert selenium.run("sys.getrefcount(pytest)") == 3
+
+
 def test_pyproxy_destroy(selenium):
     selenium.run(
         """

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -423,19 +423,52 @@ def test_pyproxy(selenium):
 
 
 def test_pyproxy_refcount(selenium):
+    selenium.run_js("window.jsfunc = function (f) { f(); }")
     selenium.run(
         """
         import sys
-        from js import document
+        from js import window
 
-        def pytest(*args, **kwargs):
+        def pyfunc(*args, **kwargs):
             print(*args, **kwargs)
-
-        document.addEventListener("click", pytest)
-        document.removeEventListener("click", pytest)
         """
     )
-    assert selenium.run("sys.getrefcount(pytest)") == 3
+
+    # the refcount should be 2 because:
+    #
+    # 1. pyfunc exists
+    # 2. pyfunc is referenced from the sys.getrefcount()-test below
+    #
+    assert selenium.run("sys.getrefcount(pyfunc)") == 2
+
+    selenium.run(
+        """
+        window.jsfunc(pyfunc) # creates new PyProxy
+        """
+    )
+
+    # the refcount should be 3 because:
+    #
+    # 1. pyfunc exists
+    # 2. one reference from PyProxy to pyfunc is alive
+    # 3. pyfunc is referenced from the sys.getrefcount()-test below
+    #
+    assert selenium.run("sys.getrefcount(pyfunc)") == 3
+
+    selenium.run(
+        """
+        window.jsfunc(pyfunc) # re-used existing PyProxy
+        window.jsfunc(pyfunc) # re-used existing PyProxy
+        """
+    )
+
+    # the refcount should still be 3 because:
+    #
+    # 1. pyfunc exists
+    # 2. one reference from PyProxy to pyfunc is still alive
+    # 3. pyfunc is referenced from the sys.getrefcount()-test below
+    #
+    assert selenium.run("sys.getrefcount(pyfunc)") == 3
 
 
 def test_pyproxy_destroy(selenium):


### PR DESCRIPTION
This bugfix reduces the number of references Python holds on objects that are being proxied to JavaScript.
There is only one PyProxy created for each object, but the reference counter was increased on every call, even when no PyProxy object was explicitly created.

hiwire's constant defines had also been moved into hiwire.h, both because they're all defined at one location and HW_UNDEFINED was needed additionally now by pyproxy_use().