### PR TITLE
Update SIZEOF_OFF_T to 8 in numpy/config.h

### DIFF
--- a/packages/numpy/config/config.h
+++ b/packages/numpy/config/config.h
@@ -1,6 +1,6 @@
 #define HAVE_ENDIAN_H 1
 #define SIZEOF_PY_INTPTR_T 4
-#define SIZEOF_OFF_T 4
+#define SIZEOF_OFF_T 8
 #define SIZEOF_PY_LONG_LONG 8
 #define MATHLIB m
 #define HAVE_SIN 1


### PR DESCRIPTION
It was changed from 4 to 8 in emscripten 1.38.31. Before the patch, compiling numpy gives some warnings about redefining SIZEOF_OFF_T, but as far as I can tell, it did not cause any real issues.