### PR TITLE
MAINT Update cibuilds image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: cibuilds/github:0.10
+      - image: cibuilds/github:0.13
 
     steps:
       - checkout


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/667

Because the updated images contains Python 3.7.7 instead of 3.6.6 previously, this should fix the mime type issues when uploading releases.