### PR TITLE
MNT update pure python packages

### DIFF
--- a/packages/Jinja2/meta.yaml
+++ b/packages/Jinja2/meta.yaml
@@ -1,15 +1,12 @@
 package:
   name: Jinja2
-  version: '2.10'
-
-source:
-  sha256: f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4
-  url: https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz
-
+  version: 2.11.2
 requirements:
   run:
   - MarkupSafe
-
+source:
+  sha256: 89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0
+  url: https://files.pythonhosted.org/packages/64/a7/45e11eebf2f15bf987c3bc11d37dcc838d9dc81250e67e4c5968f6008b6c/Jinja2-2.11.2.tar.gz
 test:
   imports:
   - jinja2

--- a/packages/Pygments/meta.yaml
+++ b/packages/Pygments/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: Pygments
-  version: 2.4.2
+  version: 2.6.1
 source:
-  sha256: 881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297
-  url: https://files.pythonhosted.org/packages/7e/ae/26808275fc76bf2832deb10d3a3ed3107bc4de01b85dcccbe525f2cd6d1e/Pygments-2.4.2.tar.gz
+  sha256: 647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44
+  url: https://files.pythonhosted.org/packages/6e/4d/4d2fe93a35dfba417311a4ff627489a947b01dc0cc377a3673c00cf7e4b2/Pygments-2.6.1.tar.gz
 test:
   imports:
   - pygments

--- a/packages/atomicwrites/meta.yaml
+++ b/packages/atomicwrites/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: atomicwrites
-  version: 1.3.0
+  version: 1.4.0
 source:
-  sha256: 75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6
-  url: https://files.pythonhosted.org/packages/ec/0f/cd484ac8820fed363b374af30049adc8fd13065720fd4f4c6be8a2309da7/atomicwrites-1.3.0.tar.gz
+  sha256: ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
+  url: https://files.pythonhosted.org/packages/55/8d/74a75635f2c3c914ab5b3850112fd4b0c8039975ecb320e4449aa363ba54/atomicwrites-1.4.0.tar.gz
 test:
   imports:
   - atomicwrites

--- a/packages/beautifulsoup4/meta.yaml
+++ b/packages/beautifulsoup4/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: beautifulsoup4
-  version: 4.7.1
-source:
-  sha256: 945065979fb8529dd2f37dbb58f00b661bdbcbebf954f93b32fdf5263ef35348
-  url: https://files.pythonhosted.org/packages/80/f2/f6aca7f1b209bb9a7ef069d68813b091c8c3620642b568dac4eb0e507748/beautifulsoup4-4.7.1.tar.gz
+  version: 4.9.1
 requirements:
   run:
   - soupsieve
+source:
+  sha256: 73cc4d115b96f79c7d77c1c7f7a0a8d4c57860d1041df407dd1aae7f07a77fd7
+  url: https://files.pythonhosted.org/packages/c6/62/8a2bef01214eeaa5a4489eca7104e152968729512ee33cb5fbbc37a896b7/beautifulsoup4-4.9.1.tar.gz
 test:
   imports:
   - bs4

--- a/packages/biopython/meta.yaml
+++ b/packages/biopython/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: biopython
-  version: '1.75'
-source:
-  sha256: 5060e4ef29c2bc214749733634051be5b8d11686c6590fa155c3443dcaa89906
-  url: https://files.pythonhosted.org/packages/33/55/becf2b99556588d22b542f3412990bfc79b674e198d9bc58f7bbc333439e/biopython-1.75.tar.gz
+  version: '1.77'
 requirements:
   run:
-    - numpy
+  - numpy
+source:
+  sha256: fb1936e9ca9e7af8de1050e84375f23328e04b801063edf0ad73733494d8ec42
+  url: https://files.pythonhosted.org/packages/3d/2f/d9df24de05d651c5e686ee8fea3afe3985c03ef9ca02f4cc1e7ea10aa31e/biopython-1.77.tar.gz
 test:
   imports:
-    - Bio
+  - Bio

--- a/packages/bleach/meta.yaml
+++ b/packages/bleach/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: bleach
-  version: 3.1.0
-source:
-  sha256: 3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa
-  url: https://files.pythonhosted.org/packages/78/5a/0df03e8735cd9c75167528299c738702437589b9c71a849489d00ffa82e8/bleach-3.1.0.tar.gz
+  version: 3.1.5
 requirements:
   run:
   - setuptools
   - webencodings
