### PR TITLE
Fix lint CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
           name: lint
           command: |
             pip install black mypy
+            # TODO: investigate why clang-format without version is not available
+            sudo ln -s /usr/bin/clang-format-6.0 /usr/bin/clang-format
             make lint
             black --check --exclude tools/file_packager.py .
             mypy --ignore-missing-imports pyodide_build/ src/ test/ packages/micropip/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/benchmark/benchmarks/allpairs_distances.py
+++ b/benchmark/benchmarks/allpairs_distances.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def allpairs_distances(A, B):
-    """ This returns the euclidean distances squared
+    """This returns the euclidean distances squared
     dist2(x, y) = dot(x, x) - 2 * dot(x, y) + dot(y, y)
     """
     A2 = np.einsum("ij,ij->i", A, A)

--- a/benchmark/benchmarks/julia.py
+++ b/benchmark/benchmarks/julia.py
@@ -6,8 +6,8 @@ import numpy as np
 
 
 def kernel(zr, zi, cr, ci, lim, cutoff):
-    """ Computes the number of iterations `n` such that
-        |z_n| > `lim`, where `z_n = z_{n-1}**2 + c`.
+    """Computes the number of iterations `n` such that
+    |z_n| > `lim`, where `z_n = z_{n-1}**2 + c`.
     """
     count = 0
     while ((zr * zr + zi * zi) < (lim * lim)) and count < cutoff:
@@ -17,8 +17,8 @@ def kernel(zr, zi, cr, ci, lim, cutoff):
 
 
 def julia(cr, ci, N, bound=1.5, lim=1000.0, cutoff=1e6):
-    """ Pure Python calculation of the Julia set for a given `c`.  No NumPy
-        array operations are used.
+    """Pure Python calculation of the Julia set for a given `c`.  No NumPy
+    array operations are used.
     """
     julia = np.empty((N, N), np.uint32)
     grid_x = np.linspace(-bound, bound, N)

--- a/benchmark/benchmarks/mandel.py
+++ b/benchmark/benchmarks/mandel.py
@@ -6,9 +6,9 @@
 
 def kernel(x, y, max_iters):
     """
-      Given the real and imaginary parts of a complex number,
-      determine if it is a candidate for membership in the Mandelbrot
-      set given a fixed number of iterations.
+    Given the real and imaginary parts of a complex number,
+    determine if it is a candidate for membership in the Mandelbrot
+    set given a fixed number of iterations.
     """
     c = complex(x, y)
     z = 0.0j

--- a/benchmark/benchmarks/slowparts.py
+++ b/benchmark/benchmarks/slowparts.py
@@ -8,8 +8,7 @@ from numpy import zeros, power, tanh
 
 
 def slowparts(d, re, preDz, preWz, SRW, RSW, yxV, xyU, resid):
-    """ computes the linear algebra intensive part of the gradients of the grae
-    """
+    """computes the linear algebra intensive part of the gradients of the grae"""
 
     def fprime(x):
         return 1 - power(tanh(x), 2)

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -27,7 +27,10 @@ def _extract_sdist(pypi_metadata: Dict[str, Any]) -> Dict:
 
     raise Exception(
         "No sdist URL found for package %s (%s)"
-        % (pypi_metadata["info"].get("name"), pypi_metadata["info"].get("package_url"),)
+        % (
+            pypi_metadata["info"].get("name"),
+            pypi_metadata["info"].get("package_url"),
+        )
     )
 
 


### PR DESCRIPTION
It looks like the `clang-format` format executable can no longer be found in the docker image and `clang-format-6.0` needs to be used. This is quite strange since the Docker image shouldn't have changed.

This is a quick workaround to avoid CI failure.

**Edit:** actually `clang-format` was failing in the past as well, but the exit code was not properly checked. The issue now was the black 20.8b1 release that had a few backward incompatible formatting changes.