### PR TITLE
Improving console.html

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,9 @@
   ```
   before loading it.
   [#855](https://github.com/iodide-project/pyodide/pull/855)
+- Improving console.html with more colors, a sync behavior,
+  full stdout/stderr support and a better representation of results
+  [#855](https://github.com/iodide-project/pyodide/pull/875)
 
 
 ## Version 0.15.0

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -36,6 +36,7 @@
               def runcode(self, code):
                   sys.stdout = io.StringIO()
                   sys.stderr = io.StringIO()
+                  term.pause()
                   term.runPython("\\n".join(self.buffer))
           _c = Console(locals=globals())
         `)
@@ -66,6 +67,7 @@
         }
 
         term.handlePythonResult = function(result) {
+          term.resume()
           if (result === undefined) {
             return
           } else if (result['_repr_html_'] !== undefined) {
@@ -76,6 +78,7 @@
         }
 
         term.handlePythonError = function(result) {
+          term.resume()
           term.error(result.toString())
         }
       });

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -23,7 +23,7 @@
           pushCode,
           {
             greetings: "Welcome to the Pyodide terminal emulator 🐍",
-            prompt: "[[;red;]>>> ]"
+            prompt: "[[;blue;]>>> ]"
           }
         );
 
@@ -49,7 +49,7 @@
           if (result) {
             term.set_prompt('[[;gray;]... ]')
           } else {
-            term.set_prompt('[[;red;]>>> ]')
+            term.set_prompt('[[;blue;]>>> ]')
           }
         }
 

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -43,6 +43,8 @@
 
         var c = pyodide.pyimport('_c')
 
+        var python_repr = pyodide.pyimport('repr')
+
         function handleResult(result) {
           if (result) {
             term.set_prompt('[[;gray;]... ]')
@@ -71,10 +73,8 @@
           term.handlePythonCommon()
           if (result === undefined) {
             return
-          } else if (result['_repr_html_'] !== undefined) {
-            term.echo(result['_repr_html_'], {raw: true})
           } else {
-            term.echo(result.toString())
+            term.echo(python_repr(result))
           }
         }
 

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -48,15 +48,6 @@
             term.set_prompt('[[;gray;]... ]')
           } else {
             term.set_prompt('[[;red;]>>> ]')
-            var stderr = pyodide.runPython("sys.stderr.getvalue()").trim()
-            if (stderr) {
-              term.echo(`[[;red;]${stderr}]`)
-            } else {
-              var stdout = pyodide.runPython("sys.stdout.getvalue()")
-              if (stdout) {
-                term.echo(stdout.trim())
-              }
-            }
           }
         }
 
@@ -66,8 +57,18 @@
           )
         }
 
-        term.handlePythonResult = function(result) {
+        term.handlePythonCommon = function () {
           term.resume()
+          var stderr = pyodide.runPython("sys.stderr.getvalue()").trim()
+          if (stderr)
+            term.echo(`[[;red;]${stderr}]`)
+          var stdout = pyodide.runPython("sys.stdout.getvalue()")
+          if (stdout)
+            term.echo(stdout.trim())
+        }
+
+        term.handlePythonResult = function(result) {
+          term.handlePythonCommon()
           if (result === undefined) {
             return
           } else if (result['_repr_html_'] !== undefined) {
@@ -78,7 +79,7 @@
         }
 
         term.handlePythonError = function(result) {
-          term.resume()
+          term.handlePythonCommon()
           term.error(result.toString())
         }
       });

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -94,7 +94,7 @@
           term.resume()
           if (result === undefined)
             return
-          term.echo(python_repr(result))
+          term.echo(`[[;green;]${python_repr(result)}]`)
         }
 
         term.handlePythonError = function(result) {

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -15,6 +15,14 @@
   <body>
     <script>
       languagePluginLoader.then(() => {
+        // exposing get_completions to global scope
+        // note: jedi is imported here, otherwise, first completion
+        // takes time to complete since it toggle the first import
+        pyodide.runPython(`
+          import pyodide, js, jedi
+          js.window.get_completions = pyodide.get_completions
+        `)
+
         function pushCode(line) {
           handleResult(c.push(line))
         }
@@ -23,7 +31,10 @@
           pushCode,
           {
             greetings: "Welcome to the Pyodide terminal emulator 🐍",
-            prompt: "[[;blue;]>>> ]"
+            prompt: "[[;blue;]>>> ]",
+            completion: function(command, callback) {
+              callback(get_completions(command))
+            }
           }
         );
 

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -27,15 +27,46 @@
           }
         );
 