+source:
+  sha256: 3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b
+  url: https://files.pythonhosted.org/packages/a9/ac/dc881fca3ac66d6f2c4c3ac46633af4e9c05ed5a0aa2e7e36dc096687dd7/bleach-3.1.5.tar.gz
 test:
   imports:
   - bleach

--- a/packages/bleach/meta.yaml
+++ b/packages/bleach/meta.yaml
@@ -5,6 +5,7 @@ requirements:
   run:
   - setuptools
   - webencodings
+  - packaging
 source:
   sha256: 3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b
   url: https://files.pythonhosted.org/packages/a9/ac/dc881fca3ac66d6f2c4c3ac46633af4e9c05ed5a0aa2e7e36dc096687dd7/bleach-3.1.5.tar.gz

--- a/packages/decorator/meta.yaml
+++ b/packages/decorator/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: decorator
-  version: 4.4.1
+  version: 4.4.2
 source:
-  sha256: 54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce
-  url: https://files.pythonhosted.org/packages/dc/c3/9d378af09f5737cfd524b844cd2fbb0d2263a35c11d712043daab290144d/decorator-4.4.1.tar.gz
+  sha256: e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7
+  url: https://files.pythonhosted.org/packages/da/93/84fa12f2dc341f8cf5f022ee09e109961055749df2d0c75c5f98746cfe6c/decorator-4.4.2.tar.gz
 test:
   imports:
   - decorator

--- a/packages/distlib/meta.yaml
+++ b/packages/distlib/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: distlib
-  version: 0.3.0
+  version: 0.3.1
 source:
-  sha256: 2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21
-  url: https://files.pythonhosted.org/packages/7d/29/694a3a4d7c0e1aef76092e9167fbe372e0f7da055f5dcf4e1313ec21d96a/distlib-0.3.0.zip
+  sha256: edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1
+  url: https://files.pythonhosted.org/packages/2f/83/1eba07997b8ba58d92b3e51445d5bf36f9fba9cb8166bcae99b9c3464841/distlib-0.3.1.zip
 test:
   imports:
   - distlib

--- a/packages/docutils/meta.yaml
+++ b/packages/docutils/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: docutils
-  version: 0.15.2
+  version: '0.16'
 source:
-  sha256: a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99
-  url: https://files.pythonhosted.org/packages/93/22/953e071b589b0b1fee420ab06a0d15e5aa0c7470eb9966d60393ce58ad61/docutils-0.15.2.tar.gz
+  sha256: c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc
+  url: https://files.pythonhosted.org/packages/2f/e0/3d435b34abd2d62e8206171892f174b180cd37b09d57b924ca5c2ef2219d/docutils-0.16.tar.gz
 test:
   imports:
   - docutils

--- a/packages/html5lib/meta.yaml
+++ b/packages/html5lib/meta.yaml
@@ -1,15 +1,12 @@
 package:
   name: html5lib
-  version: 1.0.1
-
-source:
-  sha256: 66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736
-  url: https://files.pythonhosted.org/packages/85/3e/cf449cf1b5004e87510b9368e7a5f1acd8831c2d6691edd3c62a0823f98f/html5lib-1.0.1.tar.gz
-
+  version: '1.1'
 requirements:
   run:
   - webencodings
-
+source:
+  sha256: b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
+  url: https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz
 test:
   imports:
   - html5lib

--- a/packages/kiwisolver/meta.yaml
+++ b/packages/kiwisolver/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: kiwisolver
-  version: 1.1.0
+  version: 1.2.0
 source:
-  sha256: 53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75
-  url: https://files.pythonhosted.org/packages/16/e7/df58eb8868d183223692d2a62529a594f6414964a3ae93548467b146a24d/kiwisolver-1.1.0.tar.gz
+  sha256: 247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f
+  url: https://files.pythonhosted.org/packages/62/b8/db619d97819afb52a3ff5ff6ad3f7de408cc83a8ec2dfb31a1731c0a97c2/kiwisolver-1.2.0.tar.gz
 test:
   imports:
   - kiwisolver

--- a/packages/more-itertools/meta.yaml
+++ b/packages/more-itertools/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: more-itertools
-  version: 7.2.0
+  version: 8.4.0
 source:
