### PR TITLE
DOC Add FAQ about loading external python files

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,19 @@
+# Frequently Asked Questions (FAQ)
+
+### How can I load external python files in Pyodide?
+
+The two possible solutions are,
+
+- include these files in a python package, build a pure python wheel with
+  `python setup.py bdist_wheel` and [load it with micropip](./pypi.html#installing-wheels-from-arbitrary-urls).
+- fetch the python code as a string and evaluate it in Python,
+  ```js
+  pyodide.eval_code(pyodide.open_url('https://some_url/...'))
+  ```
+
+In both cases, files need to be served with a web server and cannot be loaded from local file system.
+
+### Why can't I load files from the local file system?
+
+For security reasons JavaScript in the browser is not allowed to load local
+data files. You need to serve them with a web-browser.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ to be used with Pyodide.
 
    pypi.md
    api_reference.md
+   faq.md
 
 Developing Pyodide
 ==================


### PR DESCRIPTION
Adds a FAQ about how to loading external python files in pyodide, as it's frequently asked.

Closes https://github.com/iodide-project/pyodide/issues/723

Once https://github.com/iodide-project/pyodide/pull/692 is finalized, we could add it here as well.

For the second question about loading files from the local file system, https://github.com/iodide-project/pyodide/pull/606 is an interesting workaround. Though I'm not convinced that not having to run a web server with python locally is worth the added complexity.