### PR TITLE
DOCK Don't install tempita

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
   && chmod a+x /tmp/uglifyjs && mv -t /usr/local/bin /tmp/uglifyjs
 
 RUN pip3 --no-cache-dir install pytest pytest-xdist pytest-instafail pytest-rerunfailures \
-      pytest-httpserver pytest-cov selenium PyYAML flake8 black distlib mypy "Cython<3.0" Tempita
+      pytest-httpserver pytest-cov selenium PyYAML flake8 black distlib mypy "Cython<3.0"
 
 # Get firefox 70.0.1 and geckodriver
 RUN wget -qO- https://ftp.mozilla.org/pub/firefox/releases/70.0.1/linux-x86_64/en-US/firefox-70.0.1.tar.bz2 | tar jx \

--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,7 @@ $(PARSO_LIBS): $(CPYTHONLIB)
 
 build/packages.json: FORCE
 	date +"[%F %T] Building packages..."
+	python3 -m pip uninstall Tempita
 	make -C packages
 	date +"[%F %T] done building packages..."
 

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ $(PARSO_LIBS): $(CPYTHONLIB)
 
 build/packages.json: FORCE
 	date +"[%F %T] Building packages..."
-	python3 -m pip uninstall Tempita
+	python3 -m pip uninstall Tempita -y
 	make -C packages
 	date +"[%F %T] done building packages..."
 

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,6 @@ $(PARSO_LIBS): $(CPYTHONLIB)
 
 build/packages.json: FORCE
 	date +"[%F %T] Building packages..."
-	python3 -m pip uninstall Tempita -y
 	make -C packages
 	date +"[%F %T] done building packages..."
 


### PR DESCRIPTION
Cython ships with its own copy of Tempita, so there is no need to install it manually.

The first two commits in the PR uninstalls it during the build process, and the last undoes that change and modifies the Dockerfile instead.