### PR TITLE
Undo part of CLAPACK patch 0003

### DIFF
--- a/packages/CLAPACK/patches/0003-Remove-redundant-symbols.patch
+++ b/packages/CLAPACK/patches/0003-Remove-redundant-symbols.patch
@@ -13,19 +13,11 @@ diff --git a/Makefile b/Makefile
 index b3467a6..83baba5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -5,6 +5,15 @@
+@@ -5,6 +5,7 @@
  #
  
  include make.inc
 +include ../Makefile.envs
-+
-+TOPDIR=$(abspath .)
-+
-+CFLAGS    = $(CFLAGS_OPT) -I$(TOPDIR)/INCLUDE -fPIC -DNO_BLAS_WRAP
-+LDFLAGS	  = $(LDFLAGS_OPT) -fPIC
-+DRVCFLAGS = $(CFLAGS)
-+F2CCFLAGS = $(CFLAGS)
-+
  
  all: f2clib lib
  #all: f2clib lapack_install lib lapack_testing blas_testing variants_testing
@@ -135,31 +127,3 @@ index 7491963..0cc1cda 100644
     zlahrd.o zlahr2.o zlaic1.o zlals0.o zlalsa.o zlalsd.o zlangb.o zlange.o \
     zlangt.o zlanhb.o \
     zlanhe.o \
-diff --git a/make.inc b/make.inc
-index 567c737..d010f57 100644
---- a/make.inc
-+++ b/make.inc
-@@ -21,19 +21,15 @@ PLAT = _WA
- #  and desired load options for your machine.
- #
- #######################################################
-+
- # This is used to compile C libary
- #CC        = gcc  # inherit $CC from emmake
- # if no wrapping of the blas library is needed, uncomment next line
- #CC        = gcc -DNO_BLAS_WRAP
--CFLAGS    = -O3 -I$(TOPDIR)/INCLUDE -fPIC -DNO_BLAS_WRAP
--LDFLAGS	  = -O3
- LOADER    = $(CC)
- LOADOPTS  =
- NOOPT     = -O0 -I$(TOPDIR)/INCLUDE
--DRVCFLAGS = $(CFLAGS)
--F2CCFLAGS = $(CFLAGS)
- #######################################################################
--
- #
- # Timer for the SECOND and DSECND routines
- #
--- 
-2.19.0
-


### PR DESCRIPTION
These flags rightfully belong to make.inc, which is included in all Makefiles. Setting the variables in the parent Makefile does not do anything.

This is cherry-picked from #843 as a change that independently makes sense.
