### PR TITLE
[WIP] Scikit-image

### DIFF
--- a/packages/cloudpickle/meta.yaml
+++ b/packages/cloudpickle/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: cloudpickle
+  version: 1.5.0
+source:
+  sha256: 820c9245cebdec7257211cbe88745101d5d6a042bca11336d78ebd4897ddbc82
+  url: https://files.pythonhosted.org/packages/2b/42/1a742ae7a85e8e15a60696b0519f71db8ee04839fef6007c3859184fbe71/cloudpickle-1.5.0.tar.gz
+test:
+  imports:
+  - cloudpickle

--- a/packages/imageio/meta.yaml
+++ b/packages/imageio/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: imageio
+  version: 2.9.0
+source:
+  sha256: 52ddbaeca2dccf53ba2d6dec5676ca7bc3b2403ef8b37f7da78b7654bb3e10f0
+  url: https://files.pythonhosted.org/packages/c3/73/f37f428748c4f10a7991ac5bff00f113a34bcc0d0a78957d6e1cdc29a94e/imageio-2.9.0.tar.gz
+test:
+  imports:
+  - imageio

--- a/packages/pillow/meta.yaml
+++ b/packages/pillow/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pillow
+  version: 7.2.0
+source:
+  sha256: 97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626
+  url: https://files.pythonhosted.org/packages/3e/02/b09732ca4b14405ff159c470a612979acfc6e8645dc32f83ea0129709f7a/Pillow-7.2.0.tar.gz
+test:
+  imports:
+  - pillow

--- a/packages/pywavelets/meta.yaml
+++ b/packages/pywavelets/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: pywavelets
+  version: 1.1.1
+source:
+  sha256: 1a64b40f6acb4ffbaccce0545d7fc641744f95351f62e4c6aaa40549326008c9
+  url: https://files.pythonhosted.org/packages/17/6b/ef989cfb3acff2ea966c5f28a7443ccaec2ee136675dfa0366db2635f78a/PyWavelets-1.1.1.tar.gz
+test:
+  imports:
+  - pywavelets

--- a/packages/scikit-image/meta.yaml
+++ b/packages/scikit-image/meta.yaml
@@ -2,6 +2,8 @@ package:
   name: scikit-image
   version: 0.17.2
 source:
+  patches:
+  - patches/no-openmp.patch
   sha256: bd954c0588f0f7e81d9763dc95e06950e68247d540476e06cb77bcbcd8c2d8b3
   url: https://files.pythonhosted.org/packages/54/fd/c1b0bb8f6f12ef9b4ee8d7674dac82cd482886f8b5cd165631efa533e237/scikit-image-0.17.2.tar.gz
 test:

--- a/packages/scikit-image/meta.yaml
+++ b/packages/scikit-image/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: scikit-image
+  version: 0.17.2
+source:
+  sha256: bd954c0588f0f7e81d9763dc95e06950e68247d540476e06cb77bcbcd8c2d8b3
+  url: https://files.pythonhosted.org/packages/54/fd/c1b0bb8f6f12ef9b4ee8d7674dac82cd482886f8b5cd165631efa533e237/scikit-image-0.17.2.tar.gz
+test:
+  imports:
+  - scikit-image

--- a/packages/scikit-image/patches/no-openmp.patch
+++ b/packages/scikit-image/patches/no-openmp.patch
@@ -1,0 +1,18 @@
+commit 986ee79feb5f5324aa6cf07b1920db6d30a2fed7 (HEAD)
+Author: Chigozie Nri <chigozie@gmail.com>
+Date:   Mon Jul 13 20:59:34 2020 +0100
+
+    Don't build openmp
+
+diff --git a/setup.py b/setup.py
+index 19331e4d0..06fb24830 100755
+--- a/setup.py
++++ b/setup.py
+@@ -66,6 +66,7 @@ def openmp_build_ext():
+     class ConditionalOpenMP(build_ext):
+ 
+         def can_compile_link(self):
++            return False
+ 
+             cc = self.compiler
+             fname = 'test.c'

