### PR TITLE
Create a pyodide-py package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ root/.built: \
 		$(PARSO_LIBS) \
 		src/sitecustomize.py \
 		src/webbrowser.py \
-		src/pyodide.py \
+		src/pyodide-py/ \
 		cpython/remove_modules.txt
 	rm -rf root
 	mkdir -p root/lib
@@ -199,7 +199,7 @@ root/.built: \
 	cp src/webbrowser.py root/lib/python$(PYMINOR)
 	cp src/_testcapi.py	root/lib/python$(PYMINOR)
 	cp src/pystone.py root/lib/python$(PYMINOR)
-	cp src/pyodide.py root/lib/python$(PYMINOR)/site-packages
+	cp -r src/pyodide-py/pyodide/ $(SITEPACKAGES)
 	( \
 		cd root/lib/python$(PYMINOR); \
 		rm -fr `cat ../../../cpython/remove_modules.txt`; \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import sys
 
 for base_path in [".", ".."]:
     sys.path.insert(0, os.path.abspath(base_path))
-    sys.path.insert(1, os.path.abspath(os.path.join(base_path, "src")))
+    sys.path.insert(1, os.path.abspath(os.path.join(base_path, "src", "pyodide-py")))
     sys.path.insert(
         2, os.path.abspath(os.path.join(base_path, "packages", "micropip", "micropip"))
     )

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,0 +1,6 @@
+from ._base import open_url, eval_code, find_imports, as_nested_list
+from .console import get_completions
+
+__version__ = "0.15.0"
+
+__all__ = ["open_url", "eval_code", "find_imports", "as_nested_list", "get_completions"]

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -5,10 +5,7 @@ A library of helper utilities for connecting Python to the browser environment.
 import ast
 from io import StringIO
 from textwrap import dedent
-from typing import Dict, List, Optional, Any
-
-
-__version__ = "0.15.0"
+from typing import Dict, List, Any
 
 
 def open_url(url: str) -> StringIO:
@@ -128,42 +125,3 @@ def as_nested_list(obj) -> List:
         return [as_nested_list(x) for x in it]
     except TypeError:
         return obj
-
-
-def get_completions(
-    code: str, cursor: Optional[int] = None, namespaces: Optional[List] = None
-) -> List[str]:
-    """
-    Get code autocompletion candidates
-
-    Note that this function requires to have the jedi module loaded.
-
-    Parameters
-    ----------
-    code
-       the Python code to complete.
-    cursor
-       optional position in the code at which to autocomplete
-    namespaces
-       a list of namespaces
-
-    Returns
-    -------
-    a list of autocompleted modules
-    """
-    import jedi
-    import __main__
-
-    if namespaces is None:
-        namespaces = [__main__.__dict__]
-
-    if cursor is None:
-        cursor = len(code)
-    code = code[:cursor]
-    interp = jedi.Interpreter(code, namespaces)
-    completions = interp.completions()
-
-    return [x.name for x in completions]
-
-
-__all__ = ["open_url", "eval_code", "find_imports", "as_nested_list", "get_completions"]

--- a/src/pyodide-py/pyodide/console.py
+++ b/src/pyodide-py/pyodide/console.py
@@ -1,0 +1,37 @@
+from typing import List, Optional
+
+
+def get_completions(
+    code: str, cursor: Optional[int] = None, namespaces: Optional[List] = None
+) -> List[str]:
+    """
+    Get code autocompletion candidates
+
+    Note that this function requires to have the jedi module loaded.
+
+    Parameters
+    ----------
+    code
+       the Python code to complete.
+    cursor
+       optional position in the code at which to autocomplete
+    namespaces
+       a list of namespaces
+
+    Returns
+    -------
+    a list of autocompleted modules
+    """
+    import jedi
+    import __main__
+
+    if namespaces is None:
+        namespaces = [__main__.__dict__]
+
+    if cursor is None:
+        cursor = len(code)
+    code = code[:cursor]
+    interp = jedi.Interpreter(code, namespaces)
+    completions = interp.completions()
+
+    return [x.name for x in completions]

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
-sys.path.append(str(Path(__file__).parents[2] / "src"))
+sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
 from pyodide import find_imports  # noqa: E402
 


### PR DESCRIPTION
Creates a pyodide-py Python package (still imported as `pyodide`).

Closes  https://github.com/iodide-project/pyodide/issues/896

This is fully backward compatible import wise, but should facilitate code organization for future PRs (and in particular https://github.com/iodide-project/pyodide/pull/875)

cc @hoodmane @casatir 