### PR TITLE
BLD Don't use emscripten ports in global LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ LDFLAGS=\
 	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv"]' \
 	-s WASM=1 \
 	-s SWAPPABLE_ASM_MODULE=1 \
-	-s USE_FREETYPE=1 \
-	-s USE_LIBPNG=1 \
 	-std=c++14 \
 	-L$(wildcard $(CPYTHONROOT)/build/sqlite*/.libs) -lsqlite3 \
 	$(wildcard $(CPYTHONROOT)/build/bzip2*/libbz2.a) \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ LDFLAGS=\
 	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv"]' \
 	-s WASM=1 \
 	-s SWAPPABLE_ASM_MODULE=1 \
+	-s USE_ZLIB=1 \
 	-std=c++14 \
 	-L$(wildcard $(CPYTHONROOT)/build/sqlite*/.libs) -lsqlite3 \
 	$(wildcard $(CPYTHONROOT)/build/bzip2*/libbz2.a) \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ LDFLAGS=\
 	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv"]' \
 	-s WASM=1 \
 	-s SWAPPABLE_ASM_MODULE=1 \
-	-s USE_ZLIB=1 \
+	-s USE_LIBPNG=1 \
 	-std=c++14 \
 	-L$(wildcard $(CPYTHONROOT)/build/sqlite*/.libs) -lsqlite3 \
 	$(wildcard $(CPYTHONROOT)/build/bzip2*/libbz2.a) \


### PR DESCRIPTION
Emscripten ports are specified in package LDFLAGS as needed. So there is no need to also specify them in the global LDFLAGS. This should make building the CPython + code pyodide package slightly faster.