### PR TITLE
Remove ERROR_ON_MISSING_LIBARIES=0

### DIFF
--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -18,7 +18,6 @@ DEFAULTLDFLAGS = " ".join(
         "--memory-init-file", "0",
         "-s", "LINKABLE=1",
         "-s", "EXPORT_ALL=1",
-        "-s", "ERROR_ON_MISSING_LIBRARIES=0",
     ]
 )
 # fmt: on

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -312,6 +312,7 @@ def handle_command(line, args, dryrun=False):
             del new_args[-1]
             continue
 
+        # See https://github.com/emscripten-core/emscripten/issues/8650
         if arg == "-lfreetype":
             continue
         elif arg == "-lz":

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -313,13 +313,7 @@ def handle_command(line, args, dryrun=False):
             continue
 
         # See https://github.com/emscripten-core/emscripten/issues/8650
-        if arg == "-lfreetype":
-            continue
-        elif arg == "-lz":
-            continue
-        elif arg == "-lpng16":
-            continue
-        elif arg == "-lgfortran":
+        if arg in ["-lfreetype", "-lz", "-lpng16", "-lgfortran"]:
             continue
 
         new_args.append(arg)

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -312,6 +312,13 @@ def handle_command(line, args, dryrun=False):
             del new_args[-1]
             continue
 
+        if arg == "-lfreetype":
+            continue
+        elif arg == "-lz":
+            continue
+        elif arg == "-lpng16":
+            continue
+
         new_args.append(arg)
 
     # This can only be used for incremental rebuilds -- it generates

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -319,6 +319,8 @@ def handle_command(line, args, dryrun=False):
             continue
         elif arg == "-lpng16":
             continue
+        elif arg == "-lgfortran":
+            continue
 
         new_args.append(arg)
 


### PR DESCRIPTION
In emscripten 1.38.42, it is no longer possible to disable this option. Re-enable it and see what breaks.
