### PR TITLE
Use JsDelivr for distributing pyodide packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ build/pyodide_dev.js: src/pyodide.js
 
 build/pyodide.js: src/pyodide.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.15.0/full/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://cdn.jsdelivr.net/pyodide/v0.15.0/full/#g' $@
 
 	sed -i -e "s#{{ABI}}#$(PYODIDE_PACKAGE_ABI)#g" $@
 
@@ -127,7 +127,7 @@ build/renderedhtml.css: src/renderedhtml.less
 
 build/webworker.js: src/webworker.js
 	cp $< $@
-	sed -i -e 's#{{DEPLOY}}#https://pyodide-cdn2.iodide.io/v0.15.0/full/#g' $@
+	sed -i -e 's#{{DEPLOY}}#https://cdn.jsdelivr.net/pyodide/v0.15.0/full/#g' $@
 
 build/webworker_dev.js: src/webworker.js
 	cp $< $@

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,8 +3,13 @@
 ## Version 0.16.0
 *Unreleased*
 
-- Pyodide now includes CPython 3.8.2
+- Pyodide includes CPython 3.8.2
   [#712](https://github.com/iodide-project/pyodide/pull/712)
+- Pyodide files are distributed by [JsDelivr CDN](https://www.jsdelivr.com/),
+  `https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js`
+  The previous CDN `pyodide-cdn2.iodide.io` still works and there
+  are no plans for deprecating it. However please use
+  JsDelivr CDN as a more sustainable solution.
 - FIX Only call `Py_INCREF()` once when proxied by PyProxy
   [#708](https://github.com/iodide-project/pyodide/pull/708)
 - Updated docker image to Debian buster

--- a/docs/pypi.md
+++ b/docs/pypi.md
@@ -73,9 +73,9 @@ javascript"](./using_pyodide_from_javascript.html) a complete example would be,
 <body>
   <script type="text/javascript">
       // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-      window.languagePluginUrl = 'https://pyodide-cdn2.iodide.io/v0.15.0/full/';
+      window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.15.0/full/';
   </script>
-  <script type="text/javascript" src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js"></script>
   <script type="text/javascript">
     pythonCode = `
       def do_work(*args):

--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -7,7 +7,7 @@ Iodide](using_pyodide_from_iodide.md).
 
 To include Pyodide in your project you can use the following CDN URL,
 
-  https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js
+  https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js
 
 You can also download a release from
 [Github releases](https://github.com/iodide-project/pyodide/releases)
@@ -51,9 +51,9 @@ Create and save a test `index.html` page with the following contents:
   <head>
       <script type="text/javascript">
           // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-          window.languagePluginUrl = 'https://pyodide-cdn2.iodide.io/v0.15.0/full/';
+          window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.15.0/full/';
       </script>
-      <script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+      <script src="https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js"></script>
   </head>
   <body>
     Pyodide test page <br>
@@ -113,9 +113,9 @@ Note: although the function is called Async, it still blocks the main thread. To
 <!DOCTYPE html>
 <head>
     <script type="text/javascript">
-        window.languagePluginUrl = 'https://pyodide-cdn2.iodide.io/v0.15.0/full/';
+        window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.15.0/full/';
     </script>
-    <script src="https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Pyodide packages are now also distributed by [JsDelivr](https://www.jsdelivr.com/), for instance, as,
```
https://cdn.jsdelivr.net/pyodide/v0.15.0/full/pyodide.js
```
This is currently the recommended way of downloading pyodide.

The previous CDN (`pyodide-cdn2.iodide.io`) still works, will work for future versions and there are currently no plans for deprecating it. However, the volume of downloads has increased a lot these last few months (~1.5 TB for October) and our data transfer costs start to become non negligible.

Please use JsDelivr download links, particularly if you deploy pyodide on high traffic websites. It will be a more sustainable and reliable solution long term.

Thanks to @MartinKolarik for making this possible, and to @ehfd for raising this point earlier.

(We should probably also add a section on Partners/Sponsor organizations in the documentation in the future).

Closes https://github.com/iodide-project/pyodide/issues/669, closes https://github.com/iodide-project/pyodide/issues/760, closes https://github.com/iodide-project/pyodide/issues/762, closes https://github.com/iodide-project/pyodide/issues/751

cc @wlach @casatir