### PR TITLE
Fix documentation build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements-doc.txt


### PR DESCRIPTION
Fix documentation build at https://readthedocs.org/projects/pyodide/builds/12631624/

We now require python 3.8 to build docs as well due to the use of `ast.PyCF_ALLOW_TOP_LEVEL_AWAIT` in pyodide-py