### PR TITLE
DOC Linux build doc updates

### DIFF
--- a/docs/building_from_sources.md
+++ b/docs/building_from_sources.md
@@ -12,9 +12,11 @@ need to build it yourself prior.
 
 Additional build prerequisites are:
 
-- A working native compiler toolchain, enough to build CPython.
+- A working native compiler toolchain, enough to build [CPython](https://devguide.python.org/setup/#linux).
 - A native Python 3.8 to run the build scripts.
+- CMake
 - PyYAML
+- FreeType 2 development libraries to compile Matplotlib.
 - [lessc](http://lesscss.org/) to compile less to css.
 - [uglifyjs](https://github.com/mishoo/UglifyJS) to minify Javascript builds.
 - gfortran (GNU Fortran 95 compiler)


### PR DESCRIPTION
I just finished setting up a new Ubuntu 20.04 environment for compiling Pyodide. I ran into a couple of issues trying to get the dependencies right so I've updated the doc to reflect those requirements. I added a link to the CPython build dependencies. I added CMake to the list since I don't think the CPython build dependencies include CMake. Lastly, I added the FreeType 2 development libraries required by Matplotlib. Since the switch to Python 3.8, the Matplotlib build script, in it's attempt to tell you what dependencies are needed, raises a Python exception since it relies on functionality removed in 3.8, which makes it very confusing to figure out why the build is failing. The Matplotlib build script works fine if FreeType 2 is available since it never runs the offending code if all of its dependencies are met.