### PR TITLE
DOCS: "Service worker" ==> "Web worker"

### DIFF
--- a/docs/using_pyodide_from_webworker.md
+++ b/docs/using_pyodide_from_webworker.md
@@ -31,7 +31,7 @@ method (and vice versa).
 
 In this example process we will have three parties involved:
 
-* The **service worker** is responsible for running scripts in its own thread separate thread.
+* The **web worker** is responsible for running scripts in its own thread separate thread.
 * The **worker API** exposes a consumer-to-provider communication interface.
 * The **consumer**s want to run some scripts outside the main thread so they don't block the main thread.
 
@@ -79,9 +79,9 @@ main();
 ```
 
 Before writing the API, lets first have a look at how the worker operates.
-How does our service worker will run the `script` using a given `context`.
+How does our web worker will run the `script` using a given `context`.
 
-### Service worker
+### Web worker
 
 [A worker][worker API] is ...
 


### PR DESCRIPTION
A [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) is a special type of webworker that acts like a proxy webserver except it runs in the client. The correct term is [Web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API).