### PR TITLE
BLD Fix for compiler_compat flag in conda env

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -306,6 +306,12 @@ def handle_command(line, args, dryrun=False):
             new_args.append("-Os")
             continue
 
+        if new_args[-1].startswith("-B") and "compiler_compat" in arg:
+            # conda uses custom compiler search paths with the compiler_compat folder.
+            # Ignore it.
+            del new_args[-1]
+            continue
+
         new_args.append(arg)
 
     # This can only be used for incremental rebuilds -- it generates

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -59,3 +59,11 @@ def test_f2c():
         f2c_wrap("gfortran --shared -c test.o -o test.so")
         == "gfortran --shared -c test.o -o test.so"
     )
+
+
+def test_conda_compiler_compat():
+    Args = namedtuple("args", ["cflags", "ldflags", "host"])
+    args = Args(cflags="", ldflags="", host="")
+    assert handle_command_wrap(
+        "gcc -shared -c test.o -B /compiler_compat -o test.so", args
+    ) == ("emcc -shared -c test.bc -o test.wasm")


### PR DESCRIPTION
conda uses uses custom compiler search paths via the 
```
  -B <directory>           Add <directory> to the compiler's search paths.
```
gcc option that is not supported by emcc. So we need to explicitly ignore it in `pyodide_build/pywasmcross.py` as otherwise one gets the following error


```
emcc -O2 ... -shared -B /miniconda3/envs/pyodide-env/compiler_compat -L/miniconda3/envs/pyodide-env/lib -Wl, ... build/temp.linux-x86_64-3.8/src/markupsafe/_speedups.bc -o markupsafe/_speedups.cpython-38-x86_64-linux-gnu.wasm
shared:ERROR: miniconda3/envs/pyodide-env/compiler_compat: Input file has an unknown suffix, don't know what to do with it!
```

This in particular happens when compling pyodide in a conda env, following https://github.com/iodide-project/pyodide/pull/830

Toward https://github.com/iodide-project/pyodide/issues/795