### PR TITLE
Release 0.16.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   environment:
     - EMSDK_NUM_CORES: 4
       EMCC_CORES: 4
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.16.0/full/
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.16.1/full/
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ browser**.
 ## Try Pyodide (no installation needed)
 
 Try the [iodide demo notebook](https://alpha.iodide.io/notebooks/300/) or fire
-up a [Python REPL](https://pyodide-cdn2.iodide.io/latest/full/console.html) directly in your
+up a [Python REPL](https://pyodide-cdn2.iodide.io/v0.16.1/full/console.html) directly in your
 browser.
 
 For further information, look through the [documentation](https://pyodide.readthedocs.io/).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,14 @@
 (changelog)=
 # Release notes
 
-## Version 0.16.0
-*December 24, 2020*
+## Version 0.16.1
+*December 25, 2020*
 
+Note: due to a CI deployment issue the 0.16.0 release was skipped and replaced
+by 0.16.1 with identical contents.
 
 - Pyodide files are distributed by [JsDelivr](https://www.jsdelivr.com/),
-  `https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js`
+  `https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js`
   The previous CDN `pyodide-cdn2.iodide.io` still works and there
   are no plans for deprecating it. However please use
   JsDelivr as a more sustainable solution, including for earlier pyodide

--- a/docs/loading_packages.md
+++ b/docs/loading_packages.md
@@ -130,9 +130,9 @@ a complete example would be,
 <body>
   <script type="text/javascript">
       // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-      window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.0/full/';
+      window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.1/full/';
   </script>
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js"></script>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js"></script>
   <script type="text/javascript">
     pythonCode = `
       def do_work(*args):

--- a/docs/using_pyodide_from_javascript.md
+++ b/docs/using_pyodide_from_javascript.md
@@ -8,7 +8,7 @@ This document describes using Pyodide directly from Javascript. For information 
 
 To include Pyodide in your project you can use the following CDN URL,
 
-  https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js
+  https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js
 
 You can also download a release from
 [Github releases](https://github.com/iodide-project/pyodide/releases)
@@ -55,9 +55,9 @@ Create and save a test `index.html` page with the following contents:
   <head>
       <script type="text/javascript">
           // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-          window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.0/full/';
+          window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.1/full/';
       </script>
-      <script src="https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js"></script>
+      <script src="https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js"></script>
   </head>
   <body>
     Pyodide test page <br>
@@ -83,9 +83,9 @@ Create and save a test `index.html` page with the following contents:
 <html>
 <head>
     <script type="text/javascript">
-        window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.0/full/';
+        window.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.1/full/';
     </script>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js"></script>
 </head>
 
 <body>

--- a/docs/using_pyodide_from_webworker.md
+++ b/docs/using_pyodide_from_webworker.md
@@ -105,8 +105,8 @@ lines `pythonLoading = self.pyodide.loadPackage(['numpy', 'pytz'])` and
 // Setup your project to serve `py-worker.js`. You should also serve
 // `pyodide.js`, and all its associated `.asm.js`, `.data`, `.json`,
 // and `.wasm` files as well:
-self.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.0/full/';
-importScripts('https://cdn.jsdelivr.net/pyodide/v0.16.0/full/pyodide.js');
+self.languagePluginUrl = 'https://cdn.jsdelivr.net/pyodide/v0.16.1/full/';
+importScripts('https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js');
 
 let pythonLoading;
 async function loadPythonPackages(){

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,7 +1,7 @@
 from ._base import open_url, eval_code, find_imports, as_nested_list, JsException
 from .console import get_completions
 
-__version__ = "0.16.0"
+__version__ = "0.16.1"
 
 __all__ = [
     "open_url",


### PR DESCRIPTION
Addresses https://github.com/iodide-project/pyodide/issues/944  following the CI fix in https://github.com/iodide-project/pyodide/pull/946

Makes a new release as 0.16.1, I'll remove the failed 0.16.0 release altogether. 

We could have re-uploaded the 0.16.0 release but those files (and in particular packages.json) are served by S3 with a 1 year cache headers, and there is no automated way to invalidate jwDelivr cache, so it's probably better to just make a new release. 0.16.0post1 would have been the correct version, but it's not a very nice name in the URL so 0.16.1 will do.

Once it's deployed, we would also need to build and upload the pre-build docker image. I don't have access to a machine where I can do it this week. @dalcde you should have permissions to push to https://hub.docker.com/repository/docker/iodide/pyodide (and pyodide-env) now. Otherwise I'll upload it in January.