### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,9 +244,15 @@ workflows:
       - build-packages:
           requires:
             - build-core
+          filters:
+            tags:
+              only: /.*/
       - test-core-chrome:
           requires:
             - build-core
+          filters:
+            tags:
+              only: /.*/
       - test-core-firefox:
           requires:
             - build-core
@@ -256,6 +262,9 @@ workflows:
       - test-packages-chrome:
           requires:
             - build-packages
+          filters:
+            tags:
+              only: /.*/
       - test-packages-firefox:
           requires:
             - build-packages
@@ -265,6 +274,9 @@ workflows:
       - test-emsdk:
           requires:
             - build-core
+          filters:
+            tags:
+              only: /.*/
       - test-python:
           filters:
             tags:
@@ -276,6 +288,9 @@ workflows:
           requires:
             - test-core-firefox
             - test-packages-firefox
+            - test-core-chrome
+            - test-packages-chrome
+            - test-emsdk
           filters:
             branches:
               ignore: /.*/
@@ -285,6 +300,9 @@ workflows:
           requires:
             - test-core-firefox
             - test-packages-firefox
+            - test-core-chrome
+            - test-packages-chrome
+            - test-emsdk
           filters:
             branches:
               only: master


### PR DESCRIPTION
This incorporates two changes.

1. Since chrome tests are now much less flaky, we require chrome tests to pass before deploying.

2. Mark all jobs (except benchmark) as `filters/tags/only: /.*/` so that they run on releases. This was previously causing the 1.16.0 release to not contain package builds.

Addresses the underlying problem of #944. To actually fix #944, the release/tag has to be re-done.
