### PR TITLE
Build packages in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ packages/libxslt/libxslt*
 packages/libiconv/libiconv*
 packages/zlib/zlib*
 packages/.artifacts
+packages/*/build.log
 
 docs/python-api/
 docs/micropip-api/

--- a/docs/building_from_sources.md
+++ b/docs/building_from_sources.md
@@ -80,16 +80,15 @@ instance,
 PYODIDE_PACKAGES="toolz,attrs" make
 ```
 
-Note that this environment variable must contain both the packages and their
-dependencies. The package names must match the folder names in `packages/`
-exactly; in particular they are case sensitive.
+Dependencies of the listed packages will be built automatically as well.
+The package names must match the folder names in `packages/` exactly; in
+particular they are case sensitive.
 
-To build a minimal version of pyodide, set `PYODIDE_PACKAGES="micropip"`. The
-micropip and package is generally always included for any non empty value of
-`PYODIDE_PACKAGES`.
+To build a minimal version of pyodide, set `PYODIDE_PACKAGES=""`. The packages
+micropip and distutils are always automatically included.
 
 If scipy is included in `PYODIDE_PACKAGES`, BLAS/LAPACK must be manually built
-first with `make -c packages/CLAPACK`.
+first with `make -C packages/CLAPACK`.
 
 ## Environment variables
 

--- a/docs/building_from_sources.md
+++ b/docs/building_from_sources.md
@@ -84,8 +84,9 @@ Dependencies of the listed packages will be built automatically as well.
 The package names must match the folder names in `packages/` exactly; in
 particular they are case sensitive.
 
-To build a minimal version of pyodide, set `PYODIDE_PACKAGES=""`. The packages
-micropip and distutils are always automatically included.
+To build a minimal version of pyodide, set `PYODIDE_PACKAGES="micropip"`. The
+packages micropip and distutils are always automatically included (but an empty
+`PYODIDE_PACKAGES` is interpreted as unset).
 
 If scipy is included in `PYODIDE_PACKAGES`, BLAS/LAPACK must be manually built
 first with `make -C packages/CLAPACK`.

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -17,5 +17,5 @@ deps:
 	$(HOSTPYTHON) -m pip install "Cython<0.30.0" Tempita
 
 clean:
-	rm -rf ./*/build
+	rm -rf ./*/build ./*/build.log
 	rm -rf ./.artifacts

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -84,7 +84,10 @@ class Package:
     def __eq__(self, other) -> bool:
         return len(self.dependents) == len(other.dependents)
 
-def generate_dependency_graph(packages_dir: Path, package_list: Optional[str]) -> Dict[str, Package]:
+
+def generate_dependency_graph(
+    packages_dir: Path, package_list: Optional[str]
+) -> Dict[str, Package]:
     """
     This generates a dependency graph for the packages listed in package_list.
     A node in the graph is a Package object defined above, which maintains a
@@ -129,6 +132,7 @@ def generate_dependency_graph(packages_dir: Path, package_list: Optional[str]) -
             pkg_map[dep].dependents.add(pkg.name)
 
     return pkg_map
+
 
 def build_from_graph(pkg_map: Dict[str, Package], outputdir: Path, args) -> None:
     """
@@ -181,6 +185,7 @@ def build_from_graph(pkg_map: Dict[str, Package], outputdir: Path, args) -> None
             dependent.unbuilt_dependencies.remove(pkg.name)
             if len(dependent.unbuilt_dependencies) == 0:
                 build_queue.put(dependent)
+
 
 def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
     pkg_map = generate_dependency_graph(packages_dir, args.only)

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -64,7 +64,7 @@ class Package:
 
         with open(self.pkgdir / "build.log", "r") as f:
             for line in f:
