### PR TITLE
modifiy MEMFS timestamp handling to support better caching

### DIFF
--- a/emsdk/patches/posixish_memfs.patch
+++ b/emsdk/patches/posixish_memfs.patch
@@ -2,7 +2,7 @@ Modify MEMFS to update timestamp of parent directory on file creation and remova
 More POSIXish compliant for a one timestamp fs, behaves like a modification date.
 
 --- a/emsdk/fastcomp/emscripten/src/library_memfs.js    2019-08-19 18:11:40.000000000 +0200
-+++ b/emsdk/fastcomp/emscripten/src/library_memfs.js	2020-12-18 14:07:14.000000000 +0100
++++ b/emsdk/fastcomp/emscripten/src/library_memfs.js	2020-12-23 12:22:38.000000000 +0100
 @@ -88,6 +88,7 @@
        // add the new node to the parent
        if (parent) {
@@ -11,14 +11,15 @@ More POSIXish compliant for a one timestamp fs, behaves like a modification date
        }
        return node;
      },
-@@ -213,12 +214,15 @@
+@@ -213,12 +214,16 @@
          }
          // do the internal rewiring
          delete old_node.parent.contents[old_node.name];
-+        old_node.parent.timestamp = Date.now()
++        var now = Date.now();
++        old_node.parent.timestamp = now;
          old_node.name = new_name;
          new_dir.contents[new_name] = old_node;
-+        new_dir.timestamp = old_node.parent.timestamp;
++        new_dir.timestamp = now;
          old_node.parent = new_dir;
        },
        unlink: function(parent, name) {
@@ -27,7 +28,7 @@ More POSIXish compliant for a one timestamp fs, behaves like a modification date
        },
        rmdir: function(parent, name) {
          var node = FS.lookupNode(parent, name);
-@@ -226,6 +230,7 @@
+@@ -226,6 +231,7 @@
            throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
          }
          delete parent.contents[name];

