### PR TITLE
Pave way to compiling packages with system python

### DIFF
--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -132,6 +132,13 @@ def make_parser(parser):
         help="The path to the target Python installation",
     )
     parser.add_argument(
+        "--install-dir",
+        type=str,
+        nargs="?",
+        default="",
+        help="Directory for installing built host packages. Defaults to setup.py default. Set to 'skip' to skip installation. Installation is needed if you want to build other packages that depend on this one.",
+    )
+    parser.add_argument(
         "--only",
         type=str,
         nargs="?",

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -136,7 +136,9 @@ def make_parser(parser):
         type=str,
         nargs="?",
         default="",
-        help="Directory for installing built host packages. Defaults to setup.py default. Set to 'skip' to skip installation. Installation is needed if you want to build other packages that depend on this one.",
+        help="Directory for installing built host packages. Defaults to setup.py\
+default. Set to 'skip' to skip installation. Installation is needed if you want\
+to build other packages that depend on this one.",
     )
     parser.add_argument(
         "--only",

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -136,9 +136,11 @@ def make_parser(parser):
         type=str,
         nargs="?",
         default="",
-        help="Directory for installing built host packages. Defaults to setup.py\
-default. Set to 'skip' to skip installation. Installation is needed if you want\
-to build other packages that depend on this one.",
+        help=(
+            "Directory for installing built host packages. Defaults to setup.py "
+            "default. Set to 'skip' to skip installation. Installation is "
+            "needed if you want to build other packages that depend on this one."
+        ),
     )
     parser.add_argument(
         "--only",

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -308,9 +308,11 @@ def make_parser(parser: argparse.ArgumentParser):
         type=str,
         nargs="?",
         default="",
-        help="Directory for installing built host packages. Defaults to setup.py\
-default. Set to 'skip' to skip installation. Installation is needed if you want\
-to build other packages that depend on this one.",
+        help=(
+            "Directory for installing built host packages. Defaults to setup.py "
+            "default. Set to 'skip' to skip installation. Installation is "
+            "needed if you want to build other packages that depend on this one."
+        ),
     )
     return parser
 

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -155,6 +155,8 @@ def compile(path: Path, srcpath: Path, pkg: Dict[str, Any], args):
                 args.host,
                 "--target",
                 args.target,
+                "--install-dir",
+                args.install_dir,
             ],
             env=env,
             check=True,
@@ -300,6 +302,13 @@ def make_parser(parser: argparse.ArgumentParser):
         nargs="?",
         default=common.TARGETPYTHON,
         help="The path to the target Python installation",
+    )
+    parser.add_argument(
+        "--install-dir",
+        type=str,
+        nargs="?",
+        default="",
+        help="Directory for installing built host packages. Defaults to setup.py default. Set to 'skip' to skip installation. Installation is needed if you want to build other packages that depend on this one.",
     )
     return parser
 

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -308,7 +308,9 @@ def make_parser(parser: argparse.ArgumentParser):
         type=str,
         nargs="?",
         default="",
-        help="Directory for installing built host packages. Defaults to setup.py default. Set to 'skip' to skip installation. Installation is needed if you want to build other packages that depend on this one.",
+        help="Directory for installing built host packages. Defaults to setup.py\
+default. Set to 'skip' to skip installation. Installation is needed if you want\
+to build other packages that depend on this one.",
     )
     return parser
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -121,7 +121,7 @@ def capture_compile(args):
     env["PATH"] = str(ROOTDIR) + ":" + os.environ["PATH"]
 
     result = subprocess.run(
-        [Path(args.host) / "bin" / "python3", "setup.py", "install"], env=env
+        [Path(args.host) / "bin" / "python3", "setup.py", "build"], env=env
     )
     if result.returncode != 0:
         build_log_path = Path("build.log")
@@ -238,14 +238,14 @@ def handle_command(line, args, dryrun=False):
     # Go through and adjust arguments
     for arg in line[1:]:
         if arg.startswith("-I"):
-            # Don't include any system directories
-            if arg[2:].startswith("/usr"):
-                continue
             if (
                 str(Path(arg[2:]).resolve()).startswith(args.host)
                 and "site-packages" not in arg
             ):
                 arg = arg.replace("-I" + args.host, "-I" + args.target)
+            # Don't include any system directories
+            elif arg[2:].startswith("/usr"):
+                continue
         # Don't include any system directories
         if arg.startswith("-L/usr"):
             continue

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -427,7 +427,9 @@ def make_parser(parser):
             type=str,
             nargs="?",
             default="",
-            help="Directory for installing built host packages. Defaults to setup.py default. Set to 'skip' to skip installation. Installation is needed if you want to build other packages that depend on this one.",
+            help="Directory for installing built host packages. Defaults to setup.py\
+default. Set to 'skip' to skip installation. Installation is needed if you want\
+to build other packages that depend on this one.",
         )
     return parser
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -427,9 +427,11 @@ def make_parser(parser):
             type=str,
             nargs="?",
             default="",
-            help="Directory for installing built host packages. Defaults to setup.py\
-default. Set to 'skip' to skip installation. Installation is needed if you want\
-to build other packages that depend on this one.",
+            help=(
+                "Directory for installing built host packages. Defaults to setup.py "
+                "default. Set to 'skip' to skip installation. Installation is "
+                "needed if you want to build other packages that depend on this one."
+            ),
         )
     return parser
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -120,9 +120,13 @@ def capture_compile(args):
     make_symlinks(env)
     env["PATH"] = str(ROOTDIR) + ":" + os.environ["PATH"]
 
-    result = subprocess.run(
-        [Path(args.host) / "bin" / "python3", "setup.py", "build"], env=env
-    )
+    cmd = [Path(args.host) / "bin" / "python3", "setup.py", "install"]
+    if args.install_dir == "skip":
+        cmd[-1] = "build"
+    elif args.install_dir != "":
+        cmd.extend(["--home", args.install_dir])
+
+    result = subprocess.run(cmd, env=env)
     if result.returncode != 0:
         build_log_path = Path("build.log")
         if build_log_path.exists():
@@ -417,6 +421,13 @@ def make_parser(parser):
             nargs="?",
             default=common.TARGETPYTHON,
             help="The path to the target Python installation",
+        )
+        parser.add_argument(
+            "--install-dir",
+            type=str,
+            nargs="?",
+            default="",
+            help="Directory for installing built host packages. Defaults to setup.py default. Set to 'skip' to skip installation. Installation is needed if you want to build other packages that depend on this one.",
         )
     return parser
 


### PR DESCRIPTION
This consists of two changes:

 - Don't ignore -I/usr/* compiler arguments if it is for the host python

 - When capturing the compile commands, use setup.py build instead of
   setup.py install, so that we don't need to be able to write to the
   host python directory (we can also configure it to install elsewhere
   but this seems more straightforward).