-                print(line)
+                print(line, end="")
 
         shutil.copyfile(
             self.pkgdir / "build" / (self.name + ".data"),

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -17,7 +17,6 @@ from time import sleep
 from typing import Dict, Set, Optional, List
 
 from . import common
-from . import buildpkg
 
 
 @total_ordering
@@ -78,10 +77,10 @@ class Package:
 
     # We use this in the priority queue, which pops off the smallest element.
     # So we want the smallest element to have the largest number of dependents
-    def __lt__ (self, other):
+    def __lt__(self, other):
         return len(self.dependents) > len(other.dependents)
 
-    def __eq__ (self, other):
+    def __eq__(self, other):
         return len(self.dependents) == len(other.dependents)
 
 
@@ -150,7 +149,9 @@ def build_packages(packagesdir, outputdir, args):
             built_queue.put(pkg)
             sleep(0.01)
 
-    threads = [Thread(target=builder, daemon=True, args=(n,)).start() for n in range(0, 4)]
+    threads = [
+        Thread(target=builder, daemon=True, args=(n,)).start() for n in range(0, 4)
+    ]
 
     num_built = 0
     while num_built < len(pkg_map):
@@ -251,11 +252,7 @@ def make_parser(parser):
         ),
     )
     parser.add_argument(
-        "--num-threads",
-        type=str,
-        nargs="?",
-        default=4,
-        help="Number of threads to use"
+        "--num-threads", type=str, nargs="?", default=4, help="Number of threads to use"
     )
     return parser
 

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -150,7 +150,7 @@ def build_packages(packagesdir, outputdir, args):
             # Release the GIL so new packages get queued
             sleep(0.01)
 
-    for n in range(0, arg.num_threads):
+    for n in range(0, args.num_threads):
         Thread(target=builder, args=(n + 1,), daemon=True).start()
 
     num_built = 0

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -84,7 +84,7 @@ class Package:
     def __eq__(self, other) -> bool:
         return len(self.dependents) == len(other.dependents)
 
-def generate_dependency_graph(packagesdir: Path, package_list: Optional[str]) -> Dict[str, Package]:
+def generate_dependency_graph(packages_dir: Path, package_list: Optional[str]) -> Dict[str, Package]:
     """
     This generates a dependency graph for the packages listed in package_list.
     A node in the graph is a Package object defined above, which maintains a
@@ -97,9 +97,9 @@ def generate_dependency_graph(packagesdir: Path, package_list: Optional[str]) ->
     in the graph as its values.
 
     Parameters:
-     - packagesdir: directory that contains packages
+     - packages_dir: directory that contains packages
      - package_list: set of packages to build. If None, then all packages in
-       packagesdir are compiled.
+       packages_dir are compiled.
 
     Returns:
      - pkg_map: dictionary mapping package names to Package objects
@@ -110,13 +110,13 @@ def generate_dependency_graph(packagesdir: Path, package_list: Optional[str]) ->
     packages: Optional[Set[str]] = common._parse_package_subset(package_list)
     if packages is None:
         packages = set(
-            str(x) for x in packagesdir.iterdir() if (x / "meta.yaml").is_file()
+            str(x) for x in packages_dir.iterdir() if (x / "meta.yaml").is_file()
         )
 
     while packages:
         pkgname = packages.pop()
 
-        pkg = Package(packagesdir / pkgname)
+        pkg = Package(packages_dir / pkgname)
         pkg_map[pkg.name] = pkg
 
         for dep in pkg.dependencies:
@@ -182,8 +182,8 @@ def build_from_graph(pkg_map: Dict[str, Package], outputdir: Path, args) -> None
             if len(dependent.unbuilt_dependencies) == 0:
                 build_queue.put(dependent)
 
-def build_packages(packagesdir: Path, outputdir: Path, args) -> None:
-    pkg_map = generate_dependency_graph(packagesdir, args.only)
+def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
+    pkg_map = generate_dependency_graph(packages_dir, args.only)
 
     build_from_graph(pkg_map, outputdir, args)
 
@@ -276,9 +276,9 @@ def make_parser(parser):
 
 
 def main(args):
-    packagesdir = Path(args.dir[0]).resolve()
+    packages_dir = Path(args.dir[0]).resolve()
     outputdir = Path(args.output[0]).resolve()
-    build_packages(packagesdir, outputdir, args)
+    build_packages(packages_dir, outputdir, args)
 
 
 if __name__ == "__main__":

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -275,7 +275,11 @@ def make_parser(parser):
         ),
     )
     parser.add_argument(
-        "--n-jobs", type=int, nargs="?", default=4, help="Number of threads to use"
+        "--n-jobs",
+        type=int,
+        nargs="?",
+        default=4,
+        help="Number of packages to build in parallel",
     )
     return parser
 

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -27,7 +27,6 @@ class Package:
 
         assert self.name == pkgdir.stem
 
-        # List of unbuilt dependencies
         self.dependencies: List[str] = self.meta.get("requirements", {}).get("run", [])
         self.unbuilt_dependencies: Set[str] = set(self.dependencies)
         self.dependents: Set[str] = set()

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -37,7 +37,7 @@ class Package:
         self.unbuilt_dependencies: Set[str] = set(self.dependencies)
         self.dependents: Set[str] = set()
 
-    def build(self, outputdir: Path, args):
+    def build(self, outputdir: Path, args) -> None:
         with open(self.pkgdir / "build.log", "w") as f:
             p = subprocess.run(
                 [
@@ -78,14 +78,14 @@ class Package:
 
     # We use this in the priority queue, which pops off the smallest element.
     # So we want the smallest element to have the largest number of dependents
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return len(self.dependents) > len(other.dependents)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return len(self.dependents) == len(other.dependents)
 
 
-def build_packages(packagesdir: Path, outputdir: Path, args):
+def build_packages(packagesdir: Path, outputdir: Path, args) -> None:
     """
     The strategy for building packages is as follows --- we have a set of
     packages that we eventually want to build, each represented by a Package
