### PR TITLE
BLD Enable ccache for x86_64

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -31,6 +31,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+import shutil
 import sys
 
 
@@ -91,8 +92,12 @@ def collect_args(basename):
 
     if skip:
         sys.exit(0)
+    compiler_command = [basename]
+    if shutil.which("ccache") is not None:
+        # Enable ccache if it's installed
+        compiler_command.insert(0, "ccache")
 
-    sys.exit(subprocess.run([basename] + sys.argv[1:], env=env).returncode)
+    sys.exit(subprocess.run(compiler_command + sys.argv[1:], env=env).returncode)
 
 
 def make_symlinks(env):


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/838

Following discussion https://github.com/iodide-project/pyodide/issues/838#issuecomment-747054343 this would only help for numpy compilation time. It doesn't take that long, but this is also not too complicated, so it might be worth it.

Also in the future some packages will require scipy as a build dependency (e.g. latest versions of scikit-learn) and that takes takes much longer to build.

Also even if we update numpy to a version that has wheels for Python 3.8 (https://github.com/iodide-project/pyodide/issues/437) we could use them for build dependencies, but not for benchmarks. Since wheels use OpenBLAS making performance comparison with our reference BLAS implementation not practical. 