### PR TITLE
MNT Put files in a subfolder in the release .tar.bz2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,9 @@ jobs:
       - run:
           name: Deploy Github Releases
           command: |
-            pushd build
-            tar cjf ../pyodide-build-${CIRCLE_TAG}.tar.bz2 *
-            popd
+            cp -r build /tmp/pyodide
+            cd /tmp/
+            tar cjf pyodide-build-${CIRCLE_TAG}.tar.bz2  pyodide/
             ghr -t "${GITHUB_TOKEN}" -u "${CIRCLE_PROJECT_USERNAME}" -r "${CIRCLE_PROJECT_REPONAME}" -c "${CIRCLE_SHA1}" -delete  "${CIRCLE_TAG}" ./pyodide-build-${CIRCLE_TAG}.tar.bz2
 
       - run:


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/436

Avoids having all the packages in the current dir when extracting the release .tar.bz2