### PR TITLE
BLD Remove TEXTDECODE=0 build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ LDFLAGS=\
 	-lstdc++ \
 	--memory-init-file 0 \
 	-s "BINARYEN_TRAP_MODE='clamp'" \
-	-s TEXTDECODER=0 \
 	-s LZ4=1
 
 SIX_ROOT=packages/six/six-1.11.0/build/lib


### PR DESCRIPTION
This was introduced in #96 to bypass a Chrome bug introduced in Chrome 69 and fixed in Chrome 70. Chrome 69 supposedly has a market share of 0.09%, so I think it is safe to drop support.