-  sha256: 409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832
-  url: https://files.pythonhosted.org/packages/c2/31/45f61c8927c9550109f1c4b99ba3ca66d328d889a9c9853a808bff1c9fa0/more-itertools-7.2.0.tar.gz
+  sha256: 68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5
+  url: https://files.pythonhosted.org/packages/67/4a/16cb3acf64709eb0164e49ba463a42dc45366995848c4f0cf770f57b8120/more-itertools-8.4.0.tar.gz
 test:
   imports:
   - more_itertools

--- a/packages/networkx/meta.yaml
+++ b/packages/networkx/meta.yaml
@@ -1,45 +1,40 @@
 package:
   name: networkx
-  version: '2.2'
-
-source:
-  url: https://files.pythonhosted.org/packages/f3/f4/7e20ef40b118478191cec0b58c3192f822cace858c19505c7670961b76b2/networkx-2.2.zip
-  sha256: 45e56f7ab6fe81652fb4bc9f44faddb0e9025f469f602df14e3b2551c2ea5c8b
-
+  version: '2.4'
 requirements:
   run:
-    - decorator
-    - setuptools
-    # Upstream NetworkX has these as "soft" dependencies, but it's more
-    # convenient to have them come in automatically.
-    - matplotlib
-    - numpy
-
+  - decorator
+  - setuptools
+  - matplotlib
+  - numpy
+source:
+  sha256: f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64
+  url: https://files.pythonhosted.org/packages/bf/63/7b579dd3b1c49ce6b7fd8f6f864038f255201410905dd183cf7f4a3845cf/networkx-2.4.tar.gz
 test:
   imports:
-    - networkx
-    - networkx.algorithms
-    - networkx.algorithms.approximation
-    - networkx.algorithms.assortativity
-    - networkx.algorithms.bipartite
-    - networkx.algorithms.centrality
-    - networkx.algorithms.chordal
-    - networkx.algorithms.coloring
-    - networkx.algorithms.community
-    - networkx.algorithms.components
-    - networkx.algorithms.connectivity
-    - networkx.algorithms.flow
-    - networkx.algorithms.isomorphism
-    - networkx.algorithms.link_analysis
-    - networkx.algorithms.node_classification
-    - networkx.algorithms.operators
-    - networkx.algorithms.shortest_paths
-    - networkx.algorithms.traversal
-    - networkx.algorithms.tree
-    - networkx.classes
-    - networkx.drawing
-    - networkx.generators
-    - networkx.linalg
-    - networkx.readwrite
-    - networkx.readwrite.json_graph
-    - networkx.utils
+  - networkx
+  - networkx.algorithms
+  - networkx.algorithms.approximation
+  - networkx.algorithms.assortativity
+  - networkx.algorithms.bipartite
+  - networkx.algorithms.centrality
+  - networkx.algorithms.chordal
+  - networkx.algorithms.coloring
+  - networkx.algorithms.community
+  - networkx.algorithms.components
+  - networkx.algorithms.connectivity
+  - networkx.algorithms.flow
+  - networkx.algorithms.isomorphism
+  - networkx.algorithms.link_analysis
+  - networkx.algorithms.node_classification
+  - networkx.algorithms.operators
+  - networkx.algorithms.shortest_paths
+  - networkx.algorithms.traversal
+  - networkx.algorithms.tree
+  - networkx.classes
+  - networkx.drawing
+  - networkx.generators
+  - networkx.linalg
+  - networkx.readwrite
+  - networkx.readwrite.json_graph
+  - networkx.utils

--- a/packages/networkx/meta.yaml
+++ b/packages/networkx/meta.yaml
@@ -5,6 +5,8 @@ requirements:
   run:
   - decorator
   - setuptools
+  # Upstream NetworkX has these as "soft" dependencies, but it's more
+  # convenient to have them come in automatically.
   - matplotlib
   - numpy
 source:

--- a/packages/nltk/meta.yaml
+++ b/packages/nltk/meta.yaml
@@ -4,6 +4,9 @@ package:
 source:
   sha256: 845365449cd8c5f9731f7cb9f8bd6fd0767553b9d53af9eb1b3abf7700936b35
   url: https://files.pythonhosted.org/packages/92/75/ce35194d8e3022203cca0d2f896dbb88689f9b3fce8e9f9cff942913519d/nltk-3.5.zip
