### PR TITLE
BLD Fix emcc warning on Python3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ geckodriver.log
 firefox/
 .vscode
 .idea
+.mypy_cache/
 
 build
 downloads

--- a/emsdk/patches/emcc-python38-warning.patch
+++ b/emsdk/patches/emcc-python38-warning.patch
@@ -1,0 +1,20 @@
+--- emsdk/emsdk/emscripten/tag-1.38.31/emcc.py	2019-04-24 16:21:45.000000000 +0200
++++ emsdk/emsdk/emscripten/tag-1.38.31/emcc.py	2019-04-24 16:21:45.000000000 +0200
+@@ -816,7 +816,7 @@
+           newargs[i] = newargs[i + 1] = ''
+           if key == 'WASM_BACKEND=1':
+             exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
+-    newargs = [arg for arg in newargs if arg is not '']
++    newargs = [arg for arg in newargs if arg != '']
+ 
+     settings_key_changes = set()
+     for s in settings_changes:
+@@ -936,7 +936,7 @@
+ 
+     original_input_files = input_files[:]
+ 
+-    newargs = [a for a in newargs if a is not '']
++    newargs = [a for a in newargs if a != '']
+ 
+     # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+     has_dash_c = '-c' in newargs


### PR DESCRIPTION
Fixes a minor but very frequently occurring `emcc` warning after updating to Python 3.8 in https://github.com/iodide-project/pyodide/pull/712 

```
/src/emsdk/emsdk/emscripten/tag-1.38.31/emcc.py:819: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  newargs = [arg for arg in newargs if arg is not '']
/src/emsdk/emsdk/emscripten/tag-1.38.31/emcc.py:939: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  newargs = [a for a in newargs if a is not '']
```

The added patch will no longer be necessary once we update emscripten to more recent versions e.g. https://github.com/iodide-project/pyodide/pull/480 and https://github.com/iodide-project/pyodide/issues/476