### PR TITLE
Added fatal error messages to main

### DIFF
--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -167,3 +167,9 @@ EM_JS(int, runpython_finalize_js, (), {
   };
   return 0;
 });
+
+int
+runpython_init()
+{
+  return runpython_init_js() || runpython_init_py() || runpython_finalize_js();
+}

--- a/src/type_conversion/runpython.h
+++ b/src/type_conversion/runpython.h
@@ -5,12 +5,6 @@
  */
 
 int
-runpython_init_js();
-
-int
-runpython_init_py();
-
-int
-runpython_finalize_js();
+runpython_init();
 
 #endif /* RUNPYTHON_H */


### PR DESCRIPTION
If one of the init functions called in main fails, print a fatal error message. This should make it much easier to debug issues.
Example: If I add a name error to pyodide_py it now prints:

```
FATAL ERROR: Failed to initialize module runpython.
Error was triggered by Python exception:
Traceback (most recent call last): 
  File "/lib/python3.8/site-packages/pyodide/__init__.py", line 3, in <module> 
    test pyodide.asm.js:8:57150
NameError: name 'test' is not defined
Python exception: 
SystemError: null argument to internal routine
```