+requirements:
+  run:
+    - regex
 test:
   imports:
   - nltk

--- a/packages/nltk/meta.yaml
+++ b/packages/nltk/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: nltk
-  version: 3.4.5
+  version: '3.5'
 source:
-  sha256: bed45551259aa2101381bbdd5df37d44ca2669c5c3dad72439fa459b29137d94
-  url: https://files.pythonhosted.org/packages/f6/1d/d925cfb4f324ede997f6d47bea4d9babba51b49e87a767c170b77005889d/nltk-3.4.5.zip
+  sha256: 845365449cd8c5f9731f7cb9f8bd6fd0767553b9d53af9eb1b3abf7700936b35
+  url: https://files.pythonhosted.org/packages/92/75/ce35194d8e3022203cca0d2f896dbb88689f9b3fce8e9f9cff942913519d/nltk-3.5.zip
 test:
   imports:
   - nltk

--- a/packages/packaging/meta.yaml
+++ b/packages/packaging/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: packaging
+  version: '20.4'
+source:
+  sha256: 4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8
+  url: https://files.pythonhosted.org/packages/55/fd/fc1aca9cf51ed2f2c11748fa797370027babd82f87829c7a8e6dbe720145/packaging-20.4.tar.gz
+
+requirements:
+  run:
+    - pyparsing
+
+test:
+  imports:
+  - packaging

--- a/packages/py/meta.yaml
+++ b/packages/py/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: py
-  version: 1.8.0
+  version: 1.9.0
 source:
-  sha256: dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53
-  url: https://files.pythonhosted.org/packages/f1/5a/87ca5909f400a2de1561f1648883af74345fe96349f34f737cdfc94eba8c/py-1.8.0.tar.gz
+  sha256: 9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342
+  url: https://files.pythonhosted.org/packages/97/a6/ab9183fe08f69a53d06ac0ee8432bc0ffbb3989c575cc69b73a0229a9a99/py-1.9.0.tar.gz
 test:
   imports:
   - py

--- a/packages/pyparsing/meta.yaml
+++ b/packages/pyparsing/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pyparsing
-  version: 2.4.5
+  version: 2.4.7
 source:
   patches:
   - patches/dummy_threading.patch
-  sha256: 4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a
-  url: https://files.pythonhosted.org/packages/00/32/8076fa13e832bb4dcff379f18f228e5a53412be0631808b9ca2610c0f566/pyparsing-2.4.5.tar.gz
+  sha256: c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
+  url: https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz
 test:
   imports:
   - pyparsing

--- a/packages/pytest/meta.yaml
+++ b/packages/pytest/meta.yaml
@@ -1,23 +1,19 @@
 package:
   name: pytest
-  version: 3.6.3
-
-source:
-  url: https://files.pythonhosted.org/packages/55/50/399419c03c39bf41faa7cbd5a8976c076037b2d76adf2535610919806d67/pytest-3.6.3.tar.gz
-  md5: 8ca6124a3a80f9555c50f5c09056ea02
-
-  patches:
-    - patches/named-tmp-and-rm-dup2.patch
-
+  version: 6.0.1
 requirements:
   run:
-    - atomicwrites
-    - attrs
-    - more-itertools
-    - pluggy
-    - py
-    - setuptools
-
+  - atomicwrites
+  - attrs
+  - more-itertools
+  - pluggy
+  - py
+  - setuptools
+source:
+  patches:
+  - patches/named-tmp-and-rm-dup2.patch
+  sha256: 85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4
+  url: https://files.pythonhosted.org/packages/20/4c/d7b19b8661be78461fff0392e33943784340424921578fe1bf300ef59831/pytest-6.0.1.tar.gz
 test:
   imports:
-    - pytest
+  - pytest

--- a/packages/pytest/meta.yaml
+++ b/packages/pytest/meta.yaml
@@ -1,19 +1,23 @@
 package:
   name: pytest
-  version: 6.0.1
+  version: 3.6.3
+
+source:
+  url: https://files.pythonhosted.org/packages/55/50/399419c03c39bf41faa7cbd5a8976c076037b2d76adf2535610919806d67/pytest-3.6.3.tar.gz
+  md5: 8ca6124a3a80f9555c50f5c09056ea02
+
+  patches:
+    - patches/named-tmp-and-rm-dup2.patch
+
 requirements:
   run:
