### PR TITLE
Make a copy of `console.html` at `builld/index.html`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ all: check \
 	build/pyodide.asm.data \
 	build/pyodide.js \
 	build/console.html \
+	build/index.html \
 	build/renderedhtml.css \
 	build/test.data \
 	build/packages.json \
@@ -109,6 +110,9 @@ build/console.html: src/templates/console.html
 	cp $< $@
 	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
+build/index.html: src/templates/console.html
+	cp $< $@
+	sed -i -e 's#{{ PYODIDE_BASE_URL }}#$(PYODIDE_BASE_URL)#g' $@
 
 build/renderedhtml.css: src/css/renderedhtml.less
 	lessc $< $@

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <title>Pyodide Console</title>
+    <meta name="description" content="A Python repl backed by the pyodide Python runtime.">
+    <meta name="author" content="The Pyodide Project">
     <script src="https://code.jquery.com/jquery-latest.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" rel="stylesheet"/>


### PR DESCRIPTION
The standard for websites is to make `index.html` be the main file. Since our main file is `console.html`, I propose we should make a copy at `index.html`.

I also added a title and some meta tags.