### PR TITLE
Streamline hiwire_get_dtype

### DIFF
--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -332,9 +332,8 @@ EM_JS(JsRef, hiwire_typeof, (JsRef idobj), {
   return Module.hiwire.new_value(typeof Module.hiwire.get_value(idobj));
 });
 
-EM_JS(int, hiwire_constructor_name, (int idobj), {
-  return Module.hiwire.new_value(
-    Module.hiwire.get_value(idobj).constructor.name);
+EM_JS(char*, hiwire_constructor_name, (JsRef idobj), {
+  return stringToNewUTF8(Module.hiwire.get_value(idobj).constructor.name);
 });
 
 #define MAKE_OPERATOR(name, op)                                                \

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -428,14 +428,14 @@ EM_JS(void, hiwire_get_dtype, (int idobj, int format_ptr, int size_ptr), {
     for (let[key, [ format, size ]] of entries) {
       let format_utf8 =
         allocate(intArrayFromString(format), "i8", ALLOC_NORMAL);
-      Module.hiwire.dtype_map.set(key, [ format, size ]);
+      Module.hiwire.dtype_map.set(key, [ format_utf8, size ]);
     }
   }
   let jsobj = Module.hiwire.get_value(idobj);
-  let[format, size] =
+  let[format_utf8, size] =
     Module.hiwire.dtype_map.get(jsobj.constructor.name) || [ 0, 0 ];
   // Store results into arguments
-  setValue(format_ptr, format, "i8*");
+  setValue(format_ptr, format_utf8, "i8*");
   setValue(size_ptr, size, "i32");
 });
 

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -417,34 +417,37 @@ EM_JS(void, hiwire_copy_to_ptr, (JsRef idobj, void* ptr), {
   Module.HEAPU8.set(new Uint8Array(buffer), ptr);
 });
 
-EM_JS(void, hiwire_get_dtype, (JsRef idobj, char** format_ptr, Py_ssize_t* size_ptr), {
-  if (!Module.hiwire.dtype_map) {
-    let entries = Object.entries({
-      'Int8Array' : [ 'b', 1 ],
-      'Uint8Array' : [ 'B', 1 ],
-      'Uint8ClampedArray' : [ 'B', 1 ],
-      'Int16Array' : [ "h", 2 ],
-      'Uint16Array' : [ "H", 2 ],
-      'Int32Array' : [ "i", 4 ],
-      'Uint32Array' : [ "I", 4 ],
-      'Float32Array' : [ "f", 4 ],
-      'Float64Array' : [ "d", 8 ],
-      'ArrayBuffer' : [ 'B', 1 ], // Default to Uint8;
-    });
-    Module.hiwire.dtype_map = new Map();
-    for (let[key, [ format, size ]] of entries) {
-      let format_utf8 =
-        allocate(intArrayFromString(format), "i8", ALLOC_NORMAL);
-      Module.hiwire.dtype_map.set(key, [ format_utf8, size ]);
-    }
-  }
-  let jsobj = Module.hiwire.get_value(idobj);
-  let[format_utf8, size] =
-    Module.hiwire.dtype_map.get(jsobj.constructor.name) || [ 0, 0 ];
-  // Store results into arguments
-  setValue(format_ptr, format_utf8, "i8*");
-  setValue(size_ptr, size, "i32");
-});
+EM_JS(void,
+      hiwire_get_dtype,
+      (JsRef idobj, char** format_ptr, Py_ssize_t* size_ptr),
+      {
+        if (!Module.hiwire.dtype_map) {
+          let entries = Object.entries({
+            'Int8Array' : [ 'b', 1 ],
+            'Uint8Array' : [ 'B', 1 ],
+            'Uint8ClampedArray' : [ 'B', 1 ],
+            'Int16Array' : [ "h", 2 ],
+            'Uint16Array' : [ "H", 2 ],
+            'Int32Array' : [ "i", 4 ],
+            'Uint32Array' : [ "I", 4 ],
+            'Float32Array' : [ "f", 4 ],
+            'Float64Array' : [ "d", 8 ],
+            'ArrayBuffer' : [ 'B', 1 ], // Default to Uint8;
+          });
+          Module.hiwire.dtype_map = new Map();
+          for (let[key, [ format, size ]] of entries) {
+            let format_utf8 =
+              allocate(intArrayFromString(format), "i8", ALLOC_NORMAL);
+            Module.hiwire.dtype_map.set(key, [ format_utf8, size ]);
+          }
+        }
+        let jsobj = Module.hiwire.get_value(idobj);
+        let[format_utf8, size] =
+          Module.hiwire.dtype_map.get(jsobj.constructor.name) || [ 0, 0 ];
+        // Store results into arguments
+        setValue(format_ptr, format_utf8, "i8*");
+        setValue(size_ptr, size, "i32");
+      });
 
 EM_JS(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
   var jsarr = Module.hiwire.get_value(idarr);

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -326,7 +326,8 @@ EM_JS(int, hiwire_typeof, (int idobj), {
 });
 
 EM_JS(int, hiwire_constructor_name, (int idobj), {
-  return Module.hiwire.new_value(Module.hiwire.get_value(idobj).constructor.name);
+  return Module.hiwire.new_value(
+    Module.hiwire.get_value(idobj).constructor.name);
 });
 
 #define MAKE_OPERATOR(name, op)                                                \

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -421,24 +421,19 @@ EM_JS(void,
       (JsRef idobj, char** format_ptr, Py_ssize_t* size_ptr),
       {
         if (!Module.hiwire.dtype_map) {
-          let entries = Object.entries({
-            'Int8Array' : [ 'b', 1 ],
-            'Uint8Array' : [ 'B', 1 ],
-            'Uint8ClampedArray' : [ 'B', 1 ],
-            'Int16Array' : [ "h", 2 ],
-            'Uint16Array' : [ "H", 2 ],
-            'Int32Array' : [ "i", 4 ],
-            'Uint32Array' : [ "I", 4 ],
-            'Float32Array' : [ "f", 4 ],
-            'Float64Array' : [ "d", 8 ],
-            'ArrayBuffer' : [ 'B', 1 ], // Default to Uint8;
-          });
-          Module.hiwire.dtype_map = new Map();
-          for (let[key, [ format, size ]] of entries) {
-            let format_utf8 =
-              allocate(intArrayFromString(format), "i8", ALLOC_NORMAL);
-            Module.hiwire.dtype_map.set(key, [ format_utf8, size ]);
-          }
+          let alloc = stringToNewUTF8;
+          Module.hiwire.dtype_map = new Map([
+            [ 'Int8Array', [ alloc('b'), 1 ] ],
+            [ 'Uint8Array', [ alloc('B'), 1 ] ],
+            [ 'Uint8ClampedArray', [ alloc('B'), 1 ] ],
+            [ 'Int16Array', [ alloc('h'), 2 ] ],
+            [ 'Uint16Array', [ alloc('H'), 2 ] ],
+            [ 'Int32Array', [ alloc('i'), 4 ] ],
+            [ 'Uint32Array', [ alloc('I'), 4 ] ],
+            [ 'Float32Array', [ alloc('f'), 4 ] ],
+            [ 'Float64Array', [ alloc('d'), 8 ] ],
+            [ 'ArrayBuffer', [ alloc('B'), 1 ] ], // Default to Uint8;
+          ]);
         }
         let jsobj = Module.hiwire.get_value(idobj);
         let[format_utf8, size] =

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -424,11 +424,11 @@ EM_JS(void, hiwire_get_dtype, (int idobj, int format_ptr, int size_ptr), {
       'Float64Array' : [ "d", 8 ],
       'ArrayBuffer' : [ 'B', 1 ], // Default to Uint8;
     });
-    let map = new Map();
+    Module.hiwire.dtype_map = new Map();
     for (let[key, [ format, size ]] of entries) {
       let format_utf8 =
         allocate(intArrayFromString(format), "i8", ALLOC_NORMAL);
-      map.set(key, [ format, size ]);
+      Module.hiwire.dtype_map.set(key, [ format, size ]);
     }
   }
   let jsobj = Module.hiwire.get_value(idobj);

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -282,6 +282,7 @@ hiwire_push_object_pair(int idobj, int idkey, int idval);
  * Throws a new Error object with the given message.
  *
  * The message is conventionally a Javascript string, but that is not required.
+ * TODO: should be hiwire_set_error.
  */
 void
 hiwire_throw_error(int idmsg);
@@ -441,6 +442,14 @@ int
 hiwire_typeof(int idobj);
 
 /**
+ * Gets "value.constructor.name".
+ *
+ * Returns: New reference to Javascript string
+ */
+int
+hiwire_constructor_name(int idobj);
+
+/**
  * Returns non-zero if a < b.
  */
 int
@@ -534,24 +543,11 @@ hiwire_get_byteOffset(int idobj);
 int
 hiwire_copy_to_ptr(int idobj, int ptr);
 
-#define INT8_TYPE 1
-#define UINT8_TYPE 2
-#define UINT8CLAMPED_TYPE 3
-#define INT16_TYPE 4
-#define UINT16_TYPE 5
-#define INT32_TYPE 6
-#define UINT32_TYPE 7
-#define FLOAT32_TYPE 8
-#define FLOAT64_TYPE 9
-
 /**
  * Get a data type identifier for a given typedarray.
- *
- * It will be one of INT8_TYPE, UINT8_TYPE, UINT8CLAMPED_TYPE, INT16_TYPE,
- * UINT16_TYPE, INT32_TYPE, UINT32_TYPE, FLOAT32_TYPE, FLOAT64_TYPE.
  */
 int
-hiwire_get_dtype(int idobj);
+hiwire_get_dtype(int idobj, int format_ptr, int size_ptr);
 
 /**
  * Get a subarray from a TypedArray

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -546,7 +546,7 @@ hiwire_copy_to_ptr(int idobj, int ptr);
 /**
  * Get a data type identifier for a given typedarray.
  */
-int
+void
 hiwire_get_dtype(int idobj, int format_ptr, int size_ptr);
 
 /**

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -1,5 +1,6 @@
 #ifndef HIWIRE_H
 #define HIWIRE_H
+#include "Python.h"
 #include "stdalign.h"
 #include "types.h"
 
@@ -459,8 +460,8 @@ hiwire_typeof(JsRef idobj);
  *
  * Returns: New reference to Javascript string
  */
-int
-hiwire_constructor_name(int idobj);
+char*
+hiwire_constructor_name(JsRef idobj);
 
 /**
  * Returns non-zero if a < b.
@@ -554,13 +555,13 @@ hiwire_get_byteOffset(JsRef idobj);
  * at ptr.
  */
 void
-hiwire_copy_to_ptr(JsRef idobj, int ptr);
+hiwire_copy_to_ptr(JsRef idobj, void* ptr);
 
 /**
  * Get a data type identifier for a given typedarray.
  */
 void
-hiwire_get_dtype(JsRef idobj, int format_ptr, int size_ptr);
+hiwire_get_dtype(JsRef idobj, char** format_ptr, Py_ssize_t* size_ptr);
 
 /**
  * Get a subarray from a TypedArray

--- a/src/type_conversion/jsproxy.c
+++ b/src/type_conversion/jsproxy.c
@@ -317,12 +317,15 @@ JsProxy_GetBuffer(PyObject* o, Py_buffer* view, int flags)
   Py_ssize_t itemsize;
   hiwire_get_dtype(self->js, &format, &itemsize);
   if (format == NULL) {
+    char* typename = hiwire_constructor_name(self->js);
     PyErr_Format(
       PyExc_RuntimeError,
       "Unknown typed array type '%s'. This is a problem with Pyodide, please "
       "open an issue about it here: "
       "https://github.com/iodide-project/pyodide/issues/new",
-      (char*)hiwire_constructor_name(self->js));
+      typename);
+    free(typename);
+
     goto fail;
   }
 

--- a/src/type_conversion/jsproxy.c
+++ b/src/type_conversion/jsproxy.c
@@ -322,8 +322,7 @@ JsProxy_GetBuffer(PyObject* o, Py_buffer* view, int flags)
       "Unknown typed array type '%s'. This is problem with Pyodide, please "
       "open an issue about it here: "
       "https://github.com/iodide-project/pyodide/issues/new",
-      (char *)hiwire_constructor_name(self->js)
-    );
+      (char*)hiwire_constructor_name(self->js));
     return NULL;
   }
 

--- a/src/type_conversion/jsproxy.c
+++ b/src/type_conversion/jsproxy.c
@@ -338,7 +338,7 @@ JsProxy_GetBuffer(PyObject* o, Py_buffer* view, int flags)
 
   return 0;
 fail:
-  if(!PyErr_Occurred()){
+  if (!PyErr_Occurred()) {
     PyErr_SetString(PyExc_BufferError, "Can not use as buffer");
   }
   view->obj = NULL;

--- a/src/type_conversion/jsproxy.c
+++ b/src/type_conversion/jsproxy.c
@@ -313,51 +313,18 @@ JsProxy_GetBuffer(PyObject* o, Py_buffer* view, int flags)
     hiwire_copy_to_ptr(self->js, (int)ptr);
   }
 
-  int dtype = hiwire_get_dtype(self->js);
-
   char* format;
   Py_ssize_t itemsize;
-  switch (dtype) {
-    case INT8_TYPE:
-      format = "b";
-      itemsize = 1;
-      break;
-    case UINT8_TYPE:
-      format = "B";
-      itemsize = 1;
-      break;
-    case UINT8CLAMPED_TYPE:
-      format = "B";
-      itemsize = 1;
-      break;
-    case INT16_TYPE:
-      format = "h";
-      itemsize = 2;
-      break;
-    case UINT16_TYPE:
-      format = "H";
-      itemsize = 2;
-      break;
-    case INT32_TYPE:
-      format = "i";
-      itemsize = 4;
-      break;
-    case UINT32_TYPE:
-      format = "I";
-      itemsize = 4;
-      break;
-    case FLOAT32_TYPE:
-      format = "f";
-      itemsize = 4;
-      break;
-    case FLOAT64_TYPE:
-      format = "d";
-      itemsize = 8;
-      break;
-    default:
-      format = "B";
-      itemsize = 1;
-      break;
+  hiwire_get_dtype(self->js, (int)&format, (int)&itemsize);
+  if (format == NULL) {
+    PyErr_Format(
+      PyExc_RuntimeError,
+      "Unknown typed array type '%s'. This is problem with Pyodide, please "
+      "open an issue about it here: "
+      "https://github.com/iodide-project/pyodide/issues/new",
+      (char *)hiwire_constructor_name(self->js)
+    );
+    return NULL;
   }
 
   Py_INCREF(self);


### PR DESCRIPTION
Implementation of `hiwire_get_dtype` is split across two files. The reason seems to be that `get_dtype` returns two values: format and size. I changed it to take pointers to write the results into. This makes the code shorter and easier to understand (someone reading the files would have to search the source to find out that those constants are only used in two spots).