### PR TITLE
Adding new flag for prebuilt docker version

### DIFF
--- a/run_docker
+++ b/run_docker
@@ -27,6 +27,7 @@ function error() {
 
 
 PYODIDE_IMAGE_TAG="0.16.1"
+PYODIDE_PREBUILT_IMAGE_TAG="0.16.0b1"
 DEFAULT_PYODIDE_DOCKER_IMAGE="iodide/pyodide-env:${PYODIDE_IMAGE_TAG}"
 DEFAULT_PYODIDE_SYSTEM_PORT="8000"
 
@@ -43,7 +44,7 @@ do
           echo "WARNING: will use the env var PYODIDE_DOCKER_IMAGE=${PYODIDE_DOCKER_IMAGE},
           the flag --pre-built has no effect"
         fi
-        DEFAULT_PYODIDE_DOCKER_IMAGE="iodide/pyodide:${PYODIDE_IMAGE_TAG}"
+        DEFAULT_PYODIDE_DOCKER_IMAGE="iodide/pyodide:${PYODIDE_PREBUILT_IMAGE_TAG}"
         shift
       ;;
       -p|--port)


### PR DESCRIPTION
Because docker env and docker prebuilt images do not have the same version right now, and as a result the setup script instructions for contributors on Mac OS does not work as described in README.md. 