### PR TITLE
BLD/FIX Remove ASSERTIONS build option

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -21,7 +21,6 @@ DEFAULTLDFLAGS = " ".join(
         "-s", "LINKABLE=1",
         "-s", "EXPORT_ALL=1",
         "-s", "ERROR_ON_MISSING_LIBRARIES=0",
-        "-s", "ASSERTIONS=1",
     ]
 )
 # fmt: on


### PR DESCRIPTION
Remove the ASSERTIONS build option which was temporarily introduced for debugging in https://github.com/iodide-project/pyodide/pull/480 and wasn't removed before merging that PR by mistake. It has a non negligible performance cost. 