-  - atomicwrites
-  - attrs
-  - more-itertools
-  - pluggy
-  - py
-  - setuptools
-source:
-  patches:
-  - patches/named-tmp-and-rm-dup2.patch
-  sha256: 85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4
-  url: https://files.pythonhosted.org/packages/20/4c/d7b19b8661be78461fff0392e33943784340424921578fe1bf300ef59831/pytest-6.0.1.tar.gz
+    - atomicwrites
+    - attrs
+    - more-itertools
+    - pluggy
+    - py
+    - setuptools
+
 test:
   imports:
-  - pytest
+    - pytest

--- a/packages/pytz/meta.yaml
+++ b/packages/pytz/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: pytz
-  version: '2019.3'
+  version: '2020.1'
 source:
   patches:
   - patches/dummy-threading.patch
-  sha256: b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be
-  url: https://files.pythonhosted.org/packages/82/c3/534ddba230bd4fbbd3b7a3d35f3341d014cca213f369a9940925e7e5f691/pytz-2019.3.tar.gz
+  sha256: c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048
+  url: https://files.pythonhosted.org/packages/f4/f6/94fee50f4d54f58637d4b9987a1b862aeb6cd969e73623e02c5c00755577/pytz-2020.1.tar.gz
 test:
   imports:
   - pytz

--- a/packages/regex/meta.yaml
+++ b/packages/regex/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: regex
-  version: 2019.11.1
+  version: 2020.7.14
 source:
-  sha256: 720e34a539a76a1fedcebe4397290604cc2bdf6f81eca44adb9fb2ea071c0c69
-  url: https://files.pythonhosted.org/packages/fc/1d/13cc7d174cd2d05808abac3f5fb37433e30c4cd93b152d2a9c09c926d7e8/regex-2019.11.1.tar.gz
+  sha256: 3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb
+  url: https://files.pythonhosted.org/packages/09/c3/ddaa87500f31ed86290e3d014c0302a51fde28d7139eda0b5f33733726db/regex-2020.7.14.tar.gz
 test:
   imports:
   - regex

--- a/packages/setuptools/meta.yaml
+++ b/packages/setuptools/meta.yaml
@@ -1,16 +1,20 @@
 package:
   name: setuptools
-  version: 49.6.0
+  version: 40.0.0
+
+source:
+  url: https://pypi.io/packages/source/s/setuptools/setuptools-40.0.0.zip
+  sha256: 012adb8e25fbfd64c652e99e7bab58799a3aaf05d39ab38561f69190a909015f
+
+  patches:
+    - patches/remove-ctypes.patch
+
 requirements:
   run:
-  - pyparsing
-source:
-  patches:
-  - patches/remove-ctypes.patch
-  sha256: 46bd862894ed22c2edff033c758c2dc026324788d758e96788e8f7c11f4e9707
-  url: https://files.pythonhosted.org/packages/38/cc/db23dbe4efc464c3c0111fedf7d46de8888f05b09488d610f6f8ab6e2544/setuptools-49.6.0.zip
+    - pyparsing
+
 test:
   imports:
-  - setuptools
-  - easy_install
-  - pkg_resources
+    - setuptools
+    - easy_install
+    - pkg_resources

--- a/packages/setuptools/meta.yaml
+++ b/packages/setuptools/meta.yaml
@@ -1,20 +1,16 @@
 package:
   name: setuptools
-  version: 40.0.0
-
-source:
-  url: https://pypi.io/packages/source/s/setuptools/setuptools-40.0.0.zip
-  sha256: 012adb8e25fbfd64c652e99e7bab58799a3aaf05d39ab38561f69190a909015f
-
-  patches:
-    - patches/remove-ctypes.patch
-
+  version: 49.6.0
 requirements:
   run:
-    - pyparsing
-
+  - pyparsing
+source:
+  patches:
+  - patches/remove-ctypes.patch
+  sha256: 46bd862894ed22c2edff033c758c2dc026324788d758e96788e8f7c11f4e9707
+  url: https://files.pythonhosted.org/packages/38/cc/db23dbe4efc464c3c0111fedf7d46de8888f05b09488d610f6f8ab6e2544/setuptools-49.6.0.zip
 test:
   imports:
