### PR TITLE
Add yt package

### DIFF
--- a/packages/yt/meta.yaml
+++ b/packages/yt/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: yt
+  version: 3.5.1
+
+source:
+  url: https://pypi.io/packages/source/y/yt/yt-3.5.1.tar.gz
+  sha256: c8ef8eceb934dc189d63dc336109fad3002140a9a32b19f38d1812d5d5a30d71
+
+  patches:
+    - patches/skip-openmp.patch
+
+requirements:
+  run:
+    - numpy
+    - matplotlib
+    - sympy
+    - setuptools
+
+test:
+  imports:
+    - yt

--- a/packages/yt/patches/skip-openmp.patch
+++ b/packages/yt/patches/skip-openmp.patch
@@ -1,0 +1,13 @@
+diff --git a/setupext.py b/setupext.py
+index 92c456bab..ce2c5fbad 100644
+--- a/setupext.py
++++ b/setupext.py
+@@ -58,6 +58,8 @@ def check_for_openmp():
+     Robitaille and Curtis McCully.
+     """
+ 
++    return False
++
+     # See https://bugs.python.org/issue25150
+     if sys.version_info[:3] == (3, 5, 0):
+         return False


### PR DESCRIPTION
Hi!  This adds the yt package (https://yt-project.org/ ; https://github.com/yt-project/yt/ ) to the list of packages.  It's not the most recent version, and we're also aiming to have a new release reasonably soon, in which case I'll update it.

It doesn't take a lot of time to build, but it is non-zero, and it's a bit of a niche package, so if this doesn't fit I understand.  Or, if there's a way to disable it in the build by default, I can do that and serve it myself somehow.  Thank you!