### PR TITLE
Don't write our own instantiateWasm code

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,7 +22,7 @@
 - Updated packages: numpy 1.15.4, pandas 1.0.5 among others.
 - Updated default `--ldflags` argument to `pyodide_build` scripts to equal what
   pyodide actually uses.
-
+- Drop support for serving .wasm files with incorrect mime type.
 
 ## Version 0.15.0
 *May 19, 2020*

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -321,7 +321,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
 
   ////////////////////////////////////////////////////////////
   // Loading Pyodide
-  let wasmURL = `${baseURL}pyodide.asm.wasm`;
   let Module = {};
   self.Module = Module;
 
@@ -330,30 +329,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   Module.noWasmDecoding = true;
   Module.preloadedWasm = {};
   let isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-
-  let wasm_promise, wasm_fetch = fetch(wasmURL);
-  const compileBuffer = () =>
-      wasm_fetch.then(response => response.arrayBuffer())
-          .then(bytes => WebAssembly.compile(bytes));
-  if (WebAssembly.compileStreaming === undefined) {
-    wasm_promise = compileBuffer();
-  } else {
-    wasm_promise = WebAssembly.compileStreaming(wasm_fetch);
-    wasm_promise = wasm_promise.catch(e => {
-      if (e instanceof TypeError) {
-        console.error("pyodide streaming compilation failed:", e,
-                      "- falling back to buffered compilation");
-        return compileBuffer()
-      }
-      throw e;
-    });
-  }
-
-  Module.instantiateWasm = (info, receiveInstance) => {
-    wasm_promise.then(module => WebAssembly.instantiate(module, info))
-        .then(instance => receiveInstance(instance));
-    return {};
-  };
 
   Module.checkABI = function(ABI_number) {
     if (ABI_number !== parseInt('{{ABI}}')) {


### PR DESCRIPTION
The default version works well and pretty much does the same thing, and writing our own requires us to keep it up to date with what the default version does. In particular, it breaks with emscripten 1.38.35.

The "customized" instantiateWasm code was added pretty early on in the project, when emscripten was possibly less mature.
