### PR TITLE
Remove BINARYEN_METHOD flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ LDFLAGS=\
 	-O2 \
 	-s MODULARIZE=1 \
 	$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/libpython$(PYMINOR).a \
-	-s "BINARYEN_METHOD='native-wasm'" \
 	-s TOTAL_MEMORY=10485760 \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s MAIN_MODULE=1 \

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -8,7 +8,6 @@ DEFAULTCFLAGS = ""
 DEFAULTLDFLAGS = " ".join(
     [
         "-O2",
-        "-s", "BINARYEN_METHOD='native-wasm'",
         "-Werror",
         "-s", "EMULATED_FUNCTION_POINTERS=1",
         "-s", "EMULATE_FUNCTION_POINTER_CASTS=1",


### PR DESCRIPTION
This has been removed since 1.38.23, and is always set to native-wasm
when we set WASM=1.

See https://github.com/emscripten-core/emscripten/pull/7836