+        function trim(string) { return string.replace(/\n$/, "") }
+
+        term.stdout = { write: function (string) { term.echo(trim(string)) } }
+        term.stderr = { write: function (string) { term.error(trim(string)) } }
+
         window.term = term;
         pyodide.runPython(`
           import io, code, sys
-          from js import term, pyodide
+          from js import term
+
+
+          class CallbackBuffer(object):
+              """
+              Internal StdStream buffer that trigger flush callback.
+              """
+              def __init__(self, flush_callback):
+                  self._flush_callback = flush_callback
+                  self.closed = False
+              def writable(self): return True
+              def seekable(self): return False
+              def write(self, data):
+                  self._flush_callback(data.tobytes().decode())
+                  return len(data)
+
+
+          class StdStream(io.TextIOWrapper):
+              """
+              Custom std stream to retdirect sys.stdou/stderr to terminal.
+              """
+              def __init__(self, flush_callback):
+                  buffer = io.BufferedWriter(CallbackBuffer(flush_callback))
+                  super().__init__(buffer, line_buffering=True)
+
+
+          sys.stdout = StdStream(term.stdout.write)
+          sys.stderr = StdStream(term.stderr.write)
+
 
           class Console(code.InteractiveConsole):
               def runcode(self, code):
-                  sys.stdout = io.StringIO()
-                  sys.stderr = io.StringIO()
                   term.pause()
                   term.runPython("\\n".join(self.buffer))
           _c = Console(locals=globals())
@@ -59,28 +90,16 @@
           )
         }
 
-        term.handlePythonCommon = function () {
-          term.resume()
-          var stderr = pyodide.runPython("sys.stderr.getvalue()").trim()
-          if (stderr)
-            term.echo(`[[;red;]${stderr}]`)
-          var stdout = pyodide.runPython("sys.stdout.getvalue()")
-          if (stdout)
-            term.echo(stdout.trim())
-        }
-
         term.handlePythonResult = function(result) {
-          term.handlePythonCommon()
-          if (result === undefined) {
+          term.resume()
+          if (result === undefined)
             return
-          } else {
-            term.echo(python_repr(result))
-          }
+          term.echo(python_repr(result))
         }
 
         term.handlePythonError = function(result) {
-          term.handlePythonCommon()
-          term.error(result.toString())
+          term.resume()
+          term.error(trim(result.toString()))
         }
       });
     </script>


### PR DESCRIPTION
`console.html`is a great tool. It's a showcase for Pyodide and [the devel version](https://pyodide-cdn2.iodide.io/dev/full/console.html) allows developers to track issues and make quick tests.

Unfortunately, IMHO, it lacks some important features like:

1. sync behavior (do not set next prompt until current command finished, e.g. with imports)
2. full stdout/stderr support (e.g. import warnings are not visible)
3. correct result representation with `repr` (type `"1"` and it shows `1`, type `globals()` and it shows `[object Object]`)

While 1. and 2. are addressed in this PR, 3. seems tricky, at least with the current setup (JQuery's terminal + `copy.py` interactive console + `runPythonAscyn`) but not impossible (see [Basthon](https://basthon.fr)).

Getting correct representations for basic types (like strings) are addressed in this PR. Difficulty to get correct `repr` for complex objects comes from the fact that, when you get a Python object on the JS side (e.g. runPython[Async]'s result), it seems impossible to get it back into Python. As an illustration, compare the result of the two following code snippets:

```javascript
// returns "[object Object]"
pyodide.runPython("import js ; js.window.x = {1: 2} ; repr(js.window.x)")
// returns "{1: 2}"
pyodide.runPython("x = {1: 2} ; repr(x)")
```
Long story short, 

```javascript
pyodide.runPython("repr({1: 2})")
// is not equivalent to:
pyodide.pyimport("repr")(pyodide.runPython("{1: 2}"))
```

Any idea to fully address 3.with the current setup?

Should I edit changelog ?

Closes https://github.com/iodide-project/pyodide/issues/897