### PR TITLE
Remove undefined flags

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -104,7 +104,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.patched $(SQLITEBUILD)/libsql
 		cd $(BUILD); \
 		CONFIG_SITE=./config.site READELF=true LD_RUN_PATH="$(SQLITEBUILD):$(BZIP2BUILD)" emconfigure \
 		  ./configure \
-			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD)" \
+			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD) -I$(ZLIBBUILD)" \
 			  LDFLAGS="-L$(SQLITEBUILD) -L$(BZIP2BUILD)" \
 			  --without-pymalloc \
 			  --disable-shared \

--- a/cpython/Setup.local
+++ b/cpython/Setup.local
@@ -26,7 +26,7 @@ select selectmodule.c
 _posixsubprocess _posixsubprocess.c
 binascii binascii.c
 
-zlib zlibmodule.c -I../zlib-1.2.11
+zlib zlibmodule.c
 
 pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI -DXML_POOR_ENTROPY
 
@@ -44,9 +44,9 @@ _blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c
 # we want to define MODULE_NAME to be the string "sqlite" instead of the
 # abstract symbol sqlite.
 SQLITEMODULENAME=MODULE_NAME=\'"sqlite"\'
-_sqlite3 _sqlite/cache.c _sqlite/connection.c _sqlite/cursor.c _sqlite/microprotocols.c _sqlite/module.c _sqlite/prepare_protocol.c _sqlite/row.c _sqlite/statement.c _sqlite/util.c -D$(SQLITEMODULENAME) -I$(SQLITEBUILD) -L$(SQLITEBUILD) -lsqlite3
+_sqlite3 _sqlite/cache.c _sqlite/connection.c _sqlite/cursor.c _sqlite/microprotocols.c _sqlite/module.c _sqlite/prepare_protocol.c _sqlite/row.c _sqlite/statement.c _sqlite/util.c -D$(SQLITEMODULENAME) -lsqlite3
 _crypt _cryptmodule.c
-_bz2 _bz2module.c -I$(BZIP2BUILD) -L$(BZIP2BUILD) -lbz2
+_bz2 _bz2module.c -lbz2
 
 _queue _queuemodule.c
 


### PR DESCRIPTION
In python's Makefile generated by makesetup, SQLITEBUILD and BZIP2BUILD are not defined, so we are left with empty -I and -L commands. These manage to build by virtue of us inserting -I/path/to/sqlite and -I/path/to/bzip2 to every single build command.

This commit does the same for zlib for consistency.
