### PR TITLE
Restore PYODIDE_BASE_URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   environment:
     - EMSDK_NUM_CORES: 4
       EMCC_CORES: 4
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.16.1/full/
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/dev/full/
 
 jobs:
   lint:


### PR DESCRIPTION
A more permanent solution ought to be found, but CircleCI does not seem to make it easy. This would make dev builds work for now.
