### PR TITLE
PKG Downgrade parso to 0.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,8 @@ packages/six/six-1.11.0
 packages/lz4/lz4-1.8.3
 packages/CLAPACK/CLAPACK-WA
 packages/CLAPACK/clapack.tgz
-packages/jedi/jedi-0.15.1
-packages/parso/parso-0.5.1
+packages/jedi/jedi-*
+packages/parso/parso-*
 packages/libxml/libxml*
 packages/libxslt/libxslt*
 packages/libiconv/libiconv*

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ SIX_LIBS=$(SIX_ROOT)/six.py
 JEDI_ROOT=packages/jedi/jedi-0.17.2/jedi
 JEDI_LIBS=$(JEDI_ROOT)/__init__.py
 
-PARSO_ROOT=packages/parso/parso-0.8.0/parso
+PARSO_ROOT=packages/parso/parso-0.7.1/parso
 PARSO_LIBS=$(PARSO_ROOT)/__init__.py
 
 SITEPACKAGES=root/lib/python$(PYMINOR)/site-packages

--- a/packages/parso/Makefile
+++ b/packages/parso/Makefile
@@ -1,14 +1,14 @@
 PYODIDE_ROOT=$(abspath ../..)
 include ../../Makefile.envs
 
-PARSOVERSION=0.8.0
+PARSOVERSION=0.7.1
 
 ROOT=$(abspath .)
 
 SRC=$(ROOT)/parso-$(PARSOVERSION)
 BUILD=$(SRC)/build/lib/parso
 TARBALL=$(ROOT)/downloads/parso-$(PARSOVERSION).tar.gz
-URL=https://files.pythonhosted.org/packages/cb/1b/1d846fff1f5b10907fbfece4901410823ec529f9ee9193451278451fcb6e/parso-$(PARSOVERSION).tar.gz
+URL=https://files.pythonhosted.org/packages/40/01/e0b8d2168fb299af90a78a5919257f821e5c21399bf0906c14c9e573db3f/parso-$(PARSOVERSION).tar.gz
 
 
 all: $(SRC)/setup.py

--- a/packages/parso/checksums
+++ b/packages/parso/checksums
@@ -1,1 +1,1 @@
-2b6db14759c528d857eeb9eac559c2166b2554548af39f5198bdfb976f72aa64 downloads/parso-0.8.0.tar.gz
+caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9 downloads/parso-0.7.1.tar.gz


### PR DESCRIPTION
This is what jedi 0.17.2 wants.

This addresses the crashes observed in the comments of #821 (but not the original issue)