@@ -133,12 +133,12 @@ def build_packages(packagesdir: Path, outputdir: Path, args):
 
     # Insert packages into build_queue. We *must* do this after counting
     # dependents, because the ordering ought not to change after insertion.
-    build_queue: PriorirtyQueue = PriorityQueue()
+    build_queue: PriorityQueue = PriorityQueue()
     for pkg in pkg_map.values():
         if len(pkg.dependencies) == 0:
             build_queue.put(pkg)
 
-    built_queue = Queue()
+    built_queue: Queue = Queue()
 
     def builder(n):
         print(f"Starting thread {n}")
@@ -159,8 +159,8 @@ def build_packages(packagesdir: Path, outputdir: Path, args):
         pkg = built_queue.get()
         num_built += 1
 
-        for dependent in pkg.dependents:
-            dependent = pkg_map[dependent]
+        for _dependent in pkg.dependents:
+            dependent = pkg_map[_dependent]
             dependent.unbuilt_dependencies.remove(pkg.name)
             if len(dependent.unbuilt_dependencies) == 0:
                 build_queue.put(dependent)
@@ -171,7 +171,7 @@ def build_packages(packagesdir: Path, outputdir: Path, args):
     # so we hardcode its existence here.
     #
     # This is done last so the Makefile can use it as a completion token.
