### PR TITLE
PKG fix issue #845 : micropip not getting last version from PyPi.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,8 @@
 - Updated docker image to Debian buster
 - FIX Infer package tarball directory from source url
   [#687](https://github.com/iodide-project/pyodide/pull/687)
+- FIX Get last version from PyPi when installing a module via micropip
+  [#846](https://github.com/iodide-project/pyodide/pull/846)
 - Updated to emscripten 1.38.34
   [#480](https://github.com/iodide-project/pyodide/pull/480)
 - New packages: freesasa, lxml, python-sat, traits, astropy

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -245,7 +245,11 @@ class _PackageManager:
             ver = self.version_scheme.suggest(ver)
             if ver is not None:
                 releases.append((ver, files))
-        releases = sorted(releases, reverse=True)
+
+        def version_number(release):
+            return version.NormalizedVersion(release[0])
+
+        releases = sorted(releases, key=version_number, reverse=True)
         matcher = self.version_scheme.matcher(req.requirement)
         for ver, meta in releases:
             if matcher.match(ver):

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -69,3 +69,38 @@ def test_install_custom_url(selenium_standalone, web_server_tst_data):
     # wait untill micropip is loaded
     time.sleep(1)
     selenium_standalone.run("import snowballstemmer")
+
+
+def test_last_version_from_pypi():
+    pytest.importorskip("distlib")
+    import micropip
+
+    class Namespace:
+        def __init__(self, **entries):
+            self.__dict__.update(entries)
+
+    # requirement as returned by distlib.util.parse_requirement
+    requirement = Namespace(
+        constraints=None,
+        extras=None,
+        marker=None,
+        name="dummy_module",
+        requirement="dummy_module",
+        url=None,
+    )
+
+    # available versions
+    versions = ["0.0.1", "0.15.5", "0.9.1"]
+
+    # building metadata as returned from
+    # https://pypi.org/pypi/{pkgname}/json
+    metadata = {
+        "releases": {
+            v: [{"filename": f"dummy_module-{v}-py3-none-any.whl"}] for v in versions
+        }
+    }
+
+    # get version number from find_wheel
+    wheel, ver = micropip.PACKAGE_MANAGER.find_wheel(metadata, requirement)
+
+    assert ver == "0.15.5"


### PR DESCRIPTION
Can I add my folium example as a test case ? Or should we rely on packages we have control on, like `pyodide-micropip-test` (seen in `test_micropip.py`) ?

Closes https://github.com/iodide-project/pyodide/issues/845