### PR TITLE
PKG Fix Python 3.8 warnings in mpmath

### DIFF
--- a/packages/mpmath/meta.yaml
+++ b/packages/mpmath/meta.yaml
@@ -6,6 +6,9 @@ source:
   sha256: fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6
   url: 'https://files.pythonhosted.org/packages/ca/63/3384ebb3b51af9610086b23ea976e6d27d6d97bf140a76a365bd77a3eb32/mpmath-1.1.0.tar.gz'
 
+  patches:
+    - patches/fix-warnings.patch
+
 test:
   imports:
     - mpmath

--- a/packages/mpmath/patches/fix-warnings.patch
+++ b/packages/mpmath/patches/fix-warnings.patch
@@ -1,0 +1,21 @@
+diff --git a/mpmath/ctx_mp_python.py b/mpmath/ctx_mp_python.py
+--- a/mpmath/ctx_mp_python.py
++++ b/mpmath/ctx_mp_python.py
+@@ -889,7 +889,7 @@ def fsum(ctx, terms, absolute=False, squared=False):
+             s = ctx.make_mpc((s, mpf_sum(imag, prec, rnd)))
+         else:
+             s = ctx.make_mpf(s)
+-        if other is 0:
++        if other == 0:
+             return s
+         else:
+             return s + other
+@@ -983,7 +983,7 @@ def fdot(ctx, A, B=None, conjugate=False):
+             s = ctx.make_mpc((s, mpf_sum(imag, prec, rnd)))
+         else:
+             s = ctx.make_mpf(s)
+-        if other is 0:
++        if other == 0:
+             return s
+         else:
+             return s + other

--- a/packages/mpmath/patches/fix-warnings.patch
+++ b/packages/mpmath/patches/fix-warnings.patch
@@ -1,3 +1,6 @@
+This fix for Python 3.8 warnings is already applied in upstream and
+should probably be removed after next mpmath release.
+
 diff --git a/mpmath/ctx_mp_python.py b/mpmath/ctx_mp_python.py
 --- a/mpmath/ctx_mp_python.py
 +++ b/mpmath/ctx_mp_python.py


### PR DESCRIPTION
Python 3.8 `mpmath` warnings are [corrected upstream](https://github.com/fredrik-johansson/mpmath/issues/547) but no release since 2018...

This PR patch mpmath to remove this warnings.

This partially solves #877.