--- a/packages/tifffile/meta.yaml
+++ b/packages/tifffile/meta.yaml
@@ -1,0 +1,9 @@
+package:
+  name: tifffile
+  version: 2020.7.4
+source:
+  sha256: d7e56b9983e2e14716feaee560022baa8f92e97f36df7eee8b10e672383f694c
+  url: https://files.pythonhosted.org/packages/d1/da/86bd460aa596ead2af3d3722434ead6711a9a2955b1e70ad3aa37b291930/tifffile-2020.7.4.tar.gz
+test:
+  imports:
+  - tifffile


### PR DESCRIPTION
Contributes to #253 
Missing dependencies for scikit-image are built. Patch as suggested here https://github.com/scikit-image/scikit-image/issues/4836#issuecomment-657421518 is applied to scikit-image itself, but it does not yet successfully build:

Command
```
PYODIDE_PACKAGES="micropip,numpy,scipy,matplotlib,cycler,kiwisolver,pyparsing,python-dateutil,pytz,networkx,decorator,imageio,setuptools,tifffile,scikit-image" make
```

gives result:
(omitting stdout related to successful build of the dependencies)
ETA: OUTDATED, see comment below
```
Finished processing dependencies for scikit-image==0.17.2
emcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/home/circleci/pyodide/cpython/build/3.8.2/host/lib/python3.8/site-packages/numpy-1.15.4-py3.8-linux-x86_64.egg/numpy/core/include -I/home/circleci/pyodide/cpython/installs/python-3.8.2/include/python3.8 -c skimage/_shared/geometry.c -o build/temp.linux-x86_64-3.8/skimage/_shared/geometry.bc -MMD -MF build/temp.linux-x86_64-3.8/skimage/_shared/geometry.o.d -fopenmp
skimage/_shared/geometry.c:609:10: fatal error: 'omp.h' file not found
#include <omp.h>
         ^~~~~~~
1 error generated.
shared:ERROR: compiler frontend failed to generate LLVM bitcode, halting
[2020-08-02 09:28:59] done building package scikit-image in 62.7 s.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/circleci/pyodide/pyodide_build/__main__.py", line 34, in <module>
    main()
  File "/home/circleci/pyodide/pyodide_build/__main__.py", line 28, in main
    args.func(args)
  File "/home/circleci/pyodide/pyodide_build/buildall.py", line 149, in main
    build_packages(packagesdir, outputdir, args)
  File "/home/circleci/pyodide/pyodide_build/buildall.py", line 66, in build_packages
    build_package(pkgname, dependencies, packagesdir, outputdir, args)
  File "/home/circleci/pyodide/pyodide_build/buildall.py", line 21, in build_package
    buildpkg.build_package(packagesdir / pkgname / "meta.yaml", args)
  File "/home/circleci/pyodide/pyodide_build/buildpkg.py", line 249, in build_package
    compile(path, srcpath, pkg, args)
  File "/home/circleci/pyodide/pyodide_build/buildpkg.py", line 141, in compile
    subprocess.run(
  File "/usr/local/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/circleci/pyodide/cpython/build/3.8.2/host/bin/python3', '-m', 'pyodide_build', 'pywasmcross', '--cflags', ' ', '--ldflags', '-O3 -s BINARYEN_METHOD=native-wasm -Werror -s EMULATED_FUNCTION_POINTERS=1 -s EMULATE_FUNCTION_POINTER_CASTS=1 -s SIDE_MODULE=1 -s WASM=1 -s BINARYEN_TRAP_MODE=clamp --memory-init-file 0 -s LINKABLE=1 -s EXPORT_ALL=1 -s ERROR_ON_MISSING_LIBRARIES=0 ', '--host', '/home/circleci/pyodide/cpython/build/3.8.2/host', '--target', '/home/circleci/pyodide/cpython/installs/python-3.8.2']' returned non-zero exit status 1.
make[1]: *** [Makefile:5: all] Error 1
make[1]: Leaving directory '/home/circleci/pyodide/packages'
make: *** [Makefile:308: build/packages.json] Error 2
```