### PR TITLE
Add pyodide-interrupt package

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@
 - Drop support for serving .wasm files with incorrect mime type.
 - Replace C lz4 implementation with (upstream) javascript implementation.
   [#851](https://github.com/iodide-project/pyodide/pull/851)
+- New package
+  [pyodide-interrupt](https://pypi.org/project/pyodide-interrupts/), useful for
+  handling interrupts in Pyodide (see project descripion for details).
 
 ## Version 0.15.0
 *May 19, 2020*

--- a/packages/pyodide-interrupts/meta.yaml
+++ b/packages/pyodide-interrupts/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: pyodide-interrupts
-  version: 0.1.0
+  version: 0.1.1
 
 source:
-  url: https://github.com/SpectralSequences/pyodide_interrupts/archive/00b9baa1f029c40069cd104aeafe8043397e9a25.zip
-  sha256: 5303e143cabf98ef3b212c737a93a06e6d3ed68ac32cf6d9e1adaf2d1ffb85e0
+  url: https://files.pythonhosted.org/packages/b1/c2/918c52e47bf91570d9883a1c761c4d78a59cf4d1d8f8c67c25a4e164ff87/pyodide-interrupts-0.1.1.tar.gz
+  sha256: b85bc38b92cd5c35dd1a5192a71495abe4cd57eadccfacbc0421fb44fb6c9e74
 
 test:
   imports:

--- a/packages/pyodide-interrupts/meta.yaml
+++ b/packages/pyodide-interrupts/meta.yaml
@@ -1,0 +1,11 @@
+package:
+  name: pyodide-interrupts
+  version: 0.1.0
+
+source:
+  url: https://github.com/SpectralSequences/pyodide_interrupts/archive/00b9baa1f029c40069cd104aeafe8043397e9a25.zip
+  sha256: 5303e143cabf98ef3b212c737a93a06e6d3ed68ac32cf6d9e1adaf2d1ffb85e0
+
+test:
+  imports:
+    - pyodide_interrupts

--- a/packages/pyodide-interrupts/test_pyodide_interrupts.py
+++ b/packages/pyodide-interrupts/test_pyodide_interrupts.py
@@ -1,0 +1,17 @@
+def test_pyodide_interrupts(selenium):
+    selenium.load_package("pyodide-interrupts")
+    selenium.run("from pyodide_interrupts import check_interrupts")
+    assert (
+        selenium.run(
+            "x = 0\n"
+            "def callback():\n"
+            "    global x\n"
+            "    print('check')\n"
+            "    x += 1\n"
+            "with check_interrupts(callback, 10):\n"
+            "    for i in range(50):\n"
+            "        print(i, end=',')\n"
+            "x"
+        )
+        == 11
+    )


### PR DESCRIPTION
This package was written so that one can interrupt python execution in pyodide, c.f. #676 and the package README (this is the crappy-python-multitasking module mentioned by @hoodmane, with a nicer name).

