### PR TITLE
BLD Make package build output less verbose

### DIFF
--- a/packages/distlib/meta.yaml
+++ b/packages/distlib/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: distlib
   version: 0.3.1
 source:
-  sha256: edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bf1
+  sha256: edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1
   url: https://files.pythonhosted.org/packages/2f/83/1eba07997b8ba58d92b3e51445d5bf36f9fba9cb8166bcae99b9c3464841/distlib-0.3.1.zip
 test:
   imports:

--- a/packages/distlib/meta.yaml
+++ b/packages/distlib/meta.yaml
@@ -2,7 +2,7 @@ package:
   name: distlib
   version: 0.3.1
 source:
-  sha256: edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1
+  sha256: edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bf1
   url: https://files.pythonhosted.org/packages/2f/83/1eba07997b8ba58d92b3e51445d5bf36f9fba9cb8166bcae99b9c3464841/distlib-0.3.1.zip
 test:
   imports:

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -72,10 +72,15 @@ class Package:
                     stderr=subprocess.STDOUT,
                 )
 
-        with open(self.pkgdir / "build.log", "r") as f:
-            shutil.copyfileobj(f, sys.stdout)
+        try:
+            p.check_returncode()
+        except subprocess.CalledProcessError:
+            print(f"Error building {self.name}. Printing build logs.")
 
-        p.check_returncode()
+            with open(self.pkgdir / "build.log", "r") as f:
+                shutil.copyfileobj(f, sys.stdout)
+
+            raise
 
         if not self.library:
             shutil.copyfile(


### PR DESCRIPTION
1. Only print build logs when a build fails.
2. Raise a custom RuntimeError when build fails instead of verbose CalledProcessError --- we already print build logs

My main concern is that there might be cases where the package build does not error but produces incorrect output files, and one might want to inspect the build process for that, but in that case one can still build locally.