-    - setuptools
-    - easy_install
-    - pkg_resources
+  - setuptools
+  - easy_install
+  - pkg_resources

--- a/packages/soupsieve/meta.yaml
+++ b/packages/soupsieve/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: soupsieve
-  version: 1.9.5
+  version: 2.0.1
 source:
-  sha256: e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda
-  url: https://files.pythonhosted.org/packages/92/cf/57dfed8a00f4ba33af3a6615d693bb65a19a11e26ab13293f62359216417/soupsieve-1.9.5.tar.gz
+  sha256: a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232
+  url: https://files.pythonhosted.org/packages/3e/db/5ba900920642414333bdc3cb397075381d63eafc7e75c2373bbc560a9fa1/soupsieve-2.0.1.tar.gz
 test:
   imports:
   - soupsieve

--- a/packages/sympy/meta.yaml
+++ b/packages/sympy/meta.yaml
@@ -1,15 +1,12 @@
 package:
   name: sympy
-  version: '1.3'
-
-source:
-  sha256: e1319b556207a3758a0efebae14e5e52c648fc1db8975953b05fff12b6871b54
-  url: 'https://files.pythonhosted.org/packages/dd/f6/ed485ff22efdd7b371d0dbbf6d77ad61c3b3b7e0815a83c89cbb38ce35de/sympy-1.3.tar.gz'
-
+  version: 1.6.2
 requirements:
   run:
-    - mpmath
-
+  - mpmath
+source:
+  sha256: 1cfadcc80506e4b793f5b088558ca1fcbeaec24cd6fc86f1fdccaa3ee1d48708
+  url: https://files.pythonhosted.org/packages/8a/43/d433f66b01a355d12602ccc7de409aea4b3a1cfdb7a2fb5dac57eb4b09c1/sympy-1.6.2.tar.gz
 test:
   imports:
-    - sympy
+  - sympy

--- a/packages/traits/meta.yaml
+++ b/packages/traits/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: traits
-  version: 6.1.0
+  version: 6.1.1
 source:
-  sha256: 97fca523374ae85e3d8fd78af9a9f488aee5e88e8b842e1cfd6d637a6f310fac
-  url: https://files.pythonhosted.org/packages/95/b4/a780c097a91c9407e5c86ca24a77d0f3d8fc2110a7df9f6d0be65d409fd8/traits-6.1.0.tar.gz
+  sha256: 807da52ee0d4fc1241c8f8a04d274a28d4b23d3a5f942152497d19405482d04f
+  url: https://files.pythonhosted.org/packages/94/d4/be3765c4c1ada555a91daa5cc9df3b6c2557ec4b55ba181c23ef5682e1f8/traits-6.1.1.tar.gz
 test:
   imports:
   - traits

--- a/packages/uncertainties/meta.yaml
+++ b/packages/uncertainties/meta.yaml
@@ -4,6 +4,9 @@ package:
 source:
   sha256: 63548a94899f2a51eeb89b640f6ac311f481a8016b37dce157186e44619bc968
   url: https://files.pythonhosted.org/packages/72/16/a5bdfdb39f83bf38a7750a4446977fc5aba9027da7abb922c93a372e1d0e/uncertainties-3.1.4.tar.gz
+requirements:
+  run:
+    - future
 test:
   imports:
   - uncertainties

--- a/packages/uncertainties/meta.yaml
+++ b/packages/uncertainties/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: uncertainties
-  version: 3.1.2
+  version: 3.1.4
 source:
-  sha256: ba07c17a8a78cb58a47cd373079c7ea459f8b26cd474e29163b6ba0d72856a1e
-  url: https://files.pythonhosted.org/packages/2a/c2/babbe5b16141859dd799ed31c03987100a7b6d0ca7c0ed4429c96ce60fdf/uncertainties-3.1.2.tar.gz
+  sha256: 63548a94899f2a51eeb89b640f6ac311f481a8016b37dce157186e44619bc968
+  url: https://files.pythonhosted.org/packages/72/16/a5bdfdb39f83bf38a7750a4446977fc5aba9027da7abb922c93a372e1d0e/uncertainties-3.1.4.tar.gz
 test:
   imports:
   - uncertainties


### PR DESCRIPTION
This updates 24 pure python packages included in Pyodide to the latest version on PyPi using the script from https://github.com/iodide-project/pyodide/pull/569