### PR TITLE
Some internal improvements to hiwire

### DIFF
--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -2,132 +2,11 @@
 
 #include "hiwire.h"
 
-EM_JS(void, hiwire_setup, (), {
-  // These ids must match the constants above, but we can't use them from JS
-  var hiwire = { objects : {}, counter : 1 };
-  hiwire.objects[-2] = undefined;
-  hiwire.objects[-3] = true;
-  hiwire.objects[-4] = false;
-  hiwire.objects[-5] = null;
-
-  Module.hiwire_new_value = function(jsval)
-  {
-    var objects = hiwire.objects;
-    while (hiwire.counter in objects) {
-      hiwire.counter = (hiwire.counter + 1) & 0x7fffffff;
-    }
-    var idval = hiwire.counter;
-    objects[idval] = jsval;
-    hiwire.counter = (hiwire.counter + 1) & 0x7fffffff;
-    return idval;
-  };
-
-  Module.hiwire_get_value = function(idval) { return hiwire.objects[idval]; };
-
-  Module.hiwire_decref = function(idval)
-  {
-    if (idval < 0) {
-      return;
-    }
-    var objects = hiwire.objects;
-    delete objects[idval];
-  };
-});
-
-EM_JS(int, hiwire_incref, (int idval), {
-  if (idval < 0) {
-    return;
-  }
-  return Module.hiwire_new_value(Module.hiwire_get_value(idval));
-});
-
-EM_JS(void, hiwire_decref, (int idval), { Module.hiwire_decref(idval); });
-
-EM_JS(int, hiwire_int, (int val), { return Module.hiwire_new_value(val); });
-
-EM_JS(int, hiwire_double, (double val), {
-  return Module.hiwire_new_value(val);
-});
-
-EM_JS(int, hiwire_string_ucs4, (int ptr, int len), {
-  var jsstr = "";
-  var idx = ptr / 4;
-  for (var i = 0; i < len; ++i) {
-    jsstr += String.fromCodePoint(Module.HEAPU32[idx + i]);
-  }
-  return Module.hiwire_new_value(jsstr);
-});
-
-EM_JS(int, hiwire_string_ucs2, (int ptr, int len), {
-  var jsstr = "";
-  var idx = ptr / 2;
-  for (var i = 0; i < len; ++i) {
-    jsstr += String.fromCharCode(Module.HEAPU16[idx + i]);
-  }
-  return Module.hiwire_new_value(jsstr);
-});
-
-EM_JS(int, hiwire_string_ucs1, (int ptr, int len), {
-  var jsstr = "";
-  var idx = ptr;
-  for (var i = 0; i < len; ++i) {
-    jsstr += String.fromCharCode(Module.HEAPU8[idx + i]);
-  }
-  return Module.hiwire_new_value(jsstr);
-});
-
-EM_JS(int, hiwire_string_utf8, (int ptr), {
-  return Module.hiwire_new_value(UTF8ToString(ptr));
-});
-
-EM_JS(int, hiwire_string_ascii, (int ptr), {
-  return Module.hiwire_new_value(AsciiToString(ptr));
-});
-
-EM_JS(int, hiwire_bytes, (int ptr, int len), {
-  var bytes = new Uint8ClampedArray(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(bytes);
-});
-
-EM_JS(int, hiwire_int8array, (int ptr, int len), {
-  var array = new Int8Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_uint8array, (int ptr, int len), {
-  var array = new Uint8Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_int16array, (int ptr, int len), {
-  var array = new Int16Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_uint16array, (int ptr, int len), {
-  var array = new Uint16Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_int32array, (int ptr, int len), {
-  var array = new Int32Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_uint32array, (int ptr, int len), {
-  var array = new Uint32Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_float32array, (int ptr, int len), {
-  var array = new Float32Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
-
-EM_JS(int, hiwire_float64array, (int ptr, int len), {
-  var array = new Float64Array(Module.HEAPU8.buffer, ptr, len);
-  return Module.hiwire_new_value(array);
-})
+int
+hiwire_error()
+{
+  return HW_ERROR;
+}
 
 int
 hiwire_undefined()
@@ -153,111 +32,272 @@ hiwire_false()
   return HW_FALSE;
 }
 
+int
+hiwire_bool(int boolean)
+{
+  return boolean ? hiwire_true() : hiwire_false();
+}
+
+EM_JS(void, hiwire_setup, (), {
+  let _hiwire = { objects : new Map(), counter : 1 };
+  Module.hiwire = {};
+  Module.hiwire.ERROR = _hiwire_error();
+  Module.hiwire.UNDEFINED = _hiwire_undefined();
+  Module.hiwire.NULL = _hiwire_null();
+  Module.hiwire.TRUE = _hiwire_true();
+  Module.hiwire.FALSE = _hiwire_false();
+
+  _hiwire.objects.set(Module.hiwire.UNDEFINED, undefined);
+  _hiwire.objects.set(Module.hiwire.NULL, null);
+  _hiwire.objects.set(Module.hiwire.TRUE, true);
+  _hiwire.objects.set(Module.hiwire.FALSE, false);
+
+  Module.hiwire.new_value = function(jsval)
+  {
+    // Should we guard against duplicating standard values?
+    // Probably not worth it for performance: it's harmless to ocassionally
+    // duplicate. Maybe in test builds these should raise? if(jsval ===
+    // undefined){
+    //   return Module.hiwire.UNDEFINED;
+    // }
+    // if(jsval === null){
+    //   return Module.hiwire.NULL;
+    // }
+    // if(jsval === true){
+    //   return Module.hiwire.TRUE;
+    // }
+    // if(jsval === false){
+    //   return Module.hiwire.FALSE;
+    // }
+    while (_hiwire.objects.has(_hiwire.counter)) {
+      _hiwire.counter = (_hiwire.counter + 1) & 0x7fffffff;
+    }
+    let idval = _hiwire.counter;
+    _hiwire.objects.set(idval, jsval);
+    _hiwire.counter = (_hiwire.counter + 1) & 0x7fffffff;
+    return idval;
+  };
+
+  Module.hiwire.get_value = function(idval)
+  {
+    if (!idval) {
+      throw new Error("Argument to hiwire_get_value is undefined");
+    }
+    if (!_hiwire.objects.has(idval)) {
+      throw new Error(`Undefined id $ { idval }`);
+    }
+    return _hiwire.objects.get(idval);
+  };
+
+  Module.hiwire.decref = function(idval)
+  {
+    if (idval < 0) {
+      return;
+    }
+    _hiwire.objects.delete(idval);
+  };
+});
+
+EM_JS(int, hiwire_incref, (int idval), {
+  if (idval < 0) {
+    return;
+  }
+  return Module.hiwire.new_value(Module.hiwire.get_value(idval));
+});
+
+EM_JS(void, hiwire_decref, (int idval), { Module.hiwire.decref(idval); });
+
+EM_JS(int, hiwire_int, (int val), { return Module.hiwire.new_value(val); });
+
+EM_JS(int, hiwire_double, (double val), {
+  return Module.hiwire.new_value(val);
+});
+
+EM_JS(int, hiwire_string_ucs4, (int ptr, int len), {
+  var jsstr = "";
+  var idx = ptr / 4;
+  for (var i = 0; i < len; ++i) {
+    jsstr += String.fromCodePoint(Module.HEAPU32[idx + i]);
+  }
+  return Module.hiwire.new_value(jsstr);
+});
+
+EM_JS(int, hiwire_string_ucs2, (int ptr, int len), {
+  var jsstr = "";
+  var idx = ptr / 2;
+  for (var i = 0; i < len; ++i) {
+    jsstr += String.fromCharCode(Module.HEAPU16[idx + i]);
+  }
+  return Module.hiwire.new_value(jsstr);
+});
+
+EM_JS(int, hiwire_string_ucs1, (int ptr, int len), {
+  var jsstr = "";
+  var idx = ptr;
+  for (var i = 0; i < len; ++i) {
+    jsstr += String.fromCharCode(Module.HEAPU8[idx + i]);
+  }
+  return Module.hiwire.new_value(jsstr);
+});
+
+EM_JS(int, hiwire_string_utf8, (int ptr), {
+  return Module.hiwire.new_value(UTF8ToString(ptr));
+});
+
+EM_JS(int, hiwire_string_ascii, (int ptr), {
+  return Module.hiwire.new_value(AsciiToString(ptr));
+});
+
+EM_JS(int, hiwire_bytes, (int ptr, int len), {
+  var bytes = new Uint8ClampedArray(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(bytes);
+});
+
+EM_JS(int, hiwire_int8array, (int ptr, int len), {
+  var array = new Int8Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_uint8array, (int ptr, int len), {
+  var array = new Uint8Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_int16array, (int ptr, int len), {
+  var array = new Int16Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_uint16array, (int ptr, int len), {
+  var array = new Uint16Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_int32array, (int ptr, int len), {
+  var array = new Int32Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_uint32array, (int ptr, int len), {
+  var array = new Uint32Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_float32array, (int ptr, int len), {
+  var array = new Float32Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
+EM_JS(int, hiwire_float64array, (int ptr, int len), {
+  var array = new Float64Array(Module.HEAPU8.buffer, ptr, len);
+  return Module.hiwire.new_value(array);
+})
+
 EM_JS(void, hiwire_throw_error, (int idmsg), {
-  var jsmsg = Module.hiwire_get_value(idmsg);
-  Module.hiwire_decref(idmsg);
+  var jsmsg = Module.hiwire.get_value(idmsg);
+  Module.hiwire.decref(idmsg);
   throw new Error(jsmsg);
 });
 
-EM_JS(int, hiwire_array, (), { return Module.hiwire_new_value([]); });
+EM_JS(int, hiwire_array, (), { return Module.hiwire.new_value([]); });
 
 EM_JS(void, hiwire_push_array, (int idarr, int idval), {
-  Module.hiwire_get_value(idarr).push(Module.hiwire_get_value(idval));
+  Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
-EM_JS(int, hiwire_object, (), { return Module.hiwire_new_value({}); });
+EM_JS(int, hiwire_object, (), { return Module.hiwire.new_value({}); });
 
 EM_JS(void, hiwire_push_object_pair, (int idobj, int idkey, int idval), {
-  var jsobj = Module.hiwire_get_value(idobj);
-  var jskey = Module.hiwire_get_value(idkey);
-  var jsval = Module.hiwire_get_value(idval);
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jskey = Module.hiwire.get_value(idkey);
+  var jsval = Module.hiwire.get_value(idval);
   jsobj[jskey] = jsval;
 });
 
 EM_JS(int, hiwire_get_global, (int idname), {
   var jsname = UTF8ToString(idname);
   if (jsname in self) {
-    return Module.hiwire_new_value(self[jsname]);
+    return Module.hiwire.new_value(self[jsname]);
   } else {
-    return -1;
+    return Module.hiwire.ERROR;
   }
 });
 
 EM_JS(int, hiwire_get_member_string, (int idobj, int idkey), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(idkey);
   if (jskey in jsobj) {
-    return Module.hiwire_new_value(jsobj[jskey]);
+    return Module.hiwire.new_value(jsobj[jskey]);
   } else {
-    return -1;
+    return Module.hiwire.ERROR;
   }
 });
 
 EM_JS(void, hiwire_set_member_string, (int idobj, int ptrkey, int idval), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(ptrkey);
-  var jsval = Module.hiwire_get_value(idval);
+  var jsval = Module.hiwire.get_value(idval);
   jsobj[jskey] = jsval;
 });
 
 EM_JS(void, hiwire_delete_member_string, (int idobj, int ptrkey), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(ptrkey);
   delete jsobj[jskey];
 });
 
 EM_JS(int, hiwire_get_member_int, (int idobj, int idx), {
-  var jsobj = Module.hiwire_get_value(idobj);
-  return Module.hiwire_new_value(jsobj[idx]);
+  var jsobj = Module.hiwire.get_value(idobj);
+  return Module.hiwire.new_value(jsobj[idx]);
 });
 
 EM_JS(void, hiwire_set_member_int, (int idobj, int idx, int idval), {
-  Module.hiwire_get_value(idobj)[idx] = Module.hiwire_get_value(idval);
+  Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
 });
 
 EM_JS(int, hiwire_get_member_obj, (int idobj, int ididx), {
-  var jsobj = Module.hiwire_get_value(idobj);
-  var jsidx = Module.hiwire_get_value(ididx);
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jsidx = Module.hiwire.get_value(ididx);
   if (jsidx in jsobj) {
-    return Module.hiwire_new_value(jsobj[jsidx]);
+    return Module.hiwire.new_value(jsobj[jsidx]);
   } else {
-    return -1;
+    return Module.hiwire.ERROR;
   }
 });
 
 EM_JS(void, hiwire_set_member_obj, (int idobj, int ididx, int idval), {
-  var jsobj = Module.hiwire_get_value(idobj);
-  var jsidx = Module.hiwire_get_value(ididx);
-  var jsval = Module.hiwire_get_value(idval);
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jsidx = Module.hiwire.get_value(ididx);
+  var jsval = Module.hiwire.get_value(idval);
   jsobj[jsidx] = jsval;
 });
 
 EM_JS(void, hiwire_delete_member_obj, (int idobj, int ididx), {
-  var jsobj = Module.hiwire_get_value(idobj);
-  var jsidx = Module.hiwire_get_value(ididx);
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jsidx = Module.hiwire.get_value(ididx);
   delete jsobj[jsidx];
 });
 
 EM_JS(int, hiwire_dir, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   var result = [];
   do {
     result.push.apply(result, Object.getOwnPropertyNames(jsobj));
   } while ((jsobj = Object.getPrototypeOf(jsobj)));
-  return Module.hiwire_new_value(result);
+  return Module.hiwire.new_value(result);
 });
 
 EM_JS(int, hiwire_call, (int idfunc, int idargs), {
-  var jsfunc = Module.hiwire_get_value(idfunc);
-  var jsargs = Module.hiwire_get_value(idargs);
-  return Module.hiwire_new_value(jsfunc.apply(jsfunc, jsargs));
+  var jsfunc = Module.hiwire.get_value(idfunc);
+  var jsargs = Module.hiwire.get_value(idargs);
+  return Module.hiwire.new_value(jsfunc.apply(jsfunc, jsargs));
 });
 
 EM_JS(int, hiwire_call_member, (int idobj, int ptrname, int idargs), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   var jsname = UTF8ToString(ptrname);
-  var jsargs = Module.hiwire_get_value(idargs);
-  return Module.hiwire_new_value(jsobj[jsname].apply(jsobj, jsargs));
+  var jsargs = Module.hiwire.get_value(idargs);
+  return Module.hiwire.new_value(jsobj[jsname].apply(jsobj, jsargs));
 });
 
 EM_JS(int, hiwire_new, (int idobj, int idargs), {
@@ -265,18 +305,18 @@ EM_JS(int, hiwire_new, (int idobj, int idargs), {
   {
     return new (Function.prototype.bind.apply(Cls, arguments));
   }
-  var jsobj = Module.hiwire_get_value(idobj);
-  var jsargs = Module.hiwire_get_value(idargs);
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jsargs = Module.hiwire.get_value(idargs);
   jsargs.unshift(jsobj);
-  return Module.hiwire_new_value(newCall.apply(newCall, jsargs));
+  return Module.hiwire.new_value(newCall.apply(newCall, jsargs));
 });
 
 EM_JS(int, hiwire_get_length, (int idobj), {
-  return Module.hiwire_get_value(idobj).length;
+  return Module.hiwire.get_value(idobj).length;
 });
 
 EM_JS(int, hiwire_get_bool, (int idobj), {
-  var val = Module.hiwire_get_value(idobj);
+  var val = Module.hiwire.get_value(idobj);
   // clang-format off
   return (val && (val.length === undefined || val.length)) ? 1 : 0;
   // clang-format on
@@ -284,21 +324,21 @@ EM_JS(int, hiwire_get_bool, (int idobj), {
 
 EM_JS(int, hiwire_is_function, (int idobj), {
   // clang-format off
-  return typeof Module.hiwire_get_value(idobj) === 'function';
+  return typeof Module.hiwire.get_value(idobj) === 'function';
   // clang-format on
 });
 
 EM_JS(int, hiwire_to_string, (int idobj), {
-  return Module.hiwire_new_value(Module.hiwire_get_value(idobj).toString());
+  return Module.hiwire.new_value(Module.hiwire.get_value(idobj).toString());
 });
 
 EM_JS(int, hiwire_typeof, (int idobj), {
-  return Module.hiwire_new_value(typeof Module.hiwire_get_value(idobj));
+  return Module.hiwire.new_value(typeof Module.hiwire.get_value(idobj));
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
   EM_JS(int, hiwire_##name, (int ida, int idb), {                              \
-    return (Module.hiwire_get_value(ida) op Module.hiwire_get_value(idb)) ? 1  \
+    return (Module.hiwire.get_value(ida) op Module.hiwire.get_value(idb)) ? 1  \
                                                                           : 0; \
   });
 
@@ -311,66 +351,65 @@ MAKE_OPERATOR(greater_than_equal, >=);
 
 EM_JS(int, hiwire_next, (int idobj), {
   // clang-format off
-  if (idobj === -2) {
-    // clang-format on
-    return -1;
+  if (idobj === Module.hiwire.UNDEFINED) {
+    return Module.hiwire.ERROR;
   }
 
-  var jsobj = Module.hiwire_get_value(idobj);
-  return Module.hiwire_new_value(jsobj.next());
+  var jsobj = Module.hiwire.get_value(idobj);
+  return Module.hiwire.new_value(jsobj.next());
+  // clang-format on
 });
 
 EM_JS(int, hiwire_get_iterator, (int idobj), {
   // clang-format off
-  if (idobj === -2) {
-    return -1;
+  if (idobj === Module.hiwire.UNDEFINED) {
+    return Module.hiwire.ERROR;
   }
 
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   if (typeof jsobj.next === 'function') {
-    return Module.hiwire_new_value(jsobj);
+    return Module.hiwire.new_value(jsobj);
   } else if (typeof jsobj[Symbol.iterator] === 'function') {
-    return Module.hiwire_new_value(jsobj[Symbol.iterator]());
+    return Module.hiwire.new_value(jsobj[Symbol.iterator]());
   } else {
-    return Module.hiwire_new_value(
-      Object.entries(jsobj)[Symbol.iterator]()
-    );
+    return Module.hiwire.new_value(Object.entries(jsobj)[Symbol.iterator]());
   }
-  return -1;
+  return Module.hiwire.ERROR;
   // clang-format on
 })
 
 EM_JS(int, hiwire_nonzero, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
+  // TODO: should this be !== 0?
   return (jsobj != 0) ? 1 : 0;
 });
 
 EM_JS(int, hiwire_is_typedarray, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj['byteLength'] !== undefined) ? 1 : 0;
   // clang-format on
 });
 
 EM_JS(int, hiwire_is_on_wasm_heap, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj.buffer === Module.HEAPU8.buffer) ? 1 : 0;
   // clang-format on
 });
 
 EM_JS(int, hiwire_get_byteOffset, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteOffset'];
 });
 
 EM_JS(int, hiwire_get_byteLength, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteLength'];
 });
 
 EM_JS(int, hiwire_copy_to_ptr, (int idobj, int ptr), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   var buffer = (jsobj['buffer'] !== undefined) ? jsobj.buffer : jsobj;
   // clang-format on
@@ -378,7 +417,7 @@ EM_JS(int, hiwire_copy_to_ptr, (int idobj, int ptr), {
 });
 
 EM_JS(int, hiwire_get_dtype, (int idobj), {
-  var jsobj = Module.hiwire_get_value(idobj);
+  var jsobj = Module.hiwire.get_value(idobj);
   switch (jsobj.constructor.name) {
     case 'Int8Array':
       dtype = 1; // INT8_TYPE;
@@ -418,7 +457,7 @@ EM_JS(int, hiwire_get_dtype, (int idobj), {
 });
 
 EM_JS(int, hiwire_subarray, (int idarr, int start, int end), {
-  var jsarr = Module.hiwire_get_value(idarr);
+  var jsarr = Module.hiwire.get_value(idarr);
   var jssub = jsarr.subarray(start, end);
-  return Module.hiwire_new_value(jssub);
+  return Module.hiwire.new_value(jssub);
 });

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -81,7 +81,7 @@ EM_JS(void, hiwire_setup, (), {
   Module.hiwire.get_value = function(idval)
   {
     if (!idval) {
-      throw new Error("Argument to hiwire_get_value is undefined");
+      throw new Error("Argument to hiwire.get_value is undefined");
     }
     if (!_hiwire.objects.has(idval)) {
       throw new Error(`Undefined id $ { idval }`);

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -56,19 +56,8 @@ EM_JS(void, hiwire_setup, (), {
   {
     // Should we guard against duplicating standard values?
     // Probably not worth it for performance: it's harmless to ocassionally
-    // duplicate. Maybe in test builds these should raise? if(jsval ===
-    // undefined){
-    //   return Module.hiwire.UNDEFINED;
-    // }
-    // if(jsval === null){
-    //   return Module.hiwire.NULL;
-    // }
-    // if(jsval === true){
-    //   return Module.hiwire.TRUE;
-    // }
-    // if(jsval === false){
-    //   return Module.hiwire.FALSE;
-    // }
+    // duplicate. Maybe in test builds we could raise if jsval is a standard
+    // value?
     while (_hiwire.objects.has(_hiwire.counter)) {
       _hiwire.counter = (_hiwire.counter + 1) & 0x7fffffff;
     }

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -14,7 +14,7 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
-// Define special ids for singleton constants. These must be less than -1 to
+// Define special ids for singleton constants. These must be negative to
 // avoid being reused for other values.
 #define HW_ERROR -1
 #define HW_UNDEFINED -2
@@ -234,6 +234,15 @@ hiwire_true();
  */
 int
 hiwire_false();
+
+/**
+ * Create a new Javascript boolean value.
+ * Return value is true if boolean != 0, false if boolean == 0.
+ *
+ * Returns: New reference
+ */
+int
+hiwire_bool(int boolean);
 
 /**
  * Create a new Javascript Array.

--- a/src/type_conversion/js2python.c
+++ b/src/type_conversion/js2python.c
@@ -76,7 +76,7 @@ _js2python_jsproxy(int id)
 
 EM_JS(int, __js2python, (int id), {
   // clang-format off
-  var value = Module.hiwire_get_value(id);
+  var value = Module.hiwire.get_value(id);
   var type = typeof value;
   if (type === 'string') {
     // The general idea here is to allocate a Python string and then

--- a/src/type_conversion/pyimport.c
+++ b/src/type_conversion/pyimport.c
@@ -27,8 +27,8 @@ EM_JS(int, pyimport_init, (), {
   {
     var pyname = allocate(intArrayFromString(name), 'i8', ALLOC_NORMAL);
     var idresult = Module.__pyimport(pyname);
-    jsresult = Module.hiwire_get_value(idresult);
-    Module.hiwire_decref(idresult);
+    jsresult = Module.hiwire.get_value(idresult);
+    Module.hiwire.decref(idresult);
     _free(pyname);
     return jsresult;
   };

--- a/src/type_conversion/pyproxy.c
+++ b/src/type_conversion/pyproxy.c
@@ -10,7 +10,7 @@ _pyproxy_has(int ptrobj, int idkey)
 {
   PyObject* pyobj = (PyObject*)ptrobj;
   PyObject* pykey = js2python(idkey);
-  int result = PyObject_HasAttr(pyobj, pykey) ? hiwire_true() : hiwire_false();
+  int result = hiwire_bool(PyObject_HasAttr(pyobj, pykey));
   Py_DECREF(pykey);
   return result;
 }
@@ -128,10 +128,10 @@ EM_JS(int, pyproxy_use, (int ptrobj), {
   // Checks if there is already an existing proxy on ptrobj
 
   if (Module.PyProxies.hasOwnProperty(ptrobj)) {
-    return Module.hiwire_new_value(Module.PyProxies[ptrobj]);
+    return Module.hiwire.new_value(Module.PyProxies[ptrobj]);
   }
 
-  return -2; /* this means HW_UNDEFINED */
+  return Module.hiwire.UNDEFINED;
 })
 
 EM_JS(int, pyproxy_new, (int ptrobj), {
@@ -146,7 +146,7 @@ EM_JS(int, pyproxy_new, (int ptrobj), {
   var proxy = new Proxy(target, Module.PyProxy);
   Module.PyProxies[ptrobj] = proxy;
 
-  return Module.hiwire_new_value(proxy);
+  return Module.hiwire.new_value(proxy);
 });
 
 EM_JS(int, pyproxy_init, (), {
@@ -172,9 +172,9 @@ EM_JS(int, pyproxy_init, (), {
     isExtensible: function() { return true },
     has: function (jsobj, jskey) {
       ptrobj = this.getPtr(jsobj);
-      var idkey = Module.hiwire_new_value(jskey);
+      var idkey = Module.hiwire.new_value(jskey);
       var result = __pyproxy_has(ptrobj, idkey) != 0;
-      Module.hiwire_decref(idkey);
+      Module.hiwire.decref(idkey);
       return result;
     },
     get: function (jsobj, jskey) {
@@ -195,64 +195,64 @@ EM_JS(int, pyproxy_init, (), {
         }
       } else if (jskey == 'apply') {
         return function(jsthis, jsargs) {
-          var idargs = Module.hiwire_new_value(jsargs);
+          var idargs = Module.hiwire.new_value(jsargs);
           var idresult = __pyproxy_apply(ptrobj, idargs);
-          var jsresult = Module.hiwire_get_value(idresult);
-          Module.hiwire_decref(idresult);
-          Module.hiwire_decref(idargs);
+          var jsresult = Module.hiwire.get_value(idresult);
+          Module.hiwire.decref(idresult);
+          Module.hiwire.decref(idargs);
           return jsresult;
         };
       }
-      var idkey = Module.hiwire_new_value(jskey);
+      var idkey = Module.hiwire.new_value(jskey);
       var idresult = __pyproxy_get(ptrobj, idkey);
-      var jsresult = Module.hiwire_get_value(idresult);
-      Module.hiwire_decref(idkey);
-      Module.hiwire_decref(idresult);
+      var jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idkey);
+      Module.hiwire.decref(idresult);
       return jsresult;
     },
     set: function (jsobj, jskey, jsval) {
       ptrobj = this.getPtr(jsobj);
-      var idkey = Module.hiwire_new_value(jskey);
-      var idval = Module.hiwire_new_value(jsval);
+      var idkey = Module.hiwire.new_value(jskey);
+      var idval = Module.hiwire.new_value(jsval);
       var idresult = __pyproxy_set(ptrobj, idkey, idval);
-      var jsresult = Module.hiwire_get_value(idresult);
-      Module.hiwire_decref(idkey);
-      Module.hiwire_decref(idval);
-      Module.hiwire_decref(idresult);
+      var jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idkey);
+      Module.hiwire.decref(idval);
+      Module.hiwire.decref(idresult);
       return jsresult;
     },
     deleteProperty: function (jsobj, jskey) {
       ptrobj = this.getPtr(jsobj);
-      var idkey = Module.hiwire_new_value(jskey);
+      var idkey = Module.hiwire.new_value(jskey);
       var idresult = __pyproxy_deleteProperty(ptrobj, idkey);
-      var jsresult = Module.hiwire_get_value(idresult);
-      Module.hiwire_decref(idresult);
-      Module.hiwire_decref(idkey);
+      var jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idresult);
+      Module.hiwire.decref(idkey);
       return jsresult;
     },
     ownKeys: function (jsobj) {
       ptrobj = this.getPtr(jsobj);
       var idresult = __pyproxy_ownKeys(ptrobj);
-      var jsresult = Module.hiwire_get_value(idresult);
-      Module.hiwire_decref(idresult);
+      var jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idresult);
       this.addExtraKeys(jsresult);
       return jsresult;
     },
     enumerate: function (jsobj) {
       ptrobj = this.getPtr(jsobj);
       var idresult = __pyproxy_enumerate(ptrobj);
-      var jsresult = Module.hiwire_get_value(idresult);
-      Module.hiwire_decref(idresult);
+      var jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idresult);
       this.addExtraKeys(jsresult);
       return jsresult;
     },
     apply: function (jsobj, jsthis, jsargs) {
       ptrobj = this.getPtr(jsobj);
-      var idargs = Module.hiwire_new_value(jsargs);
+      var idargs = Module.hiwire.new_value(jsargs);
       var idresult = __pyproxy_apply(ptrobj, idargs);
-      var jsresult = Module.hiwire_get_value(idresult);
-      Module.hiwire_decref(idresult);
-      Module.hiwire_decref(idargs);
+      var jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idresult);
+      Module.hiwire.decref(idargs);
       return jsresult;
     },
   };

--- a/src/type_conversion/python2js_buffer.c
+++ b/src/type_conversion/python2js_buffer.c
@@ -32,11 +32,7 @@ static int
 _convert_bool(char* data)
 {
   char v = *((char*)data);
-  if (v) {
-    return hiwire_true();
-  } else {
-    return hiwire_false();
-  }
+  return hiwire_bool((int)v);
 }
 
 static int

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -57,8 +57,8 @@ EM_JS(int, runpython_init_js, (), {
   Module._runPythonInternal = function(pycode)
   {
     var idresult = Module.__runPython(pycode);
-    var jsresult = Module.hiwire_get_value(idresult);
-    Module.hiwire_decref(idresult);
+    var jsresult = Module.hiwire.get_value(idresult);
+    Module.hiwire.decref(idresult);
     _free(pycode);
     return jsresult;
   };
@@ -74,8 +74,8 @@ EM_JS(int, runpython_init_js, (), {
     var pycode = allocate(intArrayFromString(code), 'i8', ALLOC_NORMAL);
 
     var idimports = Module.__findImports(pycode);
-    var jsimports = Module.hiwire_get_value(idimports);
-    Module.hiwire_decref(idimports);
+    var jsimports = Module.hiwire.get_value(idimports);
+    Module.hiwire.decref(idimports);
 
     var internal = function(resolve, reject)
     {


### PR DESCRIPTION
This is split off from PR #912 to try to make reviewing easier. This is purely maintenance / internal code improvement, it should have no observable effect to the end user.

## Hiwire API changes
I exposed the hiwire constants as `Module.hiwire.ERROR`, etc. I replaced all magic hiwire numbers in javascript code by references to `Module.hiwire.SOME_CONSTANT`. I added a convenience method `hiwire_bool` because there seems to be several places where the code says `x ? hiwire_true() : hiwire_false()` and `hiwire_bool(x)` seems simpler.

Renamed:
* `Module.hiwire_new_value` ==> `Module.hiwire.new_value`
* `Module.hiwire_get_value` ==> `Module.hiwire.get_value`
* `Module.hiwire_dec_ref` ==> `Module.hiwire.dec_ref`

Most of the diff for this is from these renames.


## Internal changes to hiwire.c
 I used a Map for hiwire objects internally instead of a js object because maps ["perform better in scenarios involving frequent additions and removals of key-value pairs"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Objects_vs._Maps).
I tried to improve the clarity of the distinction between private and public methods.