### PR TITLE
Enable monkey patching of eval_code and find_imports

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,7 +45,9 @@
   [#846](https://github.com/iodide-project/pyodide/pull/846).
 - Suppress REPL results returned by `pyodide.eval_code` by adding a semicolon
   [#876](https://github.com/iodide-project/pyodide/pull/876).
-
+- Enable monkey patching of `eval_code` and `find_imports` to customize behavior
+  of `runPython` and `runPythonAsync`
+  [#941](https://github.com/iodide-project/pyodide/pull/941).
 
 ### Build system
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,15 +9,31 @@ The two possible solutions are,
   {ref}`load it with micropip <micropip-installing-from-arbitrary-urls>`.
 - fetch the python code as a string and evaluate it in Python,
   ```js
-  pyodide.eval_code(pyodide.open_url('https://some_url/...'))
+  pyodide.runPython(await fetch('https://some_url/...'))
   ```
 
 In both cases, files need to be served with a web server and cannot be loaded from local file system.
 
 ## Why can't I load files from the local file system?
 
-For security reasons JavaScript in the browser is not allowed to load local
-data files. You need to serve them with a web-browser.
+For security reasons JavaScript in the browser is not allowed to load local data files. You need to serve them with a web-browser.
+Recently there is a [Native File System API](https://wicg.github.io/file-system-access/) supported in Chrome but not in Firefox. [There is a discussion about implementing it for Firefox here.](https://github.com/mozilla/standards-positions/issues/154)
+
+
+## How can I change the behavior of `runPython` and `runPythonAsync`?
+Internally they use the `pyodide-py` apis `eval_code` and `find_imports`. You can monkey patch these.
+Run the following Python code:
+```python
+import pyodide
+old_eval_code = pyodide.eval_code
+def eval_code(code, ns):
+  extra_info = None
+  result = old_eval_code(code, ns)
+  return [ns["extra_info"], result]
+pyodide.eval_code = eval_code
+```
+Then `pyodide.runPython("2+7")` returns `9` and `pyodide.runPython("extra_info='hello' ; 2 + 2")` will return `['hello', 4]`.
+
 
 ## How to detect that code is run with Pyodide?
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -65,7 +65,7 @@ def test_adjust_ast():
     assert_stored_none("1+1;")
     assert_stored_none("def f(): 4")
     assert_stored_none(
-        """ 
+        """
         def f():
             print(9)
             return 2*7 + 5
@@ -73,7 +73,7 @@ def test_adjust_ast():
     )
 
     assert_stored_last_line(
-        """ 
+        """
         def f(x):
             print(9)
             return 2*x + 5
@@ -86,7 +86,7 @@ def test_eval_code():
     ns = {}
     assert (
         eval_code(
-            """ 
+            """
         def f(x):
             return 2*x + 5
         f(77)
@@ -103,3 +103,18 @@ def test_eval_code():
     assert ns["x"] == 7
 
     assert eval_code("1+1;", ns) is None
+
+
+def test_monkeypatch_eval_code(selenium):
+    selenium.run(
+        """
+        import pyodide
+        old_eval_code = pyodide.eval_code
+        x = 3
+        def eval_code(code, ns):
+            return [ns["x"], old_eval_code(code, ns)]
+        pyodide.eval_code = eval_code
+        """
+    )
+    assert selenium.run("x = 99; 5") == [3, 5]
+    assert selenium.run("7") == [99, 7]

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -10,8 +10,8 @@
 PyObject* globals;
 PyObject* pyodide;
 
-_Py_IDENTIFIER("eval_code");
-_Py_IDENTIFIER("find_imports");
+_Py_IDENTIFIER(eval_code);
+_Py_IDENTIFIER(find_imports);
 
 int
 _runPython(char* code)
@@ -23,7 +23,7 @@ _runPython(char* code)
   }
 
   PyObject* ret =
-    PyObject_CallMethodIdObjArgs(pyodide, &PyId_eval_code, globals, NULL);
+    _PyObject_CallMethodIdObjArgs(pyodide, &PyId_eval_code, py_code, globals, NULL);
 
   if (ret == NULL) {
     return pythonexc2js();
@@ -44,7 +44,7 @@ _findImports(char* code)
   }
 
   PyObject* ret =
-    PyObject_CallFunctionObjArgs(pyodide, &PyId_find_imports, py_code, NULL);
+    _PyObject_CallMethodIdObjArgs(pyodide, &PyId_find_imports, py_code, NULL);
 
   if (ret == NULL) {
     return pythonexc2js();

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -8,9 +8,10 @@
 #include "python2js.h"
 
 PyObject* globals;
+PyObject* pyodide;
 
-PyObject* eval_code;
-PyObject* find_imports;
+_Py_IDENTIFIER("eval_code");
+_Py_IDENTIFIER("find_imports");
 
 int
 _runPython(char* code)
@@ -22,7 +23,7 @@ _runPython(char* code)
   }
 
   PyObject* ret =
-    PyObject_CallFunctionObjArgs(eval_code, py_code, globals, NULL);
+    PyObject_CallMethodIdObjArgs(pyodide, &PyId_eval_code, globals, NULL);
 
   if (ret == NULL) {
     return pythonexc2js();
@@ -42,7 +43,8 @@ _findImports(char* code)
     return pythonexc2js();
   }
 
-  PyObject* ret = PyObject_CallFunctionObjArgs(find_imports, py_code, NULL);
+  PyObject* ret =
+    PyObject_CallFunctionObjArgs(pyodide, &PyId_find_imports, py_code, NULL);
 
   if (ret == NULL) {
     return pythonexc2js();
@@ -136,23 +138,8 @@ runpython_init_py()
     return 1;
   }
 
-  PyObject* m = PyImport_ImportModule("pyodide");
-  if (m == NULL) {
-    return 1;
-  }
-
-  PyObject* d = PyModule_GetDict(m);
-  if (d == NULL) {
-    return 1;
-  }
-
-  eval_code = PyDict_GetItemString(d, "eval_code");
-  if (eval_code == NULL) {
-    return 1;
-  }
-
-  find_imports = PyDict_GetItemString(d, "find_imports");
-  if (find_imports == NULL) {
+  pyodide = PyImport_ImportModule("pyodide");
+  if (pyodide == NULL) {
     return 1;
   }
 

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -22,8 +22,8 @@ _runPython(char* code)
     return pythonexc2js();
   }
 
-  PyObject* ret =
-    _PyObject_CallMethodIdObjArgs(pyodide, &PyId_eval_code, py_code, globals, NULL);
+  PyObject* ret = _PyObject_CallMethodIdObjArgs(
+    pyodide, &PyId_eval_code, py_code, globals, NULL);
 
   if (ret == NULL) {
     return pythonexc2js();


### PR DESCRIPTION
runpython.c uses a nonidiomatic strategy to index the `pyodide-py` module (which is defined primary in Python). This is a significant usability concern (see conversation with Casatir in #876). This is a quick patch to use the correct CPython API to call a pure python package from C and enable monkey patching.