-    package_data = {
+    package_data: dict = {
         "dependencies": {"test": []},
         "import_name_to_package_name": {},
     }

--- a/pyodide_build/tests/test_buildall.py
+++ b/pyodide_build/tests/test_buildall.py
@@ -1,0 +1,41 @@
+from collections import namedtuple
+import shutil
+import subprocess
+
+from pathlib import Path
+
+from pyodide_build import buildall
+
+PACKAGES_DIR = (Path(__file__) / ".." / ".." / ".." / "packages").resolve()
+
+def test_generate_dependency_graph():
+    package_list = "beautifulsoup4"
+
+    pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, package_list)
+
+    assert set(pkg_map.keys()), {'distlib', 'soupsieve', 'beautifulsoup4', 'micropip'}
+    assert pkg_map['soupsieve'].dependencies == []
+    assert pkg_map['soupsieve'].dependents == {'beautifulsoup4'}
+    assert pkg_map['beautifulsoup4'].dependencies == ['soupsieve']
+    assert pkg_map['beautifulsoup4'].dependents == set()
+
+def test_build_dependencies():
+    build_list = []
+    class MockPackage(buildall.Package):
+        def build(self, outputdir: Path, args) -> None:
+            build_list.append(self.name)
+
+    packages = {'micropip', 'distlib', 'soupsieve', 'beautifulsoup4'}
+    pkg_map = {}
+    for pkg in packages:
+        pkg_map[pkg] = MockPackage(PACKAGES_DIR / pkg)
+
+    pkg_map["distlib"].dependents.add("micropip")
+    pkg_map["soupsieve"].dependents.add("beautifulsoup4")
+
+    Args = namedtuple("args", ["n_jobs"])
+    buildall.build_from_graph(pkg_map, Path("."), Args(n_jobs=1))
+
+    assert set(build_list) == packages
+    assert build_list.index("distlib") < build_list.index("micropip")
+    assert build_list.index("soupsieve") < build_list.index("beautifulsoup4")

--- a/pyodide_build/tests/test_buildall.py
+++ b/pyodide_build/tests/test_buildall.py
@@ -1,6 +1,4 @@
 from collections import namedtuple
-import shutil
-import subprocess
 
 from pathlib import Path
 
@@ -8,24 +6,27 @@ from pyodide_build import buildall
 
 PACKAGES_DIR = (Path(__file__) / ".." / ".." / ".." / "packages").resolve()
 
+
 def test_generate_dependency_graph():
     package_list = "beautifulsoup4"
 
     pkg_map = buildall.generate_dependency_graph(PACKAGES_DIR, package_list)
 
-    assert set(pkg_map.keys()), {'distlib', 'soupsieve', 'beautifulsoup4', 'micropip'}
-    assert pkg_map['soupsieve'].dependencies == []
-    assert pkg_map['soupsieve'].dependents == {'beautifulsoup4'}
-    assert pkg_map['beautifulsoup4'].dependencies == ['soupsieve']
-    assert pkg_map['beautifulsoup4'].dependents == set()
+    assert set(pkg_map.keys()) == {"distlib", "soupsieve", "beautifulsoup4", "micropip"}
+    assert pkg_map["soupsieve"].dependencies == []
+    assert pkg_map["soupsieve"].dependents == {"beautifulsoup4"}
+    assert pkg_map["beautifulsoup4"].dependencies == ["soupsieve"]
+    assert pkg_map["beautifulsoup4"].dependents == set()
+
 
 def test_build_dependencies():
     build_list = []
+
     class MockPackage(buildall.Package):
         def build(self, outputdir: Path, args) -> None:
             build_list.append(self.name)
 
-    packages = {'micropip', 'distlib', 'soupsieve', 'beautifulsoup4'}
+    packages = {"micropip", "distlib", "soupsieve", "beautifulsoup4"}
     pkg_map = {}
     for pkg in packages:
         pkg_map[pkg] = MockPackage(PACKAGES_DIR / pkg)


### PR DESCRIPTION
The overarching idea of the refactoring is to build a global picture of the dependency tree before compiling. The immediate benefit of this refactoring is that PYODIDE_PACKAGES no longer needs manually including the package dependencies.

Further, the refactor is done with two additional features in mind, to be added in the future:

 - Instead of specifying skip_host in meta.yaml, a package can specify build dependencies, and skip_host is True iff it is not a build dependency of any other package

 - Build packages in parallel via a threadpool

In particular, the latter is difficult with the original recursive approach.

The code is not the most efficient; it goes through the list of packages multiple times. This script will be far from being the bottleneck, so I prefer slightly more readable code than highly efficient ones.
