### PR TITLE
Fixed error message when attempting to pyimport a nonexistent value

### DIFF
--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -1,5 +1,5 @@
+from selenium.common.exceptions import WebDriverException
 import time
-
 import pytest
 
 
@@ -51,6 +51,13 @@ def test_pyimport_same(selenium):
     assert selenium.run_js(
         "return pyodide.pyimport('func') == pyodide.pyimport('func')"
     )
+
+
+def test_pyimport_error(selenium):
+    """See #382"""
+    msg = "KeyError: 'doesnotexist'"
+    with pytest.raises(WebDriverException, match=msg):
+        selenium.run_js("pyodide.pyimport('doesnotexist')")
 
 
 def test_open_url(selenium, httpserver):

--- a/src/type_conversion/pyimport.c
+++ b/src/type_conversion/pyimport.c
@@ -11,7 +11,7 @@ int
 _pyimport(char* name)
 {
   PyObject* pyname = PyUnicode_FromString(name);
-  PyObject* pyval = PyDict_GetItem(globals, pyname);
+  PyObject* pyval = PyDict_GetItemWithError(globals, pyname);
   if (pyval == NULL) {
     Py_DECREF(pyname);
     return pythonexc2js();


### PR DESCRIPTION
Before this PR, the error message thrown by `pyodide.pyimport("missing_name")` was `Uncaught Error: No exception type or value`. Switching out `PyDict_GetItem` for `PyDict_GetItemWithError` fixes the problem. Now the error message is `KeyError: 'missing_name'`.