### PR TITLE
Remove external dependencies from file_packager.py

### DIFF
--- a/docs/new_packages.md
+++ b/docs/new_packages.md
@@ -148,3 +148,54 @@ Shell commands to run after building the library. These are run inside of
 A list of required packages.
 
 (Unlike conda, this only supports package names, not versions).
+
+## Manual creation of a Pyodide package (advanced)
+The previous sections describes how to add a python package to the pyodide
+build.
+
+There are cases where you want to ship additional python libraries without
+adding it to pyodide itself. For pure python packages, this can be achieved
+reasonably easily. The most straightforward way is to create a Python wheel and
+load it with micropip. Alternatively, we can construct a python package
+manually.
+
+It is helpful to have some understanding of the structure of a Pyodide package.
+Pyodide is obtained by compiling CPython into web assembly. As such, it loads
+packages the same way as CPython --- it looks for relevant files `.py` files in
+`/lib/python3.x/`. When creating and loading a package, our job is to put our
+`.py` files in the right location in emscripten's virtual filesystem.
+
+Suppose you have a python library that consists of a single directory
+`/PATH/TO/LIB/` whose contents would go into
+`/lib/python3.8/site-packages/PACKAGE_NAME/` under a normal python
+installation.
+
+The simplest version of the corresponding Pyodide package contains two files
+--- `PACKAGE_NAME.data` and `PACKAGE_NAME.js`. The first file
+`PACKAGE_NAME.data` is a concatenation of all contents of `/PATH/TO/LIB`. When
+loading the package via `pyodide.loadPackage`, Pyodide will load and run
+`PACKAGE_NAME.js`. The script then fetches `PACKAGE_NAME.data` and extracts the
+contents to emscripten's virtual filesystem. Afterwards, since the files are
+now in `/lib/python3.8/`, running `import PACKAGE_NAME` in python will
+successfully import the module as usual.
+
+To produce these files, download the `file_packager.py` script from
+[https://github.com/iodide-project/pyodide/blob/master/tools/file_packager.py](https://github.com/iodide-project/pyodide/blob/master/tools/file_packager.py). You then run the command
+```sh
+$ ./file_packager.py PACKAGE_NAME.data --js-output=PACKAGE_NAME.js --abi=1 --export-name=pyodide._module --use-preload-plugins --preload /PATH/TO/LIB/@/lib/python3.8/site-packages/PACKAGE_NAME/ --exclude "*__pycache__*"
+```
+The `--preload` argument instructs the package to look for the file/directory
+before the separator `@` (namely `/PATH/TO/LIB/`) and place it at the path
+after the `@` in the virtual filesystem (namely
+`/lib/python3.8/site-packages/PACKAGE_NAME/`). Remember to use the correct python version in the target path. At the time of writing, the latest release of Pyodide uses python 3.7 while git master uses python 3.8.
+
+The `--exclude` argument
+specifies files to omit from the package. This argument can be repeated, e.g.
+you can append `--exclude README.md` to the command.
+
+**Remark.** The bundled Pyodide packages uses lz4 compression when producing
+`PACKAGE_NAME.data`. These instructions skip this step as it requires
+additional dependencies, which complicates the process. In general, lz4
+compression decreases memory usage and can increase performance. On the other
+hand, if your webserver serves the files with gzip compression, pre-compressing
+with lz4 could in fact increase the number of bytes transferred.

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # flake8: noqa
 
 # This is forked from emscripten 1.38.22, with the original copyright notice
@@ -72,20 +74,7 @@ import random
 import uuid
 import ctypes
 
-emscripten_dir = os.path.join(
-  os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-  'emsdk', 'emsdk', 'fastcomp', 'emscripten'
-)
-tag_dir = sorted(os.listdir(emscripten_dir), key=lambda x: len(x))[0]
-sys.path.insert(1, emscripten_dir)
-
-from tools.toolchain_profiler import ToolchainProfiler
-if __name__ == '__main__':
-  ToolchainProfiler.record_process_start()
-
 import posixpath
-from tools import shared
-from tools.jsrun import run_js
 from subprocess import PIPE
 import fnmatch
 import json
@@ -250,6 +239,10 @@ code = '''
       if (!check) throw msg + new Error().stack;
     }
 '''
+
+def escape_for_js_string(s):
+  s = s.replace('\\', '/').replace("'", "\\'").replace('"', '\\"')
+  return s
 
 
 def has_hidden_attribute(filepath):
@@ -534,9 +527,19 @@ if has_preloaded:
           }
     '''
     use_data += ("          Module['removeRunDependency']('datafile_%s');\n"
-                 % shared.JS.escape_for_js_string(data_target))
+                 % escape_for_js_string(data_target))
 
   else:
+    emscripten_dir = os.path.join(
+      os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+      'emsdk', 'emsdk', 'fastcomp', 'emscripten'
+    )
+    tag_dir = sorted(os.listdir(emscripten_dir), key=lambda x: len(x))[0]
+    sys.path.insert(1, emscripten_dir)
+
+    from tools import shared
+    from tools.jsrun import run_js
+
     # LZ4FS usage
     temp = data_target + '.orig'
     shutil.move(data_target, temp)
@@ -551,7 +554,7 @@ if has_preloaded:
           assert(typeof Module.LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
           Module.LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
           Module['removeRunDependency']('datafile_%s');
-    ''' % (meta, shared.JS.escape_for_js_string(data_target))
+    ''' % (meta, escape_for_js_string(data_target))
 
   package_uuid = uuid.uuid4()
   package_name = data_target
@@ -574,8 +577,8 @@ if has_preloaded:
       err('warning: you defined Module.locateFilePackage, that has been renamed to Module.locateFile (using your locateFilePackage for now)');
     }
     var REMOTE_PACKAGE_NAME = Module['locateFile'] ? Module['locateFile'](REMOTE_PACKAGE_BASE, '') : REMOTE_PACKAGE_BASE;
-  ''' % (shared.JS.escape_for_js_string(data_target),
-         shared.JS.escape_for_js_string(remote_package_name))
+  ''' % (escape_for_js_string(data_target),
+         escape_for_js_string(remote_package_name))
   metadata['remote_package_size'] = remote_package_size
   metadata['package_uuid'] = str(package_uuid)
   ret += '''
@@ -802,7 +805,7 @@ if has_preloaded:
       %s
     };
     Module['addRunDependency']('datafile_%s');
-  ''' % (use_data, shared.JS.escape_for_js_string(data_target))
+  ''' % (use_data, escape_for_js_string(data_target))
   # use basename because from the browser's point of view,
   # we need to find the datafile in the same dir as the html file
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -534,7 +534,6 @@ if has_preloaded:
       os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
       'emsdk', 'emsdk', 'fastcomp', 'emscripten'
     )
-    tag_dir = sorted(os.listdir(emscripten_dir), key=lambda x: len(x))[0]
     sys.path.insert(1, emscripten_dir)
 
     from tools import shared


### PR DESCRIPTION
With the change, if `file_packager.py` is invoked without the `lz4`
configuration option, then it does not use any external dependencies,
making it easier for downstream users to package their python libraries.

This commit also adds documentation for how to package third-party
python libraries for use with Pyodide.

Fixes #808