--- a/emsdk/patches/posixish_memfs.patch
+++ b/emsdk/patches/posixish_memfs.patch
@@ -1,0 +1,37 @@
+Modify MEMFS to update timestamp of parent directory on file creation and removal.
+More POSIXish compliant for a one timestamp fs, behaves like a modification date.
+
+--- a/emsdk/fastcomp/emscripten/src/library_memfs.js    2019-08-19 18:11:40.000000000 +0200
++++ b/emsdk/fastcomp/emscripten/src/library_memfs.js	2020-12-18 14:07:14.000000000 +0100
+@@ -88,6 +88,7 @@
+       // add the new node to the parent
+       if (parent) {
+         parent.contents[name] = node;
++        parent.timestamp = node.timestamp;
+       }
+       return node;
+     },
+@@ -213,12 +214,15 @@
+         }
+         // do the internal rewiring
+         delete old_node.parent.contents[old_node.name];
++        old_node.parent.timestamp = Date.now()
+         old_node.name = new_name;
+         new_dir.contents[new_name] = old_node;
++        new_dir.timestamp = old_node.parent.timestamp;
+         old_node.parent = new_dir;
+       },
+       unlink: function(parent, name) {
+         delete parent.contents[name];
++        parent.timestamp = Date.now();
+       },
+       rmdir: function(parent, name) {
+         var node = FS.lookupNode(parent, name);
+@@ -226,6 +230,7 @@
+           throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
+         }
+         delete parent.contents[name];
++        parent.timestamp = Date.now();
+       },
+       readdir: function(node) {
+         var entries = ['.', '..'];

--- a/emsdk/tests/test_memfsmtime.py
+++ b/emsdk/tests/test_memfsmtime.py
@@ -1,0 +1,78 @@
+import subprocess
+from . import common
+
+
+def test_memfsmtime(tmpdir):
+    with tmpdir.as_cwd():
+        with open("main.c", "w") as f:
+            f.write(
+                r"""\
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+void mysleep(int delta)
+{
+    time_t end = time(NULL) + delta;
+
+    while (time(NULL)<end);
+}
+
+time_t getmtime(char *fname)
+{
+    struct stat buf;
+
+    stat(fname, &buf);
+    return buf.st_mtime;
+}
+
+void writefile(char *fname, char *content)
+{
+    int fd = open(fname, O_CREAT | O_TRUNC | O_WRONLY, 0777);
+
+    write(fd, content, strlen(content));
+    close(fd);
+}
+
+int main(int argc, char *argv[])
+{
+    char tmpdir[64] = "/tmp/tmpXXXXXXX";
+    char fname[64];
+    time_t t0;
+
+    mkdtemp(tmpdir);
+    strcpy(fname, tmpdir);
+    strcat(fname, "/foo.py");
+    t0 = getmtime(tmpdir);
+    printf("%ld tmpdir\n", getmtime(tmpdir) - t0);
+    mysleep(1);
+    writefile(fname, "bar = 54\n");
+    printf("%ld tmpdir\n", getmtime(tmpdir) - t0);
+    printf("%ld tmpdir/foo.py\n", getmtime(fname) - t0);
+    mysleep(1);
+    unlink(fname);
+    printf("%ld tmpdir\n", getmtime(tmpdir) - t0);
+}
+"""
+            )
+
+        subprocess.run(
+            [
+                "emcc",
+                "-s",
+                "MAIN_MODULE=1",
+                "main.c",
+                "-s",
+                "EMULATE_FUNCTION_POINTER_CASTS=1",
+            ],
+            check=True,
+            env=common.env,
+        )
+        out = subprocess.run(
+            ["node", "a.out.js"], capture_output=True, check=True, env=common.env
+        )
+        assert out.stdout == b"0 tmpdir\n1 tmpdir\n1 tmpdir/foo.py\n2 tmpdir\n"

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -184,3 +184,31 @@ def test_completions(selenium):
         """
     )
     assert result == ["version", "version_info"]
+
+
+def test_import_created_files(selenium):
+    # Check that creating multiple files per
+    # folder does not prevent module imports (#737)
+
+    selenium.run(
+        """
+        import sys
+        import tempfile
+        from pathlib import Path
+        from os import listdir, stat
+        
+        tmpdir = Path(tempfile.mkdtemp())
+        sys.path.append(str(tmpdir))
+        
+        #create some unrelated file
+        with open(tmpdir / "module_b.py", "w") as fd:
+            fd.write("foo = 54")
+        
+        with open(tmpdir / "module_a.py", "w") as fh:
+            fh.write("foo = 42")
+        
+        import module_a
+        sys.path.pop()
+        assert module_a.foo == 42
+        """
+    )

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -184,31 +184,3 @@ def test_completions(selenium):
         """
     )
     assert result == ["version", "version_info"]
-
-
-def test_import_created_files(selenium):
-    # Check that creating multiple files per
-    # folder does not prevent module imports (#737)
-
-    selenium.run(
-        """
-        import sys
-        import tempfile
-        from pathlib import Path
-        from os import listdir, stat
-        
-        tmpdir = Path(tempfile.mkdtemp())
-        sys.path.append(str(tmpdir))
-        
-        #create some unrelated file
-        with open(tmpdir / "module_b.py", "w") as fd:
-            fd.write("foo = 54")
-        
-        with open(tmpdir / "module_a.py", "w") as fh:
-            fh.write("foo = 42")
-        
-        import module_a
-        sys.path.pop()
-        assert module_a.foo == 42
-        """
-    )


### PR DESCRIPTION
PR implementing https://github.com/iodide-project/pyodide/issues/737#issuecomment-747722765

Modify `emscripten` filesystem behavior to look more POSIXish: the timestamp of a directory is modified each time a file is created or deleted inside the directory.

Relates to upstream discussion https://github.com/emscripten-core/emscripten/issues/11454
A long time upstreamable solution would be to implement a filesystem handling three different kinds of timestamps.

Partially solves #737