### PR TITLE
Remove --host argument in pyodide_build

### DIFF
--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -118,13 +118,6 @@ def make_parser(parser):
         help="Extra linking flags",
     )
     parser.add_argument(
-        "--host",
-        type=str,
-        nargs="?",
-        default=common.HOSTPYTHON,
-        help="The path to the host Python installation",
-    )
-    parser.add_argument(
         "--target",
         type=str,
         nargs="?",

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 from urllib import request
 from datetime import datetime
 from typing import Any, Dict
@@ -143,7 +144,7 @@ def compile(path: Path, srcpath: Path, pkg: Dict[str, Any], args):
     try:
         subprocess.run(
             [
-                str(Path(args.host) / "bin" / "python3"),
+                sys.executable,
                 "-m",
                 "pyodide_build",
                 "pywasmcross",
@@ -151,8 +152,6 @@ def compile(path: Path, srcpath: Path, pkg: Dict[str, Any], args):
                 args.cflags + " " + pkg.get("build", {}).get("cflags", ""),
                 "--ldflags",
                 args.ldflags + " " + pkg.get("build", {}).get("ldflags", ""),
-                "--host",
-                args.host,
                 "--target",
                 args.target,
                 "--install-dir",
@@ -288,13 +287,6 @@ def make_parser(parser: argparse.ArgumentParser):
         nargs="?",
         default=common.DEFAULTLDFLAGS,
         help="Extra linking flags",
-    )
-    parser.add_argument(
-        "--host",
-        type=str,
-        nargs="?",
-        default=common.HOSTPYTHON,
-        help="The path to the host Python installation",
     )
     parser.add_argument(
         "--target",

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Optional, Set
-import sys
 
 ROOTDIR = Path(__file__).parents[1].resolve() / "tools"
 TARGETPYTHON = ROOTDIR / ".." / "cpython" / "installs" / "python-3.8.2"

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -3,7 +3,6 @@ from typing import Optional, Set
 import sys
 
 ROOTDIR = Path(__file__).parents[1].resolve() / "tools"
-HOSTPYTHON = sys.prefix
 TARGETPYTHON = ROOTDIR / ".." / "cpython" / "installs" / "python-3.8.2"
 DEFAULTCFLAGS = ""
 # fmt: off

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -356,7 +356,7 @@ def clean_out_native_artifacts():
 
 def install_for_distribution(args):
     commands = [
-        sys.exectuable,
+        sys.executable,
         "setup.py",
         "install",
         "--skip-build",

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -120,7 +120,7 @@ def capture_compile(args):
     make_symlinks(env)
     env["PATH"] = str(ROOTDIR) + ":" + os.environ["PATH"]
 
-    cmd = [Path(args.host) / "bin" / "python3", "setup.py", "install"]
+    cmd = [sys.executable, "setup.py", "install"]
     if args.install_dir == "skip":
         cmd[-1] = "build"
     elif args.install_dir != "":
@@ -239,15 +239,14 @@ def handle_command(line, args, dryrun=False):
 
     lapack_dir = None
 
-    host_dir = str(Path(args.host).resolve())
     # Go through and adjust arguments
     for arg in line[1:]:
         if arg.startswith("-I"):
             if (
-                str(Path(arg[2:]).resolve()).startswith(host_dir + "/include/python")
+                str(Path(arg[2:]).resolve()).startswith(sys.prefix + "/include/python")
                 and "site-packages" not in arg
             ):
-                arg = arg.replace("-I" + args.host, "-I" + args.target)
+                arg = arg.replace("-I" + sys.prefix, "-I" + args.target)
             # Don't include any system directories
             elif arg[2:].startswith("/usr"):
                 continue
@@ -357,7 +356,7 @@ def clean_out_native_artifacts():
 
 def install_for_distribution(args):
     commands = [
-        Path(args.host) / "bin" / "python3",
+        sys.exectuable,
         "setup.py",
         "install",
         "--skip-build",
@@ -408,13 +407,6 @@ def make_parser(parser):
             nargs="?",
             default=common.DEFAULTLDFLAGS,
             help="Extra linking flags",
-        )
-        parser.add_argument(
-            "--host",
-            type=str,
-            nargs="?",
-            default=common.HOSTPYTHON,
-            help="The path to the host Python installation",
         )
         parser.add_argument(
             "--target",


### PR DESCRIPTION
Instead, we assume that the currently running python is the host. This simplifies the build script slightly and avoids making assumptions like the binary is `sys.prefix`/bin/python3. Since it is easy for the user to choose which python to use to run the scripts, there is no loss in configurability.
