### PR TITLE
Remove SWAPPABLE_ASM_MODULE setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ LDFLAGS=\
 	-s EXPORT_ALL=1 \
 	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv"]' \
 	-s WASM=1 \
-	-s SWAPPABLE_ASM_MODULE=1 \
 	-s USE_FREETYPE=1 \
 	-s USE_LIBPNG=1 \
 	-std=c++14 \


### PR DESCRIPTION
This is removed in emscripten 1.39.16, and for the wasm backend, was broken since 1.39.6. Eliminating the setting will make it easier to upgrade in the future.

This setting was added in b2599e31 without much explanation; removing it seems to work.