### PR TITLE
Use the C type system in hiwire

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   environment:
     - EMSDK_NUM_CORES: 4
       EMCC_CORES: 4
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.16.1/full/
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/dev/full/
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SHELL := /bin/bash
 CC=emcc
 CXX=em++
 OPTFLAGS=-O2
-CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -Wno-warn-absolute-paths
+CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -Wno-warn-absolute-paths -Werror=int-conversion -Werror=incompatible-pointer-types
 CXXFLAGS=$(CFLAGS) -std=c++14
 
 
@@ -30,7 +30,7 @@ LDFLAGS=\
 	-s EMULATE_FUNCTION_POINTER_CASTS=1 \
 	-s LINKABLE=1 \
 	-s EXPORT_ALL=1 \
-	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv"]' \
+	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv", "_main"]' \
 	-s WASM=1 \
 	-s SWAPPABLE_ASM_MODULE=1 \
 	-s USE_FREETYPE=1 \
@@ -161,7 +161,7 @@ clean-all: clean
 	make -C cpython clean
 	rm -fr cpython/build
 
-%.bc: %.c $(CPYTHONLIB)
+%.bc: %.c $(CPYTHONLIB) $(wildcard src/**/*.h)
 	$(CC) -o $@ -c $< $(CFLAGS) -Isrc/type_conversion/
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -33,11 +33,11 @@
 int
 main(int argc, char** argv)
 {
-  if (alignof(HwRef) != alignof(int)) {
-    FATAL_ERROR("HwRef doesn't have the same alignment as int.");
+  if (alignof(JsRef) != alignof(int)) {
+    FATAL_ERROR("JsRef doesn't have the same alignment as int.");
   }
-  if (sizeof(HwRef) != sizeof(int)) {
-    FATAL_ERROR("HwRef doesn't have the same size as int.");
+  if (sizeof(JsRef) != sizeof(int)) {
+    FATAL_ERROR("JsRef doesn't have the same size as int.");
   }
   TRY_INIT(hiwire);
 

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,8 @@
 #include "python2js.h"
 #include "runpython.h"
 
+#include <stdalign.h>
+
 #define FATAL_ERROR(args...)                                                   \
   do {                                                                         \
     printf("FATAL ERROR: ");                                                   \
@@ -31,6 +33,11 @@
 int
 main(int argc, char** argv)
 {
+  printf("alignof(HwObject): %zu, alignof(int): %zu\n",
+         alignof(HwObject),
+         alignof(int));
+  printf(
+    "sizeof(HwObject): %zu, sizeof(int): %zu\n", sizeof(HwObject), sizeof(int));
   hiwire_setup();
 
   setenv("PYTHONHOME", "/", 0);

--- a/src/main.c
+++ b/src/main.c
@@ -33,11 +33,11 @@
 int
 main(int argc, char** argv)
 {
-  if (alignof(HwObject) != alignof(int)) {
-    FATAL_ERROR("HwObject doesn't have the same alignment as int.");
+  if (alignof(HwRef) != alignof(int)) {
+    FATAL_ERROR("HwRef doesn't have the same alignment as int.");
   }
-  if (sizeof(HwObject) != sizeof(int)) {
-    FATAL_ERROR("HwObject doesn't have the same size as int.");
+  if (sizeof(HwRef) != sizeof(int)) {
+    FATAL_ERROR("HwRef doesn't have the same size as int.");
   }
   TRY_INIT(hiwire);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,7 @@
 #include <Python.h>
+#include <assert.h>
 #include <emscripten.h>
+#include <stdalign.h>
 
 #include "hiwire.h"
 #include "js2python.h"
@@ -9,8 +11,6 @@
 #include "pyproxy.h"
 #include "python2js.h"
 #include "runpython.h"
-
-#include <stdalign.h>
 
 #define FATAL_ERROR(args...)                                                   \
   do {                                                                         \
@@ -33,13 +33,12 @@
 int
 main(int argc, char** argv)
 {
-  printf("alignof(HwObject): %zu, alignof(int): %zu\n",
-         alignof(HwObject),
-         alignof(int));
-  printf(
-    "sizeof(HwObject): %zu, sizeof(int): %zu\n", sizeof(HwObject), sizeof(int));
-  hiwire_setup();
-
+  if (alignof(HwObject) != alignof(int)) {
+    FATAL_ERROR("HwObject doesn't have the same alignment as int.");
+  }
+  if (sizeof(HwObject) != sizeof(int)) {
+    FATAL_ERROR("HwObject doesn't have the same size as int.");
+  }
   setenv("PYTHONHOME", "/", 0);
 
   Py_InitializeEx(0);

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,8 @@ main(int argc, char** argv)
   if (sizeof(HwObject) != sizeof(int)) {
     FATAL_ERROR("HwObject doesn't have the same size as int.");
   }
+  TRY_INIT(hiwire);
+
   setenv("PYTHONHOME", "/", 0);
 
   Py_InitializeEx(0);

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -2,37 +2,37 @@
 
 #include "hiwire.h"
 
-HwRef
+JsRef
 hiwire_error()
 {
-  return HW_ERROR;
+  return Js_ERROR;
 }
 
-HwRef
+JsRef
 hiwire_undefined()
 {
-  return HW_UNDEFINED;
+  return Js_UNDEFINED;
 }
 
-HwRef
+JsRef
 hiwire_null()
 {
-  return HW_NULL;
+  return Js_NULL;
 }
 
-HwRef
+JsRef
 hiwire_true()
 {
-  return HW_TRUE;
+  return Js_TRUE;
 }
 
-HwRef
+JsRef
 hiwire_false()
 {
-  return HW_FALSE;
+  return Js_FALSE;
 }
 
-HwRef
+JsRef
 hiwire_bool(bool boolean)
 {
   return boolean ? hiwire_true() : hiwire_false();
@@ -88,22 +88,22 @@ EM_JS(int, hiwire_init, (), {
   return 0;
 });
 
-EM_JS(HwRef, hiwire_incref, (HwRef idval), {
+EM_JS(JsRef, hiwire_incref, (JsRef idval), {
   if (idval < 0) {
     return;
   }
   return Module.hiwire.new_value(Module.hiwire.get_value(idval));
 });
 
-EM_JS(void, hiwire_decref, (HwRef idval), { Module.hiwire.decref(idval); });
+EM_JS(void, hiwire_decref, (JsRef idval), { Module.hiwire.decref(idval); });
 
-EM_JS(HwRef, hiwire_int, (int val), { return Module.hiwire.new_value(val); });
+EM_JS(JsRef, hiwire_int, (int val), { return Module.hiwire.new_value(val); });
 
-EM_JS(HwRef, hiwire_double, (double val), {
+EM_JS(JsRef, hiwire_double, (double val), {
   return Module.hiwire.new_value(val);
 });
 
-EM_JS(HwRef, hiwire_string_ucs4, (const char* ptr, int len), {
+EM_JS(JsRef, hiwire_string_ucs4, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr / 4;
   for (var i = 0; i < len; ++i) {
@@ -112,7 +112,7 @@ EM_JS(HwRef, hiwire_string_ucs4, (const char* ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(HwRef, hiwire_string_ucs2, (const char* ptr, int len), {
+EM_JS(JsRef, hiwire_string_ucs2, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr / 2;
   for (var i = 0; i < len; ++i) {
@@ -121,7 +121,7 @@ EM_JS(HwRef, hiwire_string_ucs2, (const char* ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(HwRef, hiwire_string_ucs1, (const char* ptr, int len), {
+EM_JS(JsRef, hiwire_string_ucs1, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr;
   for (var i = 0; i < len; ++i) {
@@ -130,81 +130,81 @@ EM_JS(HwRef, hiwire_string_ucs1, (const char* ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(HwRef, hiwire_string_utf8, (const char* ptr), {
+EM_JS(JsRef, hiwire_string_utf8, (const char* ptr), {
   return Module.hiwire.new_value(UTF8ToString(ptr));
 });
 
-EM_JS(HwRef, hiwire_string_ascii, (const char* ptr), {
+EM_JS(JsRef, hiwire_string_ascii, (const char* ptr), {
   return Module.hiwire.new_value(AsciiToString(ptr));
 });
 
-EM_JS(HwRef, hiwire_bytes, (char* ptr, int len), {
+EM_JS(JsRef, hiwire_bytes, (char* ptr, int len), {
   var bytes = new Uint8ClampedArray(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(bytes);
 });
 
-EM_JS(HwRef, hiwire_int8array, (i8 * ptr, int len), {
+EM_JS(JsRef, hiwire_int8array, (i8 * ptr, int len), {
   var array = new Int8Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_uint8array, (u8 * ptr, int len), {
+EM_JS(JsRef, hiwire_uint8array, (u8 * ptr, int len), {
   var array = new Uint8Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_int16array, (i16 * ptr, int len), {
+EM_JS(JsRef, hiwire_int16array, (i16 * ptr, int len), {
   var array = new Int16Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_uint16array, (u16 * ptr, int len), {
+EM_JS(JsRef, hiwire_uint16array, (u16 * ptr, int len), {
   var array = new Uint16Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_int32array, (i32 * ptr, int len), {
+EM_JS(JsRef, hiwire_int32array, (i32 * ptr, int len), {
   var array = new Int32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_uint32array, (u32 * ptr, int len), {
+EM_JS(JsRef, hiwire_uint32array, (u32 * ptr, int len), {
   var array = new Uint32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_float32array, (f32 * ptr, int len), {
+EM_JS(JsRef, hiwire_float32array, (f32 * ptr, int len), {
   var array = new Float32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwRef, hiwire_float64array, (f64 * ptr, int len), {
+EM_JS(JsRef, hiwire_float64array, (f64 * ptr, int len), {
   var array = new Float64Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(void, hiwire_throw_error, (HwRef idmsg), {
+EM_JS(void, hiwire_throw_error, (JsRef idmsg), {
   var jsmsg = Module.hiwire.get_value(idmsg);
   Module.hiwire.decref(idmsg);
   throw new Error(jsmsg);
 });
 
-EM_JS(HwRef, hiwire_array, (), { return Module.hiwire.new_value([]); });
+EM_JS(JsRef, hiwire_array, (), { return Module.hiwire.new_value([]); });
 
-EM_JS(void, hiwire_push_array, (HwRef idarr, HwRef idval), {
+EM_JS(void, hiwire_push_array, (JsRef idarr, JsRef idval), {
   Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
-EM_JS(HwRef, hiwire_object, (), { return Module.hiwire.new_value({}); });
+EM_JS(JsRef, hiwire_object, (), { return Module.hiwire.new_value({}); });
 
-EM_JS(void, hiwire_push_object_pair, (HwRef idobj, HwRef idkey, HwRef idval), {
+EM_JS(void, hiwire_push_object_pair, (JsRef idobj, JsRef idkey, JsRef idval), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jskey = Module.hiwire.get_value(idkey);
   var jsval = Module.hiwire.get_value(idval);
   jsobj[jskey] = jsval;
 });
 
-EM_JS(HwRef, hiwire_get_global, (const char* ptrname), {
+EM_JS(JsRef, hiwire_get_global, (const char* ptrname), {
   var jsname = UTF8ToString(ptrname);
   if (jsname in self) {
     return Module.hiwire.new_value(self[jsname]);
@@ -213,7 +213,7 @@ EM_JS(HwRef, hiwire_get_global, (const char* ptrname), {
   }
 });
 
-EM_JS(HwRef, hiwire_get_member_string, (HwRef idobj, const char* ptrkey), {
+EM_JS(JsRef, hiwire_get_member_string, (JsRef idobj, const char* ptrkey), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(ptrkey);
   if (jskey in jsobj) {
@@ -225,7 +225,7 @@ EM_JS(HwRef, hiwire_get_member_string, (HwRef idobj, const char* ptrkey), {
 
 EM_JS(void,
       hiwire_set_member_string,
-      (HwRef idobj, const char* ptrkey, HwRef idval),
+      (JsRef idobj, const char* ptrkey, JsRef idval),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jskey = UTF8ToString(ptrkey);
@@ -233,22 +233,22 @@ EM_JS(void,
         jsobj[jskey] = jsval;
       });
 
-EM_JS(void, hiwire_delete_member_string, (HwRef idobj, const char* ptrkey), {
+EM_JS(void, hiwire_delete_member_string, (JsRef idobj, const char* ptrkey), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(ptrkey);
   delete jsobj[jskey];
 });
 
-EM_JS(HwRef, hiwire_get_member_int, (HwRef idobj, int idx), {
+EM_JS(JsRef, hiwire_get_member_int, (JsRef idobj, int idx), {
   var jsobj = Module.hiwire.get_value(idobj);
   return Module.hiwire.new_value(jsobj[idx]);
 });
 
-EM_JS(void, hiwire_set_member_int, (HwRef idobj, int idx, HwRef idval), {
+EM_JS(void, hiwire_set_member_int, (JsRef idobj, int idx, JsRef idval), {
   Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
 });
 
-EM_JS(HwRef, hiwire_get_member_obj, (HwRef idobj, HwRef ididx), {
+EM_JS(JsRef, hiwire_get_member_obj, (JsRef idobj, JsRef ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   if (jsidx in jsobj) {
@@ -258,20 +258,20 @@ EM_JS(HwRef, hiwire_get_member_obj, (HwRef idobj, HwRef ididx), {
   }
 });
 
-EM_JS(void, hiwire_set_member_obj, (HwRef idobj, HwRef ididx, HwRef idval), {
+EM_JS(void, hiwire_set_member_obj, (JsRef idobj, JsRef ididx, JsRef idval), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   var jsval = Module.hiwire.get_value(idval);
   jsobj[jsidx] = jsval;
 });
 
-EM_JS(void, hiwire_delete_member_obj, (HwRef idobj, HwRef ididx), {
+EM_JS(void, hiwire_delete_member_obj, (JsRef idobj, JsRef ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   delete jsobj[jsidx];
 });
 
-EM_JS(HwRef, hiwire_dir, (HwRef idobj), {
+EM_JS(JsRef, hiwire_dir, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   var result = [];
   do {
@@ -280,15 +280,15 @@ EM_JS(HwRef, hiwire_dir, (HwRef idobj), {
   return Module.hiwire.new_value(result);
 });
 
-EM_JS(HwRef, hiwire_call, (HwRef idfunc, HwRef idargs), {
+EM_JS(JsRef, hiwire_call, (JsRef idfunc, JsRef idargs), {
   var jsfunc = Module.hiwire.get_value(idfunc);
   var jsargs = Module.hiwire.get_value(idargs);
   return Module.hiwire.new_value(jsfunc.apply(jsfunc, jsargs));
 });
 
-EM_JS(HwRef,
+EM_JS(JsRef,
       hiwire_call_member,
-      (HwRef idobj, const char* ptrname, HwRef idargs),
+      (JsRef idobj, const char* ptrname, JsRef idargs),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jsname = UTF8ToString(ptrname);
@@ -296,7 +296,7 @@ EM_JS(HwRef,
         return Module.hiwire.new_value(jsobj[jsname].apply(jsobj, jsargs));
       });
 
-EM_JS(HwRef, hiwire_new, (HwRef idobj, HwRef idargs), {
+EM_JS(JsRef, hiwire_new, (JsRef idobj, JsRef idargs), {
   function newCall(Cls)
   {
     return new (Function.prototype.bind.apply(Cls, arguments));
@@ -307,33 +307,33 @@ EM_JS(HwRef, hiwire_new, (HwRef idobj, HwRef idargs), {
   return Module.hiwire.new_value(newCall.apply(newCall, jsargs));
 });
 
-EM_JS(int, hiwire_get_length, (HwRef idobj), {
+EM_JS(int, hiwire_get_length, (JsRef idobj), {
   return Module.hiwire.get_value(idobj).length;
 });
 
-EM_JS(bool, hiwire_get_bool, (HwRef idobj), {
+EM_JS(bool, hiwire_get_bool, (JsRef idobj), {
   var val = Module.hiwire.get_value(idobj);
   // clang-format off
   return (val && (val.length === undefined || val.length)) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_function, (HwRef idobj), {
+EM_JS(bool, hiwire_is_function, (JsRef idobj), {
   // clang-format off
   return typeof Module.hiwire.get_value(idobj) === 'function';
   // clang-format on
 });
 
-EM_JS(HwRef, hiwire_to_string, (HwRef idobj), {
+EM_JS(JsRef, hiwire_to_string, (JsRef idobj), {
   return Module.hiwire.new_value(Module.hiwire.get_value(idobj).toString());
 });
 
-EM_JS(HwRef, hiwire_typeof, (HwRef idobj), {
+EM_JS(JsRef, hiwire_typeof, (JsRef idobj), {
   return Module.hiwire.new_value(typeof Module.hiwire.get_value(idobj));
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
-  EM_JS(bool, hiwire_##name, (HwRef ida, HwRef idb), {                         \
+  EM_JS(bool, hiwire_##name, (JsRef ida, JsRef idb), {                         \
     return (Module.hiwire.get_value(ida) op Module.hiwire.get_value(idb)) ? 1  \
                                                                           : 0; \
   })
@@ -345,7 +345,7 @@ MAKE_OPERATOR(not_equal, !=);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS(HwRef, hiwire_next, (HwRef idobj), {
+EM_JS(JsRef, hiwire_next, (JsRef idobj), {
   // clang-format off
   if (idobj === Module.hiwire.UNDEFINED) {
     return Module.hiwire.ERROR;
@@ -356,7 +356,7 @@ EM_JS(HwRef, hiwire_next, (HwRef idobj), {
   // clang-format on
 });
 
-EM_JS(HwRef, hiwire_get_iterator, (HwRef idobj), {
+EM_JS(JsRef, hiwire_get_iterator, (JsRef idobj), {
   // clang-format off
   if (idobj === Module.hiwire.UNDEFINED) {
     return Module.hiwire.ERROR;
@@ -374,37 +374,37 @@ EM_JS(HwRef, hiwire_get_iterator, (HwRef idobj), {
   // clang-format on
 })
 
-EM_JS(bool, hiwire_nonzero, (HwRef idobj), {
+EM_JS(bool, hiwire_nonzero, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // TODO: should this be !== 0?
   return (jsobj != 0) ? 1 : 0;
 });
 
-EM_JS(bool, hiwire_is_typedarray, (HwRef idobj), {
+EM_JS(bool, hiwire_is_typedarray, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj['byteLength'] !== undefined) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_on_wasm_heap, (HwRef idobj), {
+EM_JS(bool, hiwire_is_on_wasm_heap, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj.buffer === Module.HEAPU8.buffer) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(int, hiwire_get_byteOffset, (HwRef idobj), {
+EM_JS(int, hiwire_get_byteOffset, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteOffset'];
 });
 
-EM_JS(int, hiwire_get_byteLength, (HwRef idobj), {
+EM_JS(int, hiwire_get_byteLength, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteLength'];
 });
 
-EM_JS(void, hiwire_copy_to_ptr, (HwRef idobj, int ptr), {
+EM_JS(void, hiwire_copy_to_ptr, (JsRef idobj, int ptr), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   var buffer = (jsobj['buffer'] !== undefined) ? jsobj.buffer : jsobj;
@@ -412,7 +412,7 @@ EM_JS(void, hiwire_copy_to_ptr, (HwRef idobj, int ptr), {
   Module.HEAPU8.set(new Uint8Array(buffer), ptr);
 });
 
-EM_JS(int, hiwire_get_dtype, (HwRef idobj), {
+EM_JS(int, hiwire_get_dtype, (JsRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   switch (jsobj.constructor.name) {
     case 'Int8Array':
@@ -452,7 +452,7 @@ EM_JS(int, hiwire_get_dtype, (HwRef idobj), {
   return dtype;
 });
 
-EM_JS(HwRef, hiwire_subarray, (HwRef idarr, int start, int end), {
+EM_JS(JsRef, hiwire_subarray, (JsRef idarr, int start, int end), {
   var jsarr = Module.hiwire.get_value(idarr);
   var jssub = jsarr.subarray(start, end);
   return Module.hiwire.new_value(jssub);

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -2,38 +2,44 @@
 
 #include "hiwire.h"
 
-int
+bool
+hw_is_error(HwObject key)
+{
+  return FROM_NT(key) == FROM_NT(HW_ERROR);
+}
+
+HwObject
 hiwire_error()
 {
   return HW_ERROR;
 }
 
-int
+HwObject
 hiwire_undefined()
 {
   return HW_UNDEFINED;
 }
 
-int
+HwObject
 hiwire_null()
 {
   return HW_NULL;
 }
 
-int
+HwObject
 hiwire_true()
 {
   return HW_TRUE;
 }
 
-int
+HwObject
 hiwire_false()
 {
   return HW_FALSE;
 }
 
-int
-hiwire_bool(int boolean)
+HwObject
+hiwire_bool(bool boolean)
 {
   return boolean ? hiwire_true() : hiwire_false();
 }
@@ -87,22 +93,24 @@ EM_JS(void, hiwire_setup, (), {
   };
 });
 
-EM_JS(int, hiwire_incref, (int idval), {
+EM_JS(HwObject, hiwire_incref, (HwObject idval), {
   if (idval < 0) {
     return;
   }
   return Module.hiwire.new_value(Module.hiwire.get_value(idval));
 });
 
-EM_JS(void, hiwire_decref, (int idval), { Module.hiwire.decref(idval); });
+EM_JS(void, hiwire_decref, (HwObject idval), { Module.hiwire.decref(idval); });
 
-EM_JS(int, hiwire_int, (int val), { return Module.hiwire.new_value(val); });
-
-EM_JS(int, hiwire_double, (double val), {
+EM_JS(HwObject, hiwire_int, (int val), {
   return Module.hiwire.new_value(val);
 });
 
-EM_JS(int, hiwire_string_ucs4, (int ptr, int len), {
+EM_JS(HwObject, hiwire_double, (double val), {
+  return Module.hiwire.new_value(val);
+});
+
+EM_JS(HwObject, hiwire_string_ucs4, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr / 4;
   for (var i = 0; i < len; ++i) {
@@ -111,7 +119,7 @@ EM_JS(int, hiwire_string_ucs4, (int ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(int, hiwire_string_ucs2, (int ptr, int len), {
+EM_JS(HwObject, hiwire_string_ucs2, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr / 2;
   for (var i = 0; i < len; ++i) {
@@ -120,7 +128,7 @@ EM_JS(int, hiwire_string_ucs2, (int ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(int, hiwire_string_ucs1, (int ptr, int len), {
+EM_JS(HwObject, hiwire_string_ucs1, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr;
   for (var i = 0; i < len; ++i) {
@@ -129,82 +137,85 @@ EM_JS(int, hiwire_string_ucs1, (int ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(int, hiwire_string_utf8, (int ptr), {
+EM_JS(HwObject, hiwire_string_utf8, (const char* ptr), {
   return Module.hiwire.new_value(UTF8ToString(ptr));
 });
 
-EM_JS(int, hiwire_string_ascii, (int ptr), {
+EM_JS(HwObject, hiwire_string_ascii, (const char* ptr), {
   return Module.hiwire.new_value(AsciiToString(ptr));
 });
 
-EM_JS(int, hiwire_bytes, (int ptr, int len), {
+EM_JS(HwObject, hiwire_bytes, (char* ptr, int len), {
   var bytes = new Uint8ClampedArray(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(bytes);
 });
 
-EM_JS(int, hiwire_int8array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_int8array, (i8 * ptr, int len), {
   var array = new Int8Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_uint8array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_uint8array, (u8 * ptr, int len), {
   var array = new Uint8Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_int16array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_int16array, (i16 * ptr, int len), {
   var array = new Int16Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_uint16array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_uint16array, (u16 * ptr, int len), {
   var array = new Uint16Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_int32array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_int32array, (i32 * ptr, int len), {
   var array = new Int32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_uint32array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_uint32array, (u32 * ptr, int len), {
   var array = new Uint32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_float32array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_float32array, (f32 * ptr, int len), {
   var array = new Float32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(int, hiwire_float64array, (int ptr, int len), {
+EM_JS(HwObject, hiwire_float64array, (f64 * ptr, int len), {
   var array = new Float64Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(void, hiwire_throw_error, (int idmsg), {
+EM_JS(void, hiwire_throw_error, (HwObject idmsg), {
   var jsmsg = Module.hiwire.get_value(idmsg);
   Module.hiwire.decref(idmsg);
   throw new Error(jsmsg);
 });
 
-EM_JS(int, hiwire_array, (), { return Module.hiwire.new_value([]); });
+EM_JS(HwObject, hiwire_array, (), { return Module.hiwire.new_value([]); });
 
-EM_JS(void, hiwire_push_array, (int idarr, int idval), {
+EM_JS(void, hiwire_push_array, (HwObject idarr, HwObject idval), {
   Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
-EM_JS(int, hiwire_object, (), { return Module.hiwire.new_value({}); });
+EM_JS(HwObject, hiwire_object, (), { return Module.hiwire.new_value({}); });
 
-EM_JS(void, hiwire_push_object_pair, (int idobj, int idkey, int idval), {
-  var jsobj = Module.hiwire.get_value(idobj);
-  var jskey = Module.hiwire.get_value(idkey);
-  var jsval = Module.hiwire.get_value(idval);
-  jsobj[jskey] = jsval;
-});
+EM_JS(void,
+      hiwire_push_object_pair,
+      (HwObject idobj, HwObject idkey, HwObject idval),
+      {
+        var jsobj = Module.hiwire.get_value(idobj);
+        var jskey = Module.hiwire.get_value(idkey);
+        var jsval = Module.hiwire.get_value(idval);
+        jsobj[jskey] = jsval;
+      });
 
-EM_JS(int, hiwire_get_global, (int idname), {
-  var jsname = UTF8ToString(idname);
+EM_JS(HwObject, hiwire_get_global, (const char* ptrname), {
+  var jsname = UTF8ToString(ptrname);
   if (jsname in self) {
     return Module.hiwire.new_value(self[jsname]);
   } else {
@@ -212,39 +223,45 @@ EM_JS(int, hiwire_get_global, (int idname), {
   }
 });
 
-EM_JS(int, hiwire_get_member_string, (int idobj, int idkey), {
-  var jsobj = Module.hiwire.get_value(idobj);
-  var jskey = UTF8ToString(idkey);
-  if (jskey in jsobj) {
-    return Module.hiwire.new_value(jsobj[jskey]);
-  } else {
-    return Module.hiwire.ERROR;
-  }
-});
+EM_JS(HwObject,
+      hiwire_get_member_string,
+      (HwObject idobj, const char* ptrkey),
+      {
+        var jsobj = Module.hiwire.get_value(idobj);
+        var jskey = UTF8ToString(ptrkey);
+        if (jskey in jsobj) {
+          return Module.hiwire.new_value(jsobj[jskey]);
+        } else {
+          return Module.hiwire.ERROR;
+        }
+      });
 
-EM_JS(void, hiwire_set_member_string, (int idobj, int ptrkey, int idval), {
-  var jsobj = Module.hiwire.get_value(idobj);
-  var jskey = UTF8ToString(ptrkey);
-  var jsval = Module.hiwire.get_value(idval);
-  jsobj[jskey] = jsval;
-});
+EM_JS(void,
+      hiwire_set_member_string,
+      (HwObject idobj, const char* ptrkey, HwObject idval),
+      {
+        var jsobj = Module.hiwire.get_value(idobj);
+        var jskey = UTF8ToString(ptrkey);
+        var jsval = Module.hiwire.get_value(idval);
+        jsobj[jskey] = jsval;
+      });
 
-EM_JS(void, hiwire_delete_member_string, (int idobj, int ptrkey), {
+EM_JS(void, hiwire_delete_member_string, (HwObject idobj, const char* ptrkey), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(ptrkey);
   delete jsobj[jskey];
 });
 
-EM_JS(int, hiwire_get_member_int, (int idobj, int idx), {
+EM_JS(HwObject, hiwire_get_member_int, (HwObject idobj, int idx), {
   var jsobj = Module.hiwire.get_value(idobj);
   return Module.hiwire.new_value(jsobj[idx]);
 });
 
-EM_JS(void, hiwire_set_member_int, (int idobj, int idx, int idval), {
+EM_JS(void, hiwire_set_member_int, (HwObject idobj, int idx, HwObject idval), {
   Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
 });
 
-EM_JS(int, hiwire_get_member_obj, (int idobj, int ididx), {
+EM_JS(HwObject, hiwire_get_member_obj, (HwObject idobj, HwObject ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   if (jsidx in jsobj) {
@@ -254,20 +271,23 @@ EM_JS(int, hiwire_get_member_obj, (int idobj, int ididx), {
   }
 });
 
-EM_JS(void, hiwire_set_member_obj, (int idobj, int ididx, int idval), {
-  var jsobj = Module.hiwire.get_value(idobj);
-  var jsidx = Module.hiwire.get_value(ididx);
-  var jsval = Module.hiwire.get_value(idval);
-  jsobj[jsidx] = jsval;
-});
+EM_JS(void,
+      hiwire_set_member_obj,
+      (HwObject idobj, HwObject ididx, HwObject idval),
+      {
+        var jsobj = Module.hiwire.get_value(idobj);
+        var jsidx = Module.hiwire.get_value(ididx);
+        var jsval = Module.hiwire.get_value(idval);
+        jsobj[jsidx] = jsval;
+      });
 
-EM_JS(void, hiwire_delete_member_obj, (int idobj, int ididx), {
+EM_JS(void, hiwire_delete_member_obj, (HwObject idobj, HwObject ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   delete jsobj[jsidx];
 });
 
-EM_JS(int, hiwire_dir, (int idobj), {
+EM_JS(HwObject, hiwire_dir, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   var result = [];
   do {
@@ -276,20 +296,23 @@ EM_JS(int, hiwire_dir, (int idobj), {
   return Module.hiwire.new_value(result);
 });
 
-EM_JS(int, hiwire_call, (int idfunc, int idargs), {
+EM_JS(HwObject, hiwire_call, (HwObject idfunc, HwObject idargs), {
   var jsfunc = Module.hiwire.get_value(idfunc);
   var jsargs = Module.hiwire.get_value(idargs);
   return Module.hiwire.new_value(jsfunc.apply(jsfunc, jsargs));
 });
 
-EM_JS(int, hiwire_call_member, (int idobj, int ptrname, int idargs), {
-  var jsobj = Module.hiwire.get_value(idobj);
-  var jsname = UTF8ToString(ptrname);
-  var jsargs = Module.hiwire.get_value(idargs);
-  return Module.hiwire.new_value(jsobj[jsname].apply(jsobj, jsargs));
-});
+EM_JS(HwObject,
+      hiwire_call_member,
+      (HwObject idobj, const char* ptrname, HwObject idargs),
+      {
+        var jsobj = Module.hiwire.get_value(idobj);
+        var jsname = UTF8ToString(ptrname);
+        var jsargs = Module.hiwire.get_value(idargs);
+        return Module.hiwire.new_value(jsobj[jsname].apply(jsobj, jsargs));
+      });
 
-EM_JS(int, hiwire_new, (int idobj, int idargs), {
+EM_JS(HwObject, hiwire_new, (HwObject idobj, HwObject idargs), {
   function newCall(Cls)
   {
     return new (Function.prototype.bind.apply(Cls, arguments));
@@ -300,36 +323,36 @@ EM_JS(int, hiwire_new, (int idobj, int idargs), {
   return Module.hiwire.new_value(newCall.apply(newCall, jsargs));
 });
 
-EM_JS(int, hiwire_get_length, (int idobj), {
+EM_JS(int, hiwire_get_length, (HwObject idobj), {
   return Module.hiwire.get_value(idobj).length;
 });
 
-EM_JS(int, hiwire_get_bool, (int idobj), {
+EM_JS(bool, hiwire_get_bool, (HwObject idobj), {
   var val = Module.hiwire.get_value(idobj);
   // clang-format off
   return (val && (val.length === undefined || val.length)) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(int, hiwire_is_function, (int idobj), {
+EM_JS(bool, hiwire_is_function, (HwObject idobj), {
   // clang-format off
   return typeof Module.hiwire.get_value(idobj) === 'function';
   // clang-format on
 });
 
-EM_JS(int, hiwire_to_string, (int idobj), {
+EM_JS(HwObject, hiwire_to_string, (HwObject idobj), {
   return Module.hiwire.new_value(Module.hiwire.get_value(idobj).toString());
 });
 
-EM_JS(int, hiwire_typeof, (int idobj), {
+EM_JS(HwObject, hiwire_typeof, (HwObject idobj), {
   return Module.hiwire.new_value(typeof Module.hiwire.get_value(idobj));
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
-  EM_JS(int, hiwire_##name, (int ida, int idb), {                              \
+  EM_JS(bool, hiwire_##name, (HwObject ida, HwObject idb), {                   \
     return (Module.hiwire.get_value(ida) op Module.hiwire.get_value(idb)) ? 1  \
                                                                           : 0; \
-  });
+  })
 
 MAKE_OPERATOR(less_than, <);
 MAKE_OPERATOR(less_than_equal, <=);
@@ -338,7 +361,7 @@ MAKE_OPERATOR(not_equal, !=);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS(int, hiwire_next, (int idobj), {
+EM_JS(HwObject, hiwire_next, (HwObject idobj), {
   // clang-format off
   if (idobj === Module.hiwire.UNDEFINED) {
     return Module.hiwire.ERROR;
@@ -349,7 +372,7 @@ EM_JS(int, hiwire_next, (int idobj), {
   // clang-format on
 });
 
-EM_JS(int, hiwire_get_iterator, (int idobj), {
+EM_JS(HwObject, hiwire_get_iterator, (HwObject idobj), {
   // clang-format off
   if (idobj === Module.hiwire.UNDEFINED) {
     return Module.hiwire.ERROR;
@@ -367,37 +390,37 @@ EM_JS(int, hiwire_get_iterator, (int idobj), {
   // clang-format on
 })
 
-EM_JS(int, hiwire_nonzero, (int idobj), {
+EM_JS(bool, hiwire_nonzero, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // TODO: should this be !== 0?
   return (jsobj != 0) ? 1 : 0;
 });
 
-EM_JS(int, hiwire_is_typedarray, (int idobj), {
+EM_JS(bool, hiwire_is_typedarray, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj['byteLength'] !== undefined) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(int, hiwire_is_on_wasm_heap, (int idobj), {
+EM_JS(bool, hiwire_is_on_wasm_heap, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj.buffer === Module.HEAPU8.buffer) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(int, hiwire_get_byteOffset, (int idobj), {
+EM_JS(int, hiwire_get_byteOffset, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteOffset'];
 });
 
-EM_JS(int, hiwire_get_byteLength, (int idobj), {
+EM_JS(int, hiwire_get_byteLength, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteLength'];
 });
 
-EM_JS(int, hiwire_copy_to_ptr, (int idobj, int ptr), {
+EM_JS(void, hiwire_copy_to_ptr, (HwObject idobj, int ptr), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   var buffer = (jsobj['buffer'] !== undefined) ? jsobj.buffer : jsobj;
@@ -405,7 +428,7 @@ EM_JS(int, hiwire_copy_to_ptr, (int idobj, int ptr), {
   Module.HEAPU8.set(new Uint8Array(buffer), ptr);
 });
 
-EM_JS(int, hiwire_get_dtype, (int idobj), {
+EM_JS(int, hiwire_get_dtype, (HwObject idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   switch (jsobj.constructor.name) {
     case 'Int8Array':
@@ -445,7 +468,7 @@ EM_JS(int, hiwire_get_dtype, (int idobj), {
   return dtype;
 });
 
-EM_JS(int, hiwire_subarray, (int idarr, int start, int end), {
+EM_JS(HwObject, hiwire_subarray, (HwObject idarr, int start, int end), {
   var jsarr = Module.hiwire.get_value(idarr);
   var jssub = jsarr.subarray(start, end);
   return Module.hiwire.new_value(jssub);

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -38,7 +38,7 @@ hiwire_bool(bool boolean)
   return boolean ? hiwire_true() : hiwire_false();
 }
 
-EM_JS(void, hiwire_init, (), {
+EM_JS(int, hiwire_init, (), {
   let _hiwire = { objects : new Map(), counter : 1 };
   Module.hiwire = {};
   Module.hiwire.ERROR = _hiwire_error();
@@ -85,6 +85,7 @@ EM_JS(void, hiwire_init, (), {
     }
     _hiwire.objects.delete(idval);
   };
+  return 0;
 });
 
 EM_JS(HwRef, hiwire_incref, (HwRef idval), {

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -38,7 +38,7 @@ hiwire_bool(bool boolean)
   return boolean ? hiwire_true() : hiwire_false();
 }
 
-EM_JS(void, hiwire_setup, (), {
+EM_JS(void, hiwire_init, (), {
   let _hiwire = { objects : new Map(), counter : 1 };
   Module.hiwire = {};
   Module.hiwire.ERROR = _hiwire_error();

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -96,9 +96,7 @@ EM_JS(HwRef, hiwire_incref, (HwRef idval), {
 
 EM_JS(void, hiwire_decref, (HwRef idval), { Module.hiwire.decref(idval); });
 
-EM_JS(HwRef, hiwire_int, (int val), {
-  return Module.hiwire.new_value(val);
-});
+EM_JS(HwRef, hiwire_int, (int val), { return Module.hiwire.new_value(val); });
 
 EM_JS(HwRef, hiwire_double, (double val), {
   return Module.hiwire.new_value(val);
@@ -198,15 +196,12 @@ EM_JS(void, hiwire_push_array, (HwRef idarr, HwRef idval), {
 
 EM_JS(HwRef, hiwire_object, (), { return Module.hiwire.new_value({}); });
 
-EM_JS(void,
-      hiwire_push_object_pair,
-      (HwRef idobj, HwRef idkey, HwRef idval),
-      {
-        var jsobj = Module.hiwire.get_value(idobj);
-        var jskey = Module.hiwire.get_value(idkey);
-        var jsval = Module.hiwire.get_value(idval);
-        jsobj[jskey] = jsval;
-      });
+EM_JS(void, hiwire_push_object_pair, (HwRef idobj, HwRef idkey, HwRef idval), {
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jskey = Module.hiwire.get_value(idkey);
+  var jsval = Module.hiwire.get_value(idval);
+  jsobj[jskey] = jsval;
+});
 
 EM_JS(HwRef, hiwire_get_global, (const char* ptrname), {
   var jsname = UTF8ToString(ptrname);
@@ -217,18 +212,15 @@ EM_JS(HwRef, hiwire_get_global, (const char* ptrname), {
   }
 });
 
-EM_JS(HwRef,
-      hiwire_get_member_string,
-      (HwRef idobj, const char* ptrkey),
-      {
-        var jsobj = Module.hiwire.get_value(idobj);
-        var jskey = UTF8ToString(ptrkey);
-        if (jskey in jsobj) {
-          return Module.hiwire.new_value(jsobj[jskey]);
-        } else {
-          return Module.hiwire.ERROR;
-        }
-      });
+EM_JS(HwRef, hiwire_get_member_string, (HwRef idobj, const char* ptrkey), {
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jskey = UTF8ToString(ptrkey);
+  if (jskey in jsobj) {
+    return Module.hiwire.new_value(jsobj[jskey]);
+  } else {
+    return Module.hiwire.ERROR;
+  }
+});
 
 EM_JS(void,
       hiwire_set_member_string,
@@ -265,15 +257,12 @@ EM_JS(HwRef, hiwire_get_member_obj, (HwRef idobj, HwRef ididx), {
   }
 });
 
-EM_JS(void,
-      hiwire_set_member_obj,
-      (HwRef idobj, HwRef ididx, HwRef idval),
-      {
-        var jsobj = Module.hiwire.get_value(idobj);
-        var jsidx = Module.hiwire.get_value(ididx);
-        var jsval = Module.hiwire.get_value(idval);
-        jsobj[jsidx] = jsval;
-      });
+EM_JS(void, hiwire_set_member_obj, (HwRef idobj, HwRef ididx, HwRef idval), {
+  var jsobj = Module.hiwire.get_value(idobj);
+  var jsidx = Module.hiwire.get_value(ididx);
+  var jsval = Module.hiwire.get_value(idval);
+  jsobj[jsidx] = jsval;
+});
 
 EM_JS(void, hiwire_delete_member_obj, (HwRef idobj, HwRef ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
@@ -343,7 +332,7 @@ EM_JS(HwRef, hiwire_typeof, (HwRef idobj), {
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
-  EM_JS(bool, hiwire_##name, (HwRef ida, HwRef idb), {                   \
+  EM_JS(bool, hiwire_##name, (HwRef ida, HwRef idb), {                         \
     return (Module.hiwire.get_value(ida) op Module.hiwire.get_value(idb)) ? 1  \
                                                                           : 0; \
   })

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -2,12 +2,6 @@
 
 #include "hiwire.h"
 
-bool
-hw_is_error(HwObject key)
-{
-  return FROM_NT(key) == FROM_NT(HW_ERROR);
-}
-
 HwObject
 hiwire_error()
 {

--- a/src/type_conversion/hiwire.c
+++ b/src/type_conversion/hiwire.c
@@ -2,37 +2,37 @@
 
 #include "hiwire.h"
 
-HwObject
+HwRef
 hiwire_error()
 {
   return HW_ERROR;
 }
 
-HwObject
+HwRef
 hiwire_undefined()
 {
   return HW_UNDEFINED;
 }
 
-HwObject
+HwRef
 hiwire_null()
 {
   return HW_NULL;
 }
 
-HwObject
+HwRef
 hiwire_true()
 {
   return HW_TRUE;
 }
 
-HwObject
+HwRef
 hiwire_false()
 {
   return HW_FALSE;
 }
 
-HwObject
+HwRef
 hiwire_bool(bool boolean)
 {
   return boolean ? hiwire_true() : hiwire_false();
@@ -87,24 +87,24 @@ EM_JS(void, hiwire_init, (), {
   };
 });
 
-EM_JS(HwObject, hiwire_incref, (HwObject idval), {
+EM_JS(HwRef, hiwire_incref, (HwRef idval), {
   if (idval < 0) {
     return;
   }
   return Module.hiwire.new_value(Module.hiwire.get_value(idval));
 });
 
-EM_JS(void, hiwire_decref, (HwObject idval), { Module.hiwire.decref(idval); });
+EM_JS(void, hiwire_decref, (HwRef idval), { Module.hiwire.decref(idval); });
 
-EM_JS(HwObject, hiwire_int, (int val), {
+EM_JS(HwRef, hiwire_int, (int val), {
   return Module.hiwire.new_value(val);
 });
 
-EM_JS(HwObject, hiwire_double, (double val), {
+EM_JS(HwRef, hiwire_double, (double val), {
   return Module.hiwire.new_value(val);
 });
 
-EM_JS(HwObject, hiwire_string_ucs4, (const char* ptr, int len), {
+EM_JS(HwRef, hiwire_string_ucs4, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr / 4;
   for (var i = 0; i < len; ++i) {
@@ -113,7 +113,7 @@ EM_JS(HwObject, hiwire_string_ucs4, (const char* ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(HwObject, hiwire_string_ucs2, (const char* ptr, int len), {
+EM_JS(HwRef, hiwire_string_ucs2, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr / 2;
   for (var i = 0; i < len; ++i) {
@@ -122,7 +122,7 @@ EM_JS(HwObject, hiwire_string_ucs2, (const char* ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(HwObject, hiwire_string_ucs1, (const char* ptr, int len), {
+EM_JS(HwRef, hiwire_string_ucs1, (const char* ptr, int len), {
   var jsstr = "";
   var idx = ptr;
   for (var i = 0; i < len; ++i) {
@@ -131,76 +131,76 @@ EM_JS(HwObject, hiwire_string_ucs1, (const char* ptr, int len), {
   return Module.hiwire.new_value(jsstr);
 });
 
-EM_JS(HwObject, hiwire_string_utf8, (const char* ptr), {
+EM_JS(HwRef, hiwire_string_utf8, (const char* ptr), {
   return Module.hiwire.new_value(UTF8ToString(ptr));
 });
 
-EM_JS(HwObject, hiwire_string_ascii, (const char* ptr), {
+EM_JS(HwRef, hiwire_string_ascii, (const char* ptr), {
   return Module.hiwire.new_value(AsciiToString(ptr));
 });
 
-EM_JS(HwObject, hiwire_bytes, (char* ptr, int len), {
+EM_JS(HwRef, hiwire_bytes, (char* ptr, int len), {
   var bytes = new Uint8ClampedArray(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(bytes);
 });
 
-EM_JS(HwObject, hiwire_int8array, (i8 * ptr, int len), {
+EM_JS(HwRef, hiwire_int8array, (i8 * ptr, int len), {
   var array = new Int8Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_uint8array, (u8 * ptr, int len), {
+EM_JS(HwRef, hiwire_uint8array, (u8 * ptr, int len), {
   var array = new Uint8Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_int16array, (i16 * ptr, int len), {
+EM_JS(HwRef, hiwire_int16array, (i16 * ptr, int len), {
   var array = new Int16Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_uint16array, (u16 * ptr, int len), {
+EM_JS(HwRef, hiwire_uint16array, (u16 * ptr, int len), {
   var array = new Uint16Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_int32array, (i32 * ptr, int len), {
+EM_JS(HwRef, hiwire_int32array, (i32 * ptr, int len), {
   var array = new Int32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_uint32array, (u32 * ptr, int len), {
+EM_JS(HwRef, hiwire_uint32array, (u32 * ptr, int len), {
   var array = new Uint32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_float32array, (f32 * ptr, int len), {
+EM_JS(HwRef, hiwire_float32array, (f32 * ptr, int len), {
   var array = new Float32Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(HwObject, hiwire_float64array, (f64 * ptr, int len), {
+EM_JS(HwRef, hiwire_float64array, (f64 * ptr, int len), {
   var array = new Float64Array(Module.HEAPU8.buffer, ptr, len);
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(void, hiwire_throw_error, (HwObject idmsg), {
+EM_JS(void, hiwire_throw_error, (HwRef idmsg), {
   var jsmsg = Module.hiwire.get_value(idmsg);
   Module.hiwire.decref(idmsg);
   throw new Error(jsmsg);
 });
 
-EM_JS(HwObject, hiwire_array, (), { return Module.hiwire.new_value([]); });
+EM_JS(HwRef, hiwire_array, (), { return Module.hiwire.new_value([]); });
 
-EM_JS(void, hiwire_push_array, (HwObject idarr, HwObject idval), {
+EM_JS(void, hiwire_push_array, (HwRef idarr, HwRef idval), {
   Module.hiwire.get_value(idarr).push(Module.hiwire.get_value(idval));
 });
 
-EM_JS(HwObject, hiwire_object, (), { return Module.hiwire.new_value({}); });
+EM_JS(HwRef, hiwire_object, (), { return Module.hiwire.new_value({}); });
 
 EM_JS(void,
       hiwire_push_object_pair,
-      (HwObject idobj, HwObject idkey, HwObject idval),
+      (HwRef idobj, HwRef idkey, HwRef idval),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jskey = Module.hiwire.get_value(idkey);
@@ -208,7 +208,7 @@ EM_JS(void,
         jsobj[jskey] = jsval;
       });
 
-EM_JS(HwObject, hiwire_get_global, (const char* ptrname), {
+EM_JS(HwRef, hiwire_get_global, (const char* ptrname), {
   var jsname = UTF8ToString(ptrname);
   if (jsname in self) {
     return Module.hiwire.new_value(self[jsname]);
@@ -217,9 +217,9 @@ EM_JS(HwObject, hiwire_get_global, (const char* ptrname), {
   }
 });
 
-EM_JS(HwObject,
+EM_JS(HwRef,
       hiwire_get_member_string,
-      (HwObject idobj, const char* ptrkey),
+      (HwRef idobj, const char* ptrkey),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jskey = UTF8ToString(ptrkey);
@@ -232,7 +232,7 @@ EM_JS(HwObject,
 
 EM_JS(void,
       hiwire_set_member_string,
-      (HwObject idobj, const char* ptrkey, HwObject idval),
+      (HwRef idobj, const char* ptrkey, HwRef idval),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jskey = UTF8ToString(ptrkey);
@@ -240,22 +240,22 @@ EM_JS(void,
         jsobj[jskey] = jsval;
       });
 
-EM_JS(void, hiwire_delete_member_string, (HwObject idobj, const char* ptrkey), {
+EM_JS(void, hiwire_delete_member_string, (HwRef idobj, const char* ptrkey), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jskey = UTF8ToString(ptrkey);
   delete jsobj[jskey];
 });
 
-EM_JS(HwObject, hiwire_get_member_int, (HwObject idobj, int idx), {
+EM_JS(HwRef, hiwire_get_member_int, (HwRef idobj, int idx), {
   var jsobj = Module.hiwire.get_value(idobj);
   return Module.hiwire.new_value(jsobj[idx]);
 });
 
-EM_JS(void, hiwire_set_member_int, (HwObject idobj, int idx, HwObject idval), {
+EM_JS(void, hiwire_set_member_int, (HwRef idobj, int idx, HwRef idval), {
   Module.hiwire.get_value(idobj)[idx] = Module.hiwire.get_value(idval);
 });
 
-EM_JS(HwObject, hiwire_get_member_obj, (HwObject idobj, HwObject ididx), {
+EM_JS(HwRef, hiwire_get_member_obj, (HwRef idobj, HwRef ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   if (jsidx in jsobj) {
@@ -267,7 +267,7 @@ EM_JS(HwObject, hiwire_get_member_obj, (HwObject idobj, HwObject ididx), {
 
 EM_JS(void,
       hiwire_set_member_obj,
-      (HwObject idobj, HwObject ididx, HwObject idval),
+      (HwRef idobj, HwRef ididx, HwRef idval),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jsidx = Module.hiwire.get_value(ididx);
@@ -275,13 +275,13 @@ EM_JS(void,
         jsobj[jsidx] = jsval;
       });
 
-EM_JS(void, hiwire_delete_member_obj, (HwObject idobj, HwObject ididx), {
+EM_JS(void, hiwire_delete_member_obj, (HwRef idobj, HwRef ididx), {
   var jsobj = Module.hiwire.get_value(idobj);
   var jsidx = Module.hiwire.get_value(ididx);
   delete jsobj[jsidx];
 });
 
-EM_JS(HwObject, hiwire_dir, (HwObject idobj), {
+EM_JS(HwRef, hiwire_dir, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   var result = [];
   do {
@@ -290,15 +290,15 @@ EM_JS(HwObject, hiwire_dir, (HwObject idobj), {
   return Module.hiwire.new_value(result);
 });
 
-EM_JS(HwObject, hiwire_call, (HwObject idfunc, HwObject idargs), {
+EM_JS(HwRef, hiwire_call, (HwRef idfunc, HwRef idargs), {
   var jsfunc = Module.hiwire.get_value(idfunc);
   var jsargs = Module.hiwire.get_value(idargs);
   return Module.hiwire.new_value(jsfunc.apply(jsfunc, jsargs));
 });
 
-EM_JS(HwObject,
+EM_JS(HwRef,
       hiwire_call_member,
-      (HwObject idobj, const char* ptrname, HwObject idargs),
+      (HwRef idobj, const char* ptrname, HwRef idargs),
       {
         var jsobj = Module.hiwire.get_value(idobj);
         var jsname = UTF8ToString(ptrname);
@@ -306,7 +306,7 @@ EM_JS(HwObject,
         return Module.hiwire.new_value(jsobj[jsname].apply(jsobj, jsargs));
       });
 
-EM_JS(HwObject, hiwire_new, (HwObject idobj, HwObject idargs), {
+EM_JS(HwRef, hiwire_new, (HwRef idobj, HwRef idargs), {
   function newCall(Cls)
   {
     return new (Function.prototype.bind.apply(Cls, arguments));
@@ -317,33 +317,33 @@ EM_JS(HwObject, hiwire_new, (HwObject idobj, HwObject idargs), {
   return Module.hiwire.new_value(newCall.apply(newCall, jsargs));
 });
 
-EM_JS(int, hiwire_get_length, (HwObject idobj), {
+EM_JS(int, hiwire_get_length, (HwRef idobj), {
   return Module.hiwire.get_value(idobj).length;
 });
 
-EM_JS(bool, hiwire_get_bool, (HwObject idobj), {
+EM_JS(bool, hiwire_get_bool, (HwRef idobj), {
   var val = Module.hiwire.get_value(idobj);
   // clang-format off
   return (val && (val.length === undefined || val.length)) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_function, (HwObject idobj), {
+EM_JS(bool, hiwire_is_function, (HwRef idobj), {
   // clang-format off
   return typeof Module.hiwire.get_value(idobj) === 'function';
   // clang-format on
 });
 
-EM_JS(HwObject, hiwire_to_string, (HwObject idobj), {
+EM_JS(HwRef, hiwire_to_string, (HwRef idobj), {
   return Module.hiwire.new_value(Module.hiwire.get_value(idobj).toString());
 });
 
-EM_JS(HwObject, hiwire_typeof, (HwObject idobj), {
+EM_JS(HwRef, hiwire_typeof, (HwRef idobj), {
   return Module.hiwire.new_value(typeof Module.hiwire.get_value(idobj));
 });
 
 #define MAKE_OPERATOR(name, op)                                                \
-  EM_JS(bool, hiwire_##name, (HwObject ida, HwObject idb), {                   \
+  EM_JS(bool, hiwire_##name, (HwRef ida, HwRef idb), {                   \
     return (Module.hiwire.get_value(ida) op Module.hiwire.get_value(idb)) ? 1  \
                                                                           : 0; \
   })
@@ -355,7 +355,7 @@ MAKE_OPERATOR(not_equal, !=);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS(HwObject, hiwire_next, (HwObject idobj), {
+EM_JS(HwRef, hiwire_next, (HwRef idobj), {
   // clang-format off
   if (idobj === Module.hiwire.UNDEFINED) {
     return Module.hiwire.ERROR;
@@ -366,7 +366,7 @@ EM_JS(HwObject, hiwire_next, (HwObject idobj), {
   // clang-format on
 });
 
-EM_JS(HwObject, hiwire_get_iterator, (HwObject idobj), {
+EM_JS(HwRef, hiwire_get_iterator, (HwRef idobj), {
   // clang-format off
   if (idobj === Module.hiwire.UNDEFINED) {
     return Module.hiwire.ERROR;
@@ -384,37 +384,37 @@ EM_JS(HwObject, hiwire_get_iterator, (HwObject idobj), {
   // clang-format on
 })
 
-EM_JS(bool, hiwire_nonzero, (HwObject idobj), {
+EM_JS(bool, hiwire_nonzero, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // TODO: should this be !== 0?
   return (jsobj != 0) ? 1 : 0;
 });
 
-EM_JS(bool, hiwire_is_typedarray, (HwObject idobj), {
+EM_JS(bool, hiwire_is_typedarray, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj['byteLength'] !== undefined) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(bool, hiwire_is_on_wasm_heap, (HwObject idobj), {
+EM_JS(bool, hiwire_is_on_wasm_heap, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   return (jsobj.buffer === Module.HEAPU8.buffer) ? 1 : 0;
   // clang-format on
 });
 
-EM_JS(int, hiwire_get_byteOffset, (HwObject idobj), {
+EM_JS(int, hiwire_get_byteOffset, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteOffset'];
 });
 
-EM_JS(int, hiwire_get_byteLength, (HwObject idobj), {
+EM_JS(int, hiwire_get_byteLength, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   return jsobj['byteLength'];
 });
 
-EM_JS(void, hiwire_copy_to_ptr, (HwObject idobj, int ptr), {
+EM_JS(void, hiwire_copy_to_ptr, (HwRef idobj, int ptr), {
   var jsobj = Module.hiwire.get_value(idobj);
   // clang-format off
   var buffer = (jsobj['buffer'] !== undefined) ? jsobj.buffer : jsobj;
@@ -422,7 +422,7 @@ EM_JS(void, hiwire_copy_to_ptr, (HwObject idobj, int ptr), {
   Module.HEAPU8.set(new Uint8Array(buffer), ptr);
 });
 
-EM_JS(int, hiwire_get_dtype, (HwObject idobj), {
+EM_JS(int, hiwire_get_dtype, (HwRef idobj), {
   var jsobj = Module.hiwire.get_value(idobj);
   switch (jsobj.constructor.name) {
     case 'Int8Array':
@@ -462,7 +462,7 @@ EM_JS(int, hiwire_get_dtype, (HwObject idobj), {
   return dtype;
 });
 
-EM_JS(HwObject, hiwire_subarray, (HwObject idarr, int start, int end), {
+EM_JS(HwRef, hiwire_subarray, (HwRef idarr, int start, int end), {
   var jsarr = Module.hiwire.get_value(idarr);
   var jssub = jsarr.subarray(start, end);
   return Module.hiwire.new_value(jssub);

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -43,7 +43,7 @@ typedef struct _HwObjectStruct* HwObject;
  * Initialize the variables and functions required for hiwire.
  */
 void
-hiwire_setup();
+hiwire_init();
 
 /**
  * Increase the reference count on an object.

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -1,5 +1,6 @@
 #ifndef HIWIRE_H
 #define HIWIRE_H
+#include "types.h"
 
 /**
  * hiwire: A super-simple framework for converting values between C and
@@ -14,13 +15,18 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
+NEWTYPE(HwObject, int);
+
 // Define special ids for singleton constants. These must be negative to
 // avoid being reused for other values.
-#define HW_ERROR -1
-#define HW_UNDEFINED -2
-#define HW_TRUE -3
-#define HW_FALSE -4
-#define HW_NULL -5
+#define HW_ERROR TO_NT(HwObject, -1)
+#define HW_UNDEFINED TO_NT(HwObject, -2)
+#define HW_TRUE TO_NT(HwObject, -3)
+#define HW_FALSE TO_NT(HwObject, -4)
+#define HW_NULL TO_NT(HwObject, -5)
+
+bool
+hw_is_error(HwObject key);
 
 /**
  * Initialize the variables and functions required for hiwire.
@@ -33,21 +39,21 @@ hiwire_setup();
  *
  * Returns: The new reference
  */
-int
-hiwire_incref(int idval);
+HwObject
+hiwire_incref(HwObject idval);
 
 /**
  * Decrease the reference count on an object.
  */
 void
-hiwire_decref(int idval);
+hiwire_decref(HwObject idval);
 
 /**
  * Create a new Javascript integer with the given value.
  *
  * Returns: New reference
  */
-int
+HwObject
 hiwire_int(int val);
 
 /**
@@ -55,7 +61,7 @@ hiwire_int(int val);
  *
  * Returns: New reference
  */
-int
+HwObject
 hiwire_double(double val);
 
 /**
@@ -64,8 +70,8 @@ hiwire_double(double val);
  *
  * Returns: New reference
  */
-int
-hiwire_string_ucs4(int ptr, int len);
+HwObject
+hiwire_string_ucs4(const char* ptr, int len);
 
 /**
  * Create a new Javascript string, given a pointer to a buffer
@@ -73,8 +79,8 @@ hiwire_string_ucs4(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_string_ucs2(int ptr, int len);
+HwObject
+hiwire_string_ucs2(const char* ptr, int len);
 
 /**
  * Create a new Javascript string, given a pointer to a buffer
@@ -82,8 +88,8 @@ hiwire_string_ucs2(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_string_ucs1(int ptr, int len);
+HwObject
+hiwire_string_ucs1(const char* ptr, int len);
 
 /**
  * Create a new Javascript string, given a pointer to a null-terminated buffer
@@ -91,8 +97,8 @@ hiwire_string_ucs1(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_string_utf8(int ptr);
+HwObject
+hiwire_string_utf8(const char* ptr);
 
 /**
  * Create a new Javascript string, given a pointer to a null-terminated buffer
@@ -101,8 +107,8 @@ hiwire_string_utf8(int ptr);
  *
  * Returns: New reference
  */
-int
-hiwire_string_ascii(int ptr);
+HwObject
+hiwire_string_ascii(const char* ptr);
 
 /**
  * Create a new Javascript Uint8ClampedArray, given a pointer to a buffer and a
@@ -112,8 +118,8 @@ hiwire_string_ascii(int ptr);
  *
  * Returns: New reference
  */
-int
-hiwire_bytes(int ptr, int len);
+HwObject
+hiwire_bytes(char* ptr, int len);
 
 /**
  * Create a new Javascript Int8Array, given a pointer to a buffer and a
@@ -123,8 +129,8 @@ hiwire_bytes(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_int8array(int ptr, int len);
+HwObject
+hiwire_int8array(i8* ptr, int len);
 
 /**
  * Create a new Javascript Uint8Array, given a pointer to a buffer and a
@@ -134,8 +140,8 @@ hiwire_int8array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_uint8array(int ptr, int len);
+HwObject
+hiwire_uint8array(u8* ptr, int len);
 
 /**
  * Create a new Javascript Int16Array, given a pointer to a buffer and a
@@ -145,8 +151,8 @@ hiwire_uint8array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_int16array(int ptr, int len);
+HwObject
+hiwire_int16array(i16* ptr, int len);
 
 /**
  * Create a new Javascript Uint16Array, given a pointer to a buffer and a
@@ -156,8 +162,8 @@ hiwire_int16array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_uint16array(int ptr, int len);
+HwObject
+hiwire_uint16array(u16* ptr, int len);
 
 /**
  * Create a new Javascript Int32Array, given a pointer to a buffer and a
@@ -167,8 +173,8 @@ hiwire_uint16array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_int32array(int ptr, int len);
+HwObject
+hiwire_int32array(i32* ptr, int len);
 
 /**
  * Create a new Javascript Uint32Array, given a pointer to a buffer and a
@@ -178,8 +184,8 @@ hiwire_int32array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_uint32array(int ptr, int len);
+HwObject
+hiwire_uint32array(u32* ptr, int len);
 
 /**
  * Create a new Javascript Float32Array, given a pointer to a buffer and a
@@ -189,8 +195,8 @@ hiwire_uint32array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_float32array(int ptr, int len);
+HwObject
+hiwire_float32array(f32* ptr, int len);
 
 /**
  * Create a new Javascript Float64Array, given a pointer to a buffer and a
@@ -200,56 +206,56 @@ hiwire_float32array(int ptr, int len);
  *
  * Returns: New reference
  */
-int
-hiwire_float64array(int ptr, int len);
+HwObject
+hiwire_float64array(f64* ptr, int len);
 
 /**
  * Create a new Javascript undefined value.
  *
- * Returns: New reference
+ * Returns: "New" reference
  */
-int
+HwObject
 hiwire_undefined();
 
 /**
  * Create a new Javascript null value.
  *
- * Returns: New reference
+ * Returns: "New" reference
  */
-int
+HwObject
 hiwire_null();
 
 /**
  * Create a new Javascript true value.
  *
- * Returns: New reference
+ * Returns: "New" reference
  */
-int
+HwObject
 hiwire_true();
 
 /**
  * Create a new Javascript false value.
  *
- * Returns: New reference
+ * Returns: "New" reference
  */
-int
+HwObject
 hiwire_false();
 
 /**
  * Create a new Javascript boolean value.
  * Return value is true if boolean != 0, false if boolean == 0.
  *
- * Returns: New reference
+ * Returns: "New" reference
  */
-int
-hiwire_bool(int boolean);
+HwObject
+hiwire_bool(bool boolean);
 
 /**
  * Create a new Javascript Array.
  *
  * Returns: New reference
  */
-int
+HwObject
 hiwire_array();
 
 /**
@@ -259,14 +265,14 @@ hiwire_array();
  * responsibility to decref it.
  */
 void
-hiwire_push_array(int idobj, int idval);
+hiwire_push_array(HwObject idobj, HwObject idval);
 
 /**
  * Create a new Javascript object.
  *
  * Returns: New reference
  */
-int
+HwObject
 hiwire_object();
 
 /**
@@ -276,7 +282,7 @@ hiwire_object();
  * user's responsibility to decref them.
  */
 void
-hiwire_push_object_pair(int idobj, int idkey, int idval);
+hiwire_push_object_pair(HwObject idobj, HwObject idkey, HwObject idval);
 
 /**
  * Throws a new Error object with the given message.
@@ -284,41 +290,37 @@ hiwire_push_object_pair(int idobj, int idkey, int idval);
  * The message is conventionally a Javascript string, but that is not required.
  */
 void
-hiwire_throw_error(int idmsg);
+hiwire_throw_error(HwObject idmsg);
 
 /**
  * Get a Javascript object from the global namespace, i.e. window.
  *
  * Returns: New reference
  */
-int
-hiwire_get_global(int ptrname);
+HwObject
+hiwire_get_global(const char* ptrname);
 
 /**
  * Get an object member by string.
  *
- * The string is a char* to null-terminated UTF8.
  *
  * Returns: New reference
  */
-int
-hiwire_get_member_string(int idobj, int ptrname);
+HwObject
+hiwire_get_member_string(HwObject idobj, const char* ptrname);
 
 /**
  * Set an object member by string.
- *
- * The string is a char* to null-terminated UTF8.
  */
 void
-hiwire_set_member_string(int idobj, int ptrname, int idval);
+hiwire_set_member_string(HwObject idobj, const char* ptrname, HwObject idval);
 
 /**
  * Delete an object member by string.
  *
- * The string is a char* to null-terminated UTF8.
  */
 void
-hiwire_delete_member_string(int idobj, int ptrname);
+hiwire_delete_member_string(HwObject idobj, const char* ptrname);
 
 /**
  * Get an object member by integer.
@@ -327,8 +329,8 @@ hiwire_delete_member_string(int idobj, int ptrname);
  *
  * Returns: New reference
  */
-int
-hiwire_get_member_int(int idobj, int idx);
+HwObject
+hiwire_get_member_int(HwObject idobj, int idx);
 
 /**
  * Set an object member by integer.
@@ -337,36 +339,36 @@ hiwire_get_member_int(int idobj, int idx);
  *
  */
 void
-hiwire_set_member_int(int idobj, int idx, int idval);
+hiwire_set_member_int(HwObject idobj, int idx, HwObject idval);
 
 /**
  * Get an object member by object.
  *
  * Returns: New reference
  */
-int
-hiwire_get_member_obj(int idobj, int ididx);
+HwObject
+hiwire_get_member_obj(HwObject idobj, HwObject ididx);
 
 /**
  * Set an object member by object.
  *
  */
 void
-hiwire_set_member_obj(int idobj, int ididx, int idval);
+hiwire_set_member_obj(HwObject idobj, HwObject ididx, HwObject idval);
 
 /**
  * Delete an object member by object.
  *
  */
 void
-hiwire_delete_member_obj(int idobj, int ididx);
+hiwire_delete_member_obj(HwObject idobj, HwObject ididx);
 
 /**
  * Get the methods on an object, both on itself and what it inherits.
  *
  */
-int
-hiwire_dir(int idobj);
+HwObject
+hiwire_dir(HwObject idobj);
 
 /**
  * Call a function
@@ -375,8 +377,8 @@ hiwire_dir(int idobj);
  *
  * Returns: New reference
  */
-int
-hiwire_call(int idobj, int idargs);
+HwObject
+hiwire_call(HwObject idobj, HwObject idargs);
 
 /**
  * Call a member function.
@@ -387,8 +389,8 @@ hiwire_call(int idobj, int idargs);
  *
  * Returns: New reference
  */
-int
-hiwire_call_member(int idobj, int ptrname, int idargs);
+HwObject
+hiwire_call_member(HwObject idobj, const char* ptrname, HwObject idargs);
 
 /**
  * Calls the constructor of a class object.
@@ -397,117 +399,117 @@ hiwire_call_member(int idobj, int ptrname, int idargs);
  *
  * Returns: New reference
  */
-int
-hiwire_new(int idobj, int idargs);
+HwObject
+hiwire_new(HwObject idobj, HwObject idargs);
 
 /**
  * Returns the value of the `length` member on a Javascript object.
  *
  * Returns: C int
  */
-int
-hiwire_get_length(int idobj);
+bool
+hiwire_get_length(HwObject idobj);
 
 /**
  * Returns the boolean value of a Javascript object.
  *
  * Returns: C int
  */
-int
-hiwire_get_bool(int idobj);
+bool
+hiwire_get_bool(HwObject idobj);
 
 /**
  * Returns 1 if the object is a function.
  *
  * Returns: C int
  */
-int
-hiwire_is_function(int idobj);
+bool
+hiwire_is_function(HwObject idobj);
 
 /**
  * Gets the string representation of an object by calling `toString`.
  *
  * Returns: New reference to Javascript string
  */
-int
-hiwire_to_string(int idobj);
+HwObject
+hiwire_to_string(HwObject idobj);
 
 /**
  * Gets the "typeof" string for a value.
  *
  * Returns: New reference to Javascript string
  */
-int
-hiwire_typeof(int idobj);
+HwObject
+hiwire_typeof(HwObject idobj);
 
 /**
  * Returns non-zero if a < b.
  */
-int
-hiwire_less_than(int ida, int idb);
+bool
+hiwire_less_than(HwObject ida, HwObject idb);
 
 /**
  * Returns non-zero if a <= b.
  */
-int
-hiwire_less_than_equal(int ida, int idb);
+bool
+hiwire_less_than_equal(HwObject ida, HwObject idb);
 
 /**
  * Returns non-zero if a == b.
  */
-int
-hiwire_equal(int ida, int idb);
+bool
+hiwire_equal(HwObject ida, HwObject idb);
 
 /**
  * Returns non-zero if a != b.
  */
-int
-hiwire_not_equal(int idx, int idb);
+bool
+hiwire_not_equal(HwObject idx, HwObject idb);
 
 /**
  * Returns non-zero if a > b.
  */
-int
-hiwire_greater_than(int ida, int idb);
+bool
+hiwire_greater_than(HwObject ida, HwObject idb);
 
 /**
  * Returns non-zero if a >= b.
  */
-int
-hiwire_greater_than_equal(int ida, int idb);
+bool
+hiwire_greater_than_equal(HwObject ida, HwObject idb);
 
 /**
  * Calls the `next` function on an iterator.
  *
  * Returns: HW_ERROR if `next` function is undefined.
  */
-int
-hiwire_next(int idobj);
+HwObject
+hiwire_next(HwObject idobj);
 
 /**
  * Returns the iterator associated with the given object, if any.
  */
-int
-hiwire_get_iterator(int idobj);
+HwObject
+hiwire_get_iterator(HwObject idobj);
 
 /**
  * Returns 1 if the value is non-zero.
  *
  */
-int
-hiwire_nonzero(int idobj);
+bool
+hiwire_nonzero(HwObject idobj);
 
 /**
  * Returns 1 if the value is a typedarray.
  */
-int
-hiwire_is_typedarray(int idobj);
+bool
+hiwire_is_typedarray(HwObject idobj);
 
 /**
  * Returns 1 if the value is a typedarray whose buffer is part of the WASM heap.
  */
-int
-hiwire_is_on_wasm_heap(int idobj);
+bool
+hiwire_is_on_wasm_heap(HwObject idobj);
 
 /**
  * Returns the value of obj.byteLength.
@@ -516,7 +518,7 @@ hiwire_is_on_wasm_heap(int idobj);
  * true.
  */
 int
-hiwire_get_byteLength(int idobj);
+hiwire_get_byteLength(HwObject idobj);
 
 /**
  * Returns the value of obj.byteOffset.
@@ -525,14 +527,14 @@ hiwire_get_byteLength(int idobj);
  * true and hiwire_is_on_wasm_heap is true.
  */
 int
-hiwire_get_byteOffset(int idobj);
+hiwire_get_byteOffset(HwObject idobj);
 
 /**
  * Copies the buffer contents of a given typed array or buffer into the memory
  * at ptr.
  */
-int
-hiwire_copy_to_ptr(int idobj, int ptr);
+void
+hiwire_copy_to_ptr(HwObject idobj, int ptr);
 
 #define INT8_TYPE 1
 #define UINT8_TYPE 2
@@ -551,12 +553,12 @@ hiwire_copy_to_ptr(int idobj, int ptr);
  * UINT16_TYPE, INT32_TYPE, UINT32_TYPE, FLOAT32_TYPE, FLOAT64_TYPE.
  */
 int
-hiwire_get_dtype(int idobj);
+hiwire_get_dtype(HwObject idobj);
 
 /**
  * Get a subarray from a TypedArray
  */
-int
-hiwire_subarray(int idarr, int start, int end);
+HwObject
+hiwire_subarray(HwObject idarr, int start, int end);
 
 #endif /* HIWIRE_H */

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -16,28 +16,28 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
-// HwRef is a NewType of int.
+// JsRef is a NewType of int.
 // I checked and
-//  alignof(HwRef) = alignof(int) = 4
-//  sizeof(HwRef) = sizeof(int) = 4
+//  alignof(JsRef) = alignof(int) = 4
+//  sizeof(JsRef) = sizeof(int) = 4
 // Just to be extra future proof, I added assertions about this to the begining
-// of main.c So we are all good for using HwRef as a newtype for int. I also
+// of main.c So we are all good for using JsRef as a newtype for int. I also
 // added
 //  -Werror=int-conversion -Werror=incompatible-pointer-types
-// to the compile flags, so that no implicit casts will happen between HwRef
+// to the compile flags, so that no implicit casts will happen between JsRef
 // and any other type.
-struct _HwRefStruct
+struct _JsRefStruct
 {};
 
-typedef struct _HwRefStruct* HwRef;
+typedef struct _JsRefStruct* JsRef;
 
 // Define special ids for singleton constants. These must be negative to
 // avoid being reused for other values.
-#define HW_ERROR ((HwRef)(-1))
-#define HW_UNDEFINED ((HwRef)(-2))
-#define HW_TRUE ((HwRef)(-3))
-#define HW_FALSE ((HwRef)(-4))
-#define HW_NULL ((HwRef)(-5))
+#define Js_ERROR ((JsRef)(-1))
+#define Js_UNDEFINED ((JsRef)(-2))
+#define Js_TRUE ((JsRef)(-3))
+#define Js_FALSE ((JsRef)(-4))
+#define Js_NULL ((JsRef)(-5))
 
 /**
  * Initialize the variables and functions required for hiwire.
@@ -50,21 +50,21 @@ hiwire_init();
  *
  * Returns: The new reference
  */
-HwRef
-hiwire_incref(HwRef idval);
+JsRef
+hiwire_incref(JsRef idval);
 
 /**
  * Decrease the reference count on an object.
  */
 void
-hiwire_decref(HwRef idval);
+hiwire_decref(JsRef idval);
 
 /**
  * Create a new Javascript integer with the given value.
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_int(int val);
 
 /**
@@ -72,7 +72,7 @@ hiwire_int(int val);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_double(double val);
 
 /**
@@ -81,7 +81,7 @@ hiwire_double(double val);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_string_ucs4(const char* ptr, int len);
 
 /**
@@ -90,7 +90,7 @@ hiwire_string_ucs4(const char* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_string_ucs2(const char* ptr, int len);
 
 /**
@@ -99,7 +99,7 @@ hiwire_string_ucs2(const char* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_string_ucs1(const char* ptr, int len);
 
 /**
@@ -108,7 +108,7 @@ hiwire_string_ucs1(const char* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_string_utf8(const char* ptr);
 
 /**
@@ -118,7 +118,7 @@ hiwire_string_utf8(const char* ptr);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_string_ascii(const char* ptr);
 
 /**
@@ -129,7 +129,7 @@ hiwire_string_ascii(const char* ptr);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_bytes(char* ptr, int len);
 
 /**
@@ -140,7 +140,7 @@ hiwire_bytes(char* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_int8array(i8* ptr, int len);
 
 /**
@@ -151,7 +151,7 @@ hiwire_int8array(i8* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_uint8array(u8* ptr, int len);
 
 /**
@@ -162,7 +162,7 @@ hiwire_uint8array(u8* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_int16array(i16* ptr, int len);
 
 /**
@@ -173,7 +173,7 @@ hiwire_int16array(i16* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_uint16array(u16* ptr, int len);
 
 /**
@@ -184,7 +184,7 @@ hiwire_uint16array(u16* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_int32array(i32* ptr, int len);
 
 /**
@@ -195,7 +195,7 @@ hiwire_int32array(i32* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_uint32array(u32* ptr, int len);
 
 /**
@@ -206,7 +206,7 @@ hiwire_uint32array(u32* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_float32array(f32* ptr, int len);
 
 /**
@@ -217,7 +217,7 @@ hiwire_float32array(f32* ptr, int len);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_float64array(f64* ptr, int len);
 
 /**
@@ -225,7 +225,7 @@ hiwire_float64array(f64* ptr, int len);
  *
  * Returns: "New" reference
  */
-HwRef
+JsRef
 hiwire_undefined();
 
 /**
@@ -233,7 +233,7 @@ hiwire_undefined();
  *
  * Returns: "New" reference
  */
-HwRef
+JsRef
 hiwire_null();
 
 /**
@@ -241,7 +241,7 @@ hiwire_null();
  *
  * Returns: "New" reference
  */
-HwRef
+JsRef
 hiwire_true();
 
 /**
@@ -249,7 +249,7 @@ hiwire_true();
  *
  * Returns: "New" reference
  */
-HwRef
+JsRef
 hiwire_false();
 
 /**
@@ -258,7 +258,7 @@ hiwire_false();
  *
  * Returns: "New" reference
  */
-HwRef
+JsRef
 hiwire_bool(bool boolean);
 
 /**
@@ -266,7 +266,7 @@ hiwire_bool(bool boolean);
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_array();
 
 /**
@@ -276,14 +276,14 @@ hiwire_array();
  * responsibility to decref it.
  */
 void
-hiwire_push_array(HwRef idobj, HwRef idval);
+hiwire_push_array(JsRef idobj, JsRef idval);
 
 /**
  * Create a new Javascript object.
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_object();
 
 /**
@@ -293,7 +293,7 @@ hiwire_object();
  * user's responsibility to decref them.
  */
 void
-hiwire_push_object_pair(HwRef idobj, HwRef idkey, HwRef idval);
+hiwire_push_object_pair(JsRef idobj, JsRef idkey, JsRef idval);
 
 /**
  * Throws a new Error object with the given message.
@@ -301,14 +301,14 @@ hiwire_push_object_pair(HwRef idobj, HwRef idkey, HwRef idval);
  * The message is conventionally a Javascript string, but that is not required.
  */
 void
-hiwire_throw_error(HwRef idmsg);
+hiwire_throw_error(JsRef idmsg);
 
 /**
  * Get a Javascript object from the global namespace, i.e. window.
  *
  * Returns: New reference
  */
-HwRef
+JsRef
 hiwire_get_global(const char* ptrname);
 
 /**
@@ -317,21 +317,21 @@ hiwire_get_global(const char* ptrname);
  *
  * Returns: New reference
  */
-HwRef
-hiwire_get_member_string(HwRef idobj, const char* ptrname);
+JsRef
+hiwire_get_member_string(JsRef idobj, const char* ptrname);
 
 /**
  * Set an object member by string.
  */
 void
-hiwire_set_member_string(HwRef idobj, const char* ptrname, HwRef idval);
+hiwire_set_member_string(JsRef idobj, const char* ptrname, JsRef idval);
 
 /**
  * Delete an object member by string.
  *
  */
 void
-hiwire_delete_member_string(HwRef idobj, const char* ptrname);
+hiwire_delete_member_string(JsRef idobj, const char* ptrname);
 
 /**
  * Get an object member by integer.
@@ -340,8 +340,8 @@ hiwire_delete_member_string(HwRef idobj, const char* ptrname);
  *
  * Returns: New reference
  */
-HwRef
-hiwire_get_member_int(HwRef idobj, int idx);
+JsRef
+hiwire_get_member_int(JsRef idobj, int idx);
 
 /**
  * Set an object member by integer.
@@ -350,36 +350,36 @@ hiwire_get_member_int(HwRef idobj, int idx);
  *
  */
 void
-hiwire_set_member_int(HwRef idobj, int idx, HwRef idval);
+hiwire_set_member_int(JsRef idobj, int idx, JsRef idval);
 
 /**
  * Get an object member by object.
  *
  * Returns: New reference
  */
-HwRef
-hiwire_get_member_obj(HwRef idobj, HwRef ididx);
+JsRef
+hiwire_get_member_obj(JsRef idobj, JsRef ididx);
 
 /**
  * Set an object member by object.
  *
  */
 void
-hiwire_set_member_obj(HwRef idobj, HwRef ididx, HwRef idval);
+hiwire_set_member_obj(JsRef idobj, JsRef ididx, JsRef idval);
 
 /**
  * Delete an object member by object.
  *
  */
 void
-hiwire_delete_member_obj(HwRef idobj, HwRef ididx);
+hiwire_delete_member_obj(JsRef idobj, JsRef ididx);
 
 /**
  * Get the methods on an object, both on itself and what it inherits.
  *
  */
-HwRef
-hiwire_dir(HwRef idobj);
+JsRef
+hiwire_dir(JsRef idobj);
 
 /**
  * Call a function
@@ -388,8 +388,8 @@ hiwire_dir(HwRef idobj);
  *
  * Returns: New reference
  */
-HwRef
-hiwire_call(HwRef idobj, HwRef idargs);
+JsRef
+hiwire_call(JsRef idobj, JsRef idargs);
 
 /**
  * Call a member function.
@@ -400,8 +400,8 @@ hiwire_call(HwRef idobj, HwRef idargs);
  *
  * Returns: New reference
  */
-HwRef
-hiwire_call_member(HwRef idobj, const char* ptrname, HwRef idargs);
+JsRef
+hiwire_call_member(JsRef idobj, const char* ptrname, JsRef idargs);
 
 /**
  * Calls the constructor of a class object.
@@ -410,8 +410,8 @@ hiwire_call_member(HwRef idobj, const char* ptrname, HwRef idargs);
  *
  * Returns: New reference
  */
-HwRef
-hiwire_new(HwRef idobj, HwRef idargs);
+JsRef
+hiwire_new(JsRef idobj, JsRef idargs);
 
 /**
  * Returns the value of the `length` member on a Javascript object.
@@ -419,7 +419,7 @@ hiwire_new(HwRef idobj, HwRef idargs);
  * Returns: C int
  */
 bool
-hiwire_get_length(HwRef idobj);
+hiwire_get_length(JsRef idobj);
 
 /**
  * Returns the boolean value of a Javascript object.
@@ -427,7 +427,7 @@ hiwire_get_length(HwRef idobj);
  * Returns: C int
  */
 bool
-hiwire_get_bool(HwRef idobj);
+hiwire_get_bool(JsRef idobj);
 
 /**
  * Returns 1 if the object is a function.
@@ -435,92 +435,92 @@ hiwire_get_bool(HwRef idobj);
  * Returns: C int
  */
 bool
-hiwire_is_function(HwRef idobj);
+hiwire_is_function(JsRef idobj);
 
 /**
  * Gets the string representation of an object by calling `toString`.
  *
  * Returns: New reference to Javascript string
  */
-HwRef
-hiwire_to_string(HwRef idobj);
+JsRef
+hiwire_to_string(JsRef idobj);
 
 /**
  * Gets the "typeof" string for a value.
  *
  * Returns: New reference to Javascript string
  */
-HwRef
-hiwire_typeof(HwRef idobj);
+JsRef
+hiwire_typeof(JsRef idobj);
 
 /**
  * Returns non-zero if a < b.
  */
 bool
-hiwire_less_than(HwRef ida, HwRef idb);
+hiwire_less_than(JsRef ida, JsRef idb);
 
 /**
  * Returns non-zero if a <= b.
  */
 bool
-hiwire_less_than_equal(HwRef ida, HwRef idb);
+hiwire_less_than_equal(JsRef ida, JsRef idb);
 
 /**
  * Returns non-zero if a == b.
  */
 bool
-hiwire_equal(HwRef ida, HwRef idb);
+hiwire_equal(JsRef ida, JsRef idb);
 
 /**
  * Returns non-zero if a != b.
  */
 bool
-hiwire_not_equal(HwRef idx, HwRef idb);
+hiwire_not_equal(JsRef idx, JsRef idb);
 
 /**
  * Returns non-zero if a > b.
  */
 bool
-hiwire_greater_than(HwRef ida, HwRef idb);
+hiwire_greater_than(JsRef ida, JsRef idb);
 
 /**
  * Returns non-zero if a >= b.
  */
 bool
-hiwire_greater_than_equal(HwRef ida, HwRef idb);
+hiwire_greater_than_equal(JsRef ida, JsRef idb);
 
 /**
  * Calls the `next` function on an iterator.
  *
- * Returns: HW_ERROR if `next` function is undefined.
+ * Returns: Js_ERROR if `next` function is undefined.
  */
-HwRef
-hiwire_next(HwRef idobj);
+JsRef
+hiwire_next(JsRef idobj);
 
 /**
  * Returns the iterator associated with the given object, if any.
  */
-HwRef
-hiwire_get_iterator(HwRef idobj);
+JsRef
+hiwire_get_iterator(JsRef idobj);
 
 /**
  * Returns 1 if the value is non-zero.
  *
  */
 bool
-hiwire_nonzero(HwRef idobj);
+hiwire_nonzero(JsRef idobj);
 
 /**
  * Returns 1 if the value is a typedarray.
  */
 bool
-hiwire_is_typedarray(HwRef idobj);
+hiwire_is_typedarray(JsRef idobj);
 
 /**
  * Returns 1 if the value is a typedarray whose buffer is part of the WASM heap.
  */
 bool
-hiwire_is_on_wasm_heap(HwRef idobj);
+hiwire_is_on_wasm_heap(JsRef idobj);
 
 /**
  * Returns the value of obj.byteLength.
@@ -529,7 +529,7 @@ hiwire_is_on_wasm_heap(HwRef idobj);
  * true.
  */
 int
-hiwire_get_byteLength(HwRef idobj);
+hiwire_get_byteLength(JsRef idobj);
 
 /**
  * Returns the value of obj.byteOffset.
@@ -538,14 +538,14 @@ hiwire_get_byteLength(HwRef idobj);
  * true and hiwire_is_on_wasm_heap is true.
  */
 int
-hiwire_get_byteOffset(HwRef idobj);
+hiwire_get_byteOffset(JsRef idobj);
 
 /**
  * Copies the buffer contents of a given typed array or buffer into the memory
  * at ptr.
  */
 void
-hiwire_copy_to_ptr(HwRef idobj, int ptr);
+hiwire_copy_to_ptr(JsRef idobj, int ptr);
 
 #define INT8_TYPE 1
 #define UINT8_TYPE 2
@@ -564,12 +564,12 @@ hiwire_copy_to_ptr(HwRef idobj, int ptr);
  * UINT16_TYPE, INT32_TYPE, UINT32_TYPE, FLOAT32_TYPE, FLOAT64_TYPE.
  */
 int
-hiwire_get_dtype(HwRef idobj);
+hiwire_get_dtype(JsRef idobj);
 
 /**
  * Get a subarray from a TypedArray
  */
-HwRef
-hiwire_subarray(HwRef idarr, int start, int end);
+JsRef
+hiwire_subarray(JsRef idarr, int start, int end);
 
 #endif /* HIWIRE_H */

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -42,7 +42,7 @@ typedef struct _JsRefStruct* JsRef;
 /**
  * Initialize the variables and functions required for hiwire.
  */
-void
+int
 hiwire_init();
 
 /**

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -16,6 +16,16 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
+// HwObject is a NewType of int.
+// I checked and
+//  alignof(HwObject) = alignof(int) = 4
+//  sizeof(HwObject) = sizeof(int) = 4
+// Just to be extra future proof, I added assertions about this to the begining
+// of main.c So we are all good for using HwObject as a newtype for int. I also
+// added
+//  -Werror=int-conversion -Werror=incompatible-pointer-types
+// to the compile flags, so that no implicit casts will happen between HwObject
+// and any other type.
 struct _HwObjectStruct
 {};
 

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -16,28 +16,28 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
-// HwObject is a NewType of int.
+// HwRef is a NewType of int.
 // I checked and
-//  alignof(HwObject) = alignof(int) = 4
-//  sizeof(HwObject) = sizeof(int) = 4
+//  alignof(HwRef) = alignof(int) = 4
+//  sizeof(HwRef) = sizeof(int) = 4
 // Just to be extra future proof, I added assertions about this to the begining
-// of main.c So we are all good for using HwObject as a newtype for int. I also
+// of main.c So we are all good for using HwRef as a newtype for int. I also
 // added
 //  -Werror=int-conversion -Werror=incompatible-pointer-types
-// to the compile flags, so that no implicit casts will happen between HwObject
+// to the compile flags, so that no implicit casts will happen between HwRef
 // and any other type.
-struct _HwObjectStruct
+struct _HwRefStruct
 {};
 
-typedef struct _HwObjectStruct* HwObject;
+typedef struct _HwRefStruct* HwRef;
 
 // Define special ids for singleton constants. These must be negative to
 // avoid being reused for other values.
-#define HW_ERROR ((HwObject)(-1))
-#define HW_UNDEFINED ((HwObject)(-2))
-#define HW_TRUE ((HwObject)(-3))
-#define HW_FALSE ((HwObject)(-4))
-#define HW_NULL ((HwObject)(-5))
+#define HW_ERROR ((HwRef)(-1))
+#define HW_UNDEFINED ((HwRef)(-2))
+#define HW_TRUE ((HwRef)(-3))
+#define HW_FALSE ((HwRef)(-4))
+#define HW_NULL ((HwRef)(-5))
 
 /**
  * Initialize the variables and functions required for hiwire.
@@ -50,21 +50,21 @@ hiwire_init();
  *
  * Returns: The new reference
  */
-HwObject
-hiwire_incref(HwObject idval);
+HwRef
+hiwire_incref(HwRef idval);
 
 /**
  * Decrease the reference count on an object.
  */
 void
-hiwire_decref(HwObject idval);
+hiwire_decref(HwRef idval);
 
 /**
  * Create a new Javascript integer with the given value.
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_int(int val);
 
 /**
@@ -72,7 +72,7 @@ hiwire_int(int val);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_double(double val);
 
 /**
@@ -81,7 +81,7 @@ hiwire_double(double val);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_string_ucs4(const char* ptr, int len);
 
 /**
@@ -90,7 +90,7 @@ hiwire_string_ucs4(const char* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_string_ucs2(const char* ptr, int len);
 
 /**
@@ -99,7 +99,7 @@ hiwire_string_ucs2(const char* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_string_ucs1(const char* ptr, int len);
 
 /**
@@ -108,7 +108,7 @@ hiwire_string_ucs1(const char* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_string_utf8(const char* ptr);
 
 /**
@@ -118,7 +118,7 @@ hiwire_string_utf8(const char* ptr);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_string_ascii(const char* ptr);
 
 /**
@@ -129,7 +129,7 @@ hiwire_string_ascii(const char* ptr);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_bytes(char* ptr, int len);
 
 /**
@@ -140,7 +140,7 @@ hiwire_bytes(char* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_int8array(i8* ptr, int len);
 
 /**
@@ -151,7 +151,7 @@ hiwire_int8array(i8* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_uint8array(u8* ptr, int len);
 
 /**
@@ -162,7 +162,7 @@ hiwire_uint8array(u8* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_int16array(i16* ptr, int len);
 
 /**
@@ -173,7 +173,7 @@ hiwire_int16array(i16* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_uint16array(u16* ptr, int len);
 
 /**
@@ -184,7 +184,7 @@ hiwire_uint16array(u16* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_int32array(i32* ptr, int len);
 
 /**
@@ -195,7 +195,7 @@ hiwire_int32array(i32* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_uint32array(u32* ptr, int len);
 
 /**
@@ -206,7 +206,7 @@ hiwire_uint32array(u32* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_float32array(f32* ptr, int len);
 
 /**
@@ -217,7 +217,7 @@ hiwire_float32array(f32* ptr, int len);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_float64array(f64* ptr, int len);
 
 /**
@@ -225,7 +225,7 @@ hiwire_float64array(f64* ptr, int len);
  *
  * Returns: "New" reference
  */
-HwObject
+HwRef
 hiwire_undefined();
 
 /**
@@ -233,7 +233,7 @@ hiwire_undefined();
  *
  * Returns: "New" reference
  */
-HwObject
+HwRef
 hiwire_null();
 
 /**
@@ -241,7 +241,7 @@ hiwire_null();
  *
  * Returns: "New" reference
  */
-HwObject
+HwRef
 hiwire_true();
 
 /**
@@ -249,7 +249,7 @@ hiwire_true();
  *
  * Returns: "New" reference
  */
-HwObject
+HwRef
 hiwire_false();
 
 /**
@@ -258,7 +258,7 @@ hiwire_false();
  *
  * Returns: "New" reference
  */
-HwObject
+HwRef
 hiwire_bool(bool boolean);
 
 /**
@@ -266,7 +266,7 @@ hiwire_bool(bool boolean);
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_array();
 
 /**
@@ -276,14 +276,14 @@ hiwire_array();
  * responsibility to decref it.
  */
 void
-hiwire_push_array(HwObject idobj, HwObject idval);
+hiwire_push_array(HwRef idobj, HwRef idval);
 
 /**
  * Create a new Javascript object.
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_object();
 
 /**
@@ -293,7 +293,7 @@ hiwire_object();
  * user's responsibility to decref them.
  */
 void
-hiwire_push_object_pair(HwObject idobj, HwObject idkey, HwObject idval);
+hiwire_push_object_pair(HwRef idobj, HwRef idkey, HwRef idval);
 
 /**
  * Throws a new Error object with the given message.
@@ -301,14 +301,14 @@ hiwire_push_object_pair(HwObject idobj, HwObject idkey, HwObject idval);
  * The message is conventionally a Javascript string, but that is not required.
  */
 void
-hiwire_throw_error(HwObject idmsg);
+hiwire_throw_error(HwRef idmsg);
 
 /**
  * Get a Javascript object from the global namespace, i.e. window.
  *
  * Returns: New reference
  */
-HwObject
+HwRef
 hiwire_get_global(const char* ptrname);
 
 /**
@@ -317,21 +317,21 @@ hiwire_get_global(const char* ptrname);
  *
  * Returns: New reference
  */
-HwObject
-hiwire_get_member_string(HwObject idobj, const char* ptrname);
+HwRef
+hiwire_get_member_string(HwRef idobj, const char* ptrname);
 
 /**
  * Set an object member by string.
  */
 void
-hiwire_set_member_string(HwObject idobj, const char* ptrname, HwObject idval);
+hiwire_set_member_string(HwRef idobj, const char* ptrname, HwRef idval);
 
 /**
  * Delete an object member by string.
  *
  */
 void
-hiwire_delete_member_string(HwObject idobj, const char* ptrname);
+hiwire_delete_member_string(HwRef idobj, const char* ptrname);
 
 /**
  * Get an object member by integer.
@@ -340,8 +340,8 @@ hiwire_delete_member_string(HwObject idobj, const char* ptrname);
  *
  * Returns: New reference
  */
-HwObject
-hiwire_get_member_int(HwObject idobj, int idx);
+HwRef
+hiwire_get_member_int(HwRef idobj, int idx);
 
 /**
  * Set an object member by integer.
@@ -350,36 +350,36 @@ hiwire_get_member_int(HwObject idobj, int idx);
  *
  */
 void
-hiwire_set_member_int(HwObject idobj, int idx, HwObject idval);
+hiwire_set_member_int(HwRef idobj, int idx, HwRef idval);
 
 /**
  * Get an object member by object.
  *
  * Returns: New reference
  */
-HwObject
-hiwire_get_member_obj(HwObject idobj, HwObject ididx);
+HwRef
+hiwire_get_member_obj(HwRef idobj, HwRef ididx);
 
 /**
  * Set an object member by object.
  *
  */
 void
-hiwire_set_member_obj(HwObject idobj, HwObject ididx, HwObject idval);
+hiwire_set_member_obj(HwRef idobj, HwRef ididx, HwRef idval);
 
 /**
  * Delete an object member by object.
  *
  */
 void
-hiwire_delete_member_obj(HwObject idobj, HwObject ididx);
+hiwire_delete_member_obj(HwRef idobj, HwRef ididx);
 
 /**
  * Get the methods on an object, both on itself and what it inherits.
  *
  */
-HwObject
-hiwire_dir(HwObject idobj);
+HwRef
+hiwire_dir(HwRef idobj);
 
 /**
  * Call a function
@@ -388,8 +388,8 @@ hiwire_dir(HwObject idobj);
  *
  * Returns: New reference
  */
-HwObject
-hiwire_call(HwObject idobj, HwObject idargs);
+HwRef
+hiwire_call(HwRef idobj, HwRef idargs);
 
 /**
  * Call a member function.
@@ -400,8 +400,8 @@ hiwire_call(HwObject idobj, HwObject idargs);
  *
  * Returns: New reference
  */
-HwObject
-hiwire_call_member(HwObject idobj, const char* ptrname, HwObject idargs);
+HwRef
+hiwire_call_member(HwRef idobj, const char* ptrname, HwRef idargs);
 
 /**
  * Calls the constructor of a class object.
@@ -410,8 +410,8 @@ hiwire_call_member(HwObject idobj, const char* ptrname, HwObject idargs);
  *
  * Returns: New reference
  */
-HwObject
-hiwire_new(HwObject idobj, HwObject idargs);
+HwRef
+hiwire_new(HwRef idobj, HwRef idargs);
 
 /**
  * Returns the value of the `length` member on a Javascript object.
@@ -419,7 +419,7 @@ hiwire_new(HwObject idobj, HwObject idargs);
  * Returns: C int
  */
 bool
-hiwire_get_length(HwObject idobj);
+hiwire_get_length(HwRef idobj);
 
 /**
  * Returns the boolean value of a Javascript object.
@@ -427,7 +427,7 @@ hiwire_get_length(HwObject idobj);
  * Returns: C int
  */
 bool
-hiwire_get_bool(HwObject idobj);
+hiwire_get_bool(HwRef idobj);
 
 /**
  * Returns 1 if the object is a function.
@@ -435,92 +435,92 @@ hiwire_get_bool(HwObject idobj);
  * Returns: C int
  */
 bool
-hiwire_is_function(HwObject idobj);
+hiwire_is_function(HwRef idobj);
 
 /**
  * Gets the string representation of an object by calling `toString`.
  *
  * Returns: New reference to Javascript string
  */
-HwObject
-hiwire_to_string(HwObject idobj);
+HwRef
+hiwire_to_string(HwRef idobj);
 
 /**
  * Gets the "typeof" string for a value.
  *
  * Returns: New reference to Javascript string
  */
-HwObject
-hiwire_typeof(HwObject idobj);
+HwRef
+hiwire_typeof(HwRef idobj);
 
 /**
  * Returns non-zero if a < b.
  */
 bool
-hiwire_less_than(HwObject ida, HwObject idb);
+hiwire_less_than(HwRef ida, HwRef idb);
 
 /**
  * Returns non-zero if a <= b.
  */
 bool
-hiwire_less_than_equal(HwObject ida, HwObject idb);
+hiwire_less_than_equal(HwRef ida, HwRef idb);
 
 /**
  * Returns non-zero if a == b.
  */
 bool
-hiwire_equal(HwObject ida, HwObject idb);
+hiwire_equal(HwRef ida, HwRef idb);
 
 /**
  * Returns non-zero if a != b.
  */
 bool
-hiwire_not_equal(HwObject idx, HwObject idb);
+hiwire_not_equal(HwRef idx, HwRef idb);
 
 /**
  * Returns non-zero if a > b.
  */
 bool
-hiwire_greater_than(HwObject ida, HwObject idb);
+hiwire_greater_than(HwRef ida, HwRef idb);
 
 /**
  * Returns non-zero if a >= b.
  */
 bool
-hiwire_greater_than_equal(HwObject ida, HwObject idb);
+hiwire_greater_than_equal(HwRef ida, HwRef idb);
 
 /**
  * Calls the `next` function on an iterator.
  *
  * Returns: HW_ERROR if `next` function is undefined.
  */
-HwObject
-hiwire_next(HwObject idobj);
+HwRef
+hiwire_next(HwRef idobj);
 
 /**
  * Returns the iterator associated with the given object, if any.
  */
-HwObject
-hiwire_get_iterator(HwObject idobj);
+HwRef
+hiwire_get_iterator(HwRef idobj);
 
 /**
  * Returns 1 if the value is non-zero.
  *
  */
 bool
-hiwire_nonzero(HwObject idobj);
+hiwire_nonzero(HwRef idobj);
 
 /**
  * Returns 1 if the value is a typedarray.
  */
 bool
-hiwire_is_typedarray(HwObject idobj);
+hiwire_is_typedarray(HwRef idobj);
 
 /**
  * Returns 1 if the value is a typedarray whose buffer is part of the WASM heap.
  */
 bool
-hiwire_is_on_wasm_heap(HwObject idobj);
+hiwire_is_on_wasm_heap(HwRef idobj);
 
 /**
  * Returns the value of obj.byteLength.
@@ -529,7 +529,7 @@ hiwire_is_on_wasm_heap(HwObject idobj);
  * true.
  */
 int
-hiwire_get_byteLength(HwObject idobj);
+hiwire_get_byteLength(HwRef idobj);
 
 /**
  * Returns the value of obj.byteOffset.
@@ -538,14 +538,14 @@ hiwire_get_byteLength(HwObject idobj);
  * true and hiwire_is_on_wasm_heap is true.
  */
 int
-hiwire_get_byteOffset(HwObject idobj);
+hiwire_get_byteOffset(HwRef idobj);
 
 /**
  * Copies the buffer contents of a given typed array or buffer into the memory
  * at ptr.
  */
 void
-hiwire_copy_to_ptr(HwObject idobj, int ptr);
+hiwire_copy_to_ptr(HwRef idobj, int ptr);
 
 #define INT8_TYPE 1
 #define UINT8_TYPE 2
@@ -564,12 +564,12 @@ hiwire_copy_to_ptr(HwObject idobj, int ptr);
  * UINT16_TYPE, INT32_TYPE, UINT32_TYPE, FLOAT32_TYPE, FLOAT64_TYPE.
  */
 int
-hiwire_get_dtype(HwObject idobj);
+hiwire_get_dtype(HwRef idobj);
 
 /**
  * Get a subarray from a TypedArray
  */
-HwObject
-hiwire_subarray(HwObject idarr, int start, int end);
+HwRef
+hiwire_subarray(HwRef idarr, int start, int end);
 
 #endif /* HIWIRE_H */

--- a/src/type_conversion/hiwire.h
+++ b/src/type_conversion/hiwire.h
@@ -1,5 +1,6 @@
 #ifndef HIWIRE_H
 #define HIWIRE_H
+#include "stdalign.h"
 #include "types.h"
 
 /**
@@ -15,18 +16,18 @@
  * object. There may be one or more keys pointing to the same object.
  */
 
-NEWTYPE(HwObject, int);
+struct _HwObjectStruct
+{};
+
+typedef struct _HwObjectStruct* HwObject;
 
 // Define special ids for singleton constants. These must be negative to
 // avoid being reused for other values.
-#define HW_ERROR TO_NT(HwObject, -1)
-#define HW_UNDEFINED TO_NT(HwObject, -2)
-#define HW_TRUE TO_NT(HwObject, -3)
-#define HW_FALSE TO_NT(HwObject, -4)
-#define HW_NULL TO_NT(HwObject, -5)
-
-bool
-hw_is_error(HwObject key);
+#define HW_ERROR ((HwObject)(-1))
+#define HW_UNDEFINED ((HwObject)(-2))
+#define HW_TRUE ((HwObject)(-3))
+#define HW_FALSE ((HwObject)(-4))
+#define HW_NULL ((HwObject)(-5))
 
 /**
  * Initialize the variables and functions required for hiwire.

--- a/src/type_conversion/js2python.c
+++ b/src/type_conversion/js2python.c
@@ -60,27 +60,27 @@ _js2python_pyproxy(PyObject* val)
 }
 
 PyObject*
-_js2python_memoryview(HwObject id)
+_js2python_memoryview(HwRef id)
 {
   PyObject* jsproxy = JsProxy_cnew(id);
   return PyMemoryView_FromObject(jsproxy);
 }
 
 PyObject*
-_js2python_jsproxy(HwObject id)
+_js2python_jsproxy(HwRef id)
 {
   return JsProxy_cnew(id);
 }
 
 PyObject*
-_js2python_error(HwObject id)
+_js2python_error(HwRef id)
 {
   return JsProxy_new_error(id);
 }
 
 // TODO: Add some meaningful order
 
-EM_JS(PyObject*, __js2python, (HwObject id), {
+EM_JS(PyObject*, __js2python, (HwRef id), {
   function __js2python_string(value)
   {
     // The general idea here is to allocate a Python string and then
@@ -159,7 +159,7 @@ EM_JS(PyObject*, __js2python, (HwObject id), {
 });
 
 PyObject*
-js2python(HwObject id)
+js2python(HwRef id)
 {
   return (PyObject*)__js2python(id);
 }

--- a/src/type_conversion/js2python.c
+++ b/src/type_conversion/js2python.c
@@ -60,27 +60,27 @@ _js2python_pyproxy(PyObject* val)
 }
 
 PyObject*
-_js2python_memoryview(HwRef id)
+_js2python_memoryview(JsRef id)
 {
   PyObject* jsproxy = JsProxy_cnew(id);
   return PyMemoryView_FromObject(jsproxy);
 }
 
 PyObject*
-_js2python_jsproxy(HwRef id)
+_js2python_jsproxy(JsRef id)
 {
   return JsProxy_cnew(id);
 }
 
 PyObject*
-_js2python_error(HwRef id)
+_js2python_error(JsRef id)
 {
   return JsProxy_new_error(id);
 }
 
 // TODO: Add some meaningful order
 
-EM_JS(PyObject*, __js2python, (HwRef id), {
+EM_JS(PyObject*, __js2python, (JsRef id), {
   function __js2python_string(value)
   {
     // The general idea here is to allocate a Python string and then
@@ -159,7 +159,7 @@ EM_JS(PyObject*, __js2python, (HwRef id), {
 });
 
 PyObject*
-js2python(HwRef id)
+js2python(JsRef id)
 {
   return (PyObject*)__js2python(id);
 }

--- a/src/type_conversion/js2python.c
+++ b/src/type_conversion/js2python.c
@@ -8,79 +8,79 @@
 // Since we're going *to* Python, just let any Python exceptions at conversion
 // bubble out to Python
 
-int
+PyObject*
 _js2python_allocate_string(int size, int max_code_point)
 {
-  return (int)PyUnicode_New(size, max_code_point);
+  return PyUnicode_New(size, max_code_point);
 }
 
-int
-_js2python_get_ptr(int obj)
+void*
+_js2python_get_ptr(PyObject* obj)
 {
-  return (int)PyUnicode_DATA((PyObject*)obj);
+  return PyUnicode_DATA(obj);
 }
 
-int
+PyObject*
 _js2python_number(double val)
 {
   double i;
 
   if (modf(val, &i) == 0.0)
-    return (int)PyLong_FromDouble(i);
+    return PyLong_FromDouble(i);
 
-  return (int)PyFloat_FromDouble(val);
+  return PyFloat_FromDouble(val);
 }
 
-int
+PyObject*
 _js2python_none()
 {
   Py_INCREF(Py_None);
-  return (int)Py_None;
+  return Py_None;
 }
 
-int
+PyObject*
 _js2python_true()
 {
   Py_INCREF(Py_True);
-  return (int)Py_True;
+  return Py_True;
 }
 
-int
+PyObject*
 _js2python_false()
 {
   Py_INCREF(Py_False);
-  return (int)Py_False;
+  return Py_False;
 }
 
-int
+PyObject*
 _js2python_pyproxy(PyObject* val)
 {
   Py_INCREF(val);
-  return (int)val;
+  return val;
 }
 
-int
-_js2python_memoryview(int id)
+PyObject*
+_js2python_memoryview(HwObject id)
 {
   PyObject* jsproxy = JsProxy_cnew(id);
-  return (int)PyMemoryView_FromObject(jsproxy);
+  return PyMemoryView_FromObject(jsproxy);
 }
 
-int
-_js2python_jsproxy(int id)
+PyObject*
+_js2python_jsproxy(HwObject id)
 {
-  return (int)JsProxy_cnew(id);
+  return JsProxy_cnew(id);
 }
 
-int
-_js2python_error(int id)
+PyObject*
+_js2python_error(HwObject id)
 {
-  return (int)JsProxy_new_error(id);
+  return JsProxy_new_error(id);
 }
 
 // TODO: Add some meaningful order
 
-EM_JS(int, __js2python, (int id), {
+EM_JS(PyObject*, __js2python, (HwObject id), {
   function __js2python_string(value)
   {
     // The general idea here is to allocate a Python string and then
@@ -150,7 +150,7 @@ EM_JS(int, __js2python, (int id), {
     return __js2python_pyproxy(Module.PyProxy.getPtr(value));
   } else if (value['byteLength'] !== undefined) {
     return __js2python_memoryview(id);
-  } else if (is_error(value)) { 
+  } else if (is_error(value)) {
     return __js2python_error(id);
   } else {
     return __js2python_jsproxy(id);
@@ -159,7 +159,7 @@ EM_JS(int, __js2python, (int id), {
 });
 
 PyObject*
-js2python(int id)
+js2python(HwObject id)
 {
   return (PyObject*)__js2python(id);
 }

--- a/src/type_conversion/js2python.h
+++ b/src/type_conversion/js2python.h
@@ -15,7 +15,7 @@
  *    used to obtain the exception.
  */
 PyObject*
-js2python(HwObject x);
+js2python(HwRef x);
 
 /** Initialize any global variables used by this module. */
 int

--- a/src/type_conversion/js2python.h
+++ b/src/type_conversion/js2python.h
@@ -5,6 +5,7 @@
  * Utilities to convert Javascript objects to Python objects.
  */
 
+#include "hiwire.h"
 #include <Python.h>
 
 /** Convert a Javascript object to a Python object.
@@ -14,7 +15,7 @@
  *    used to obtain the exception.
  */
 PyObject*
-js2python(int x);
+js2python(HwObject x);
 
 /** Initialize any global variables used by this module. */
 int

--- a/src/type_conversion/js2python.h
+++ b/src/type_conversion/js2python.h
@@ -15,7 +15,7 @@
  *    used to obtain the exception.
  */
 PyObject*
-js2python(HwRef x);
+js2python(JsRef x);
 
 /** Initialize any global variables used by this module. */
 int

--- a/src/type_conversion/jsimport.c
+++ b/src/type_conversion/jsimport.c
@@ -14,8 +14,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
   if (c == NULL) {
     return NULL;
   }
-  hwkey idval = hiwire_get_global(c);
-  if (hw_is_error(idval)) {
+  HwObject idval = hiwire_get_global(c);
+  if (idval == HW_ERROR) {
     PyErr_Format(PyExc_AttributeError, "Unknown attribute '%s'", c);
     return NULL;
   }
@@ -27,8 +27,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
 static PyObject*
 JsImport_Dir()
 {
-  hwkey idwindow = hiwire_get_global("self");
-  hwkey iddir = hiwire_dir(idwindow);
+  HwObject idwindow = hiwire_get_global("self");
+  HwObject iddir = hiwire_dir(idwindow);
   hiwire_decref(idwindow);
   PyObject* pydir = js2python(iddir);
   hiwire_decref(iddir);

--- a/src/type_conversion/jsimport.c
+++ b/src/type_conversion/jsimport.c
@@ -14,7 +14,7 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
   if (c == NULL) {
     return NULL;
   }
-  HwObject idval = hiwire_get_global(c);
+  HwRef idval = hiwire_get_global(c);
   if (idval == HW_ERROR) {
     PyErr_Format(PyExc_AttributeError, "Unknown attribute '%s'", c);
     return NULL;
@@ -27,8 +27,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
 static PyObject*
 JsImport_Dir()
 {
-  HwObject idwindow = hiwire_get_global("self");
-  HwObject iddir = hiwire_dir(idwindow);
+  HwRef idwindow = hiwire_get_global("self");
+  HwRef iddir = hiwire_dir(idwindow);
   hiwire_decref(idwindow);
   PyObject* pydir = js2python(iddir);
   hiwire_decref(iddir);

--- a/src/type_conversion/jsimport.c
+++ b/src/type_conversion/jsimport.c
@@ -14,8 +14,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
   if (c == NULL) {
     return NULL;
   }
-  HwRef idval = hiwire_get_global(c);
-  if (idval == HW_ERROR) {
+  JsRef idval = hiwire_get_global(c);
+  if (idval == Js_ERROR) {
     PyErr_Format(PyExc_AttributeError, "Unknown attribute '%s'", c);
     return NULL;
   }
@@ -27,8 +27,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
 static PyObject*
 JsImport_Dir()
 {
-  HwRef idwindow = hiwire_get_global("self");
-  HwRef iddir = hiwire_dir(idwindow);
+  JsRef idwindow = hiwire_get_global("self");
+  JsRef iddir = hiwire_dir(idwindow);
   hiwire_decref(idwindow);
   PyObject* pydir = js2python(iddir);
   hiwire_decref(iddir);

--- a/src/type_conversion/jsimport.c
+++ b/src/type_conversion/jsimport.c
@@ -14,8 +14,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
   if (c == NULL) {
     return NULL;
   }
-  int idval = hiwire_get_global((int)c);
-  if (idval == -1) {
+  hwkey idval = hiwire_get_global(c);
+  if (hw_is_error(idval)) {
     PyErr_Format(PyExc_AttributeError, "Unknown attribute '%s'", c);
     return NULL;
   }
@@ -27,8 +27,8 @@ JsImport_GetAttr(PyObject* self, PyObject* attr)
 static PyObject*
 JsImport_Dir()
 {
-  int idwindow = hiwire_get_global((int)"self");
-  int iddir = hiwire_dir(idwindow);
+  hwkey idwindow = hiwire_get_global("self");
+  hwkey iddir = hiwire_dir(idwindow);
   hiwire_decref(idwindow);
   PyObject* pydir = js2python(iddir);
   hiwire_decref(iddir);

--- a/src/type_conversion/jsproxy.c
+++ b/src/type_conversion/jsproxy.c
@@ -70,7 +70,7 @@ JsProxy_GetAttr(PyObject* o, PyObject* attr_name)
   HwObject idresult = hiwire_get_member_string(self->js, key);
   Py_DECREF(str);
 
-  if (hw_is_error(idresult)) {
+  if (idresult == HW_ERROR) {
     PyErr_SetString(PyExc_AttributeError, key);
     return NULL;
   }
@@ -192,7 +192,7 @@ JsProxy_GetIter(PyObject* o)
 
   HwObject iditer = hiwire_get_iterator(self->js);
 
-  if (hw_is_error(iditer)) {
+  if (iditer == HW_ERROR) {
     PyErr_SetString(PyExc_TypeError, "Object is not iterable");
     return NULL;
   }
@@ -206,7 +206,7 @@ JsProxy_IterNext(PyObject* o)
   JsProxy* self = (JsProxy*)o;
 
   HwObject idresult = hiwire_next(self->js);
-  if (hw_is_error(idresult)) {
+  if (idresult == HW_ERROR) {
     return NULL;
   }
 
@@ -263,7 +263,7 @@ JsProxy_subscript(PyObject* o, PyObject* pyidx)
   HwObject ididx = python2js(pyidx);
   HwObject idresult = hiwire_get_member_obj(self->js, ididx);
   hiwire_decref(ididx);
-  if (hw_is_error(idresult)) {
+  if (idresult == HW_ERROR) {
     PyErr_SetObject(PyExc_KeyError, pyidx);
     return NULL;
   }

--- a/src/type_conversion/jsproxy.c
+++ b/src/type_conversion/jsproxy.c
@@ -10,7 +10,7 @@
 static PyTypeObject* PyExc_BaseException_Type;
 
 static PyObject*
-JsBoundMethod_cnew(HwRef this_, const char* name);
+JsBoundMethod_cnew(JsRef this_, const char* name);
 
 ////////////////////////////////////////////////////////////
 // JsProxy
@@ -22,7 +22,7 @@ JsBoundMethod_cnew(HwRef this_, const char* name);
 typedef struct
 {
   PyObject_HEAD
-  HwRef js;
+  JsRef js;
   PyObject* bytes;
 } JsProxy;
 // clang-format on
@@ -39,7 +39,7 @@ static PyObject*
 JsProxy_Repr(PyObject* o)
 {
   JsProxy* self = (JsProxy*)o;
-  HwRef idrepr = hiwire_to_string(self->js);
+  JsRef idrepr = hiwire_to_string(self->js);
   PyObject* pyrepr = js2python(idrepr);
   return pyrepr;
 }
@@ -61,16 +61,16 @@ JsProxy_GetAttr(PyObject* o, PyObject* attr_name)
     return PyObject_GenericGetAttr(o, attr_name);
   } else if (strncmp(key, "typeof", 7) == 0) {
     Py_DECREF(str);
-    HwRef idval = hiwire_typeof(self->js);
+    JsRef idval = hiwire_typeof(self->js);
     PyObject* result = js2python(idval);
     hiwire_decref(idval);
     return result;
   }
 
-  HwRef idresult = hiwire_get_member_string(self->js, key);
+  JsRef idresult = hiwire_get_member_string(self->js, key);
   Py_DECREF(str);
 
-  if (idresult == HW_ERROR) {
+  if (idresult == Js_ERROR) {
     PyErr_SetString(PyExc_AttributeError, key);
     return NULL;
   }
@@ -99,7 +99,7 @@ JsProxy_SetAttr(PyObject* o, PyObject* attr_name, PyObject* pyvalue)
   if (pyvalue == NULL) {
     hiwire_delete_member_string(self->js, key);
   } else {
-    HwRef idvalue = python2js(pyvalue);
+    JsRef idvalue = python2js(pyvalue);
     hiwire_set_member_string(self->js, key, idvalue);
     hiwire_decref(idvalue);
   }
@@ -115,21 +115,21 @@ JsProxy_Call(PyObject* o, PyObject* args, PyObject* kwargs)
 
   Py_ssize_t nargs = PyTuple_Size(args);
 
-  HwRef idargs = hiwire_array();
+  JsRef idargs = hiwire_array();
 
   for (Py_ssize_t i = 0; i < nargs; ++i) {
-    HwRef idarg = python2js(PyTuple_GET_ITEM(args, i));
+    JsRef idarg = python2js(PyTuple_GET_ITEM(args, i));
     hiwire_push_array(idargs, idarg);
     hiwire_decref(idarg);
   }
 
   if (PyDict_Size(kwargs)) {
-    HwRef idkwargs = python2js(kwargs);
+    JsRef idkwargs = python2js(kwargs);
     hiwire_push_array(idargs, idkwargs);
     hiwire_decref(idkwargs);
   }
 
-  HwRef idresult = hiwire_call(self->js, idargs);
+  JsRef idresult = hiwire_call(self->js, idargs);
   hiwire_decref(idargs);
   PyObject* pyresult = js2python(idresult);
   hiwire_decref(idresult);
@@ -153,8 +153,8 @@ JsProxy_RichCompare(PyObject* a, PyObject* b, int op)
   }
 
   int result;
-  HwRef ida = python2js(a);
-  HwRef idb = python2js(b);
+  JsRef ida = python2js(a);
+  JsRef idb = python2js(b);
   switch (op) {
     case Py_LT:
       result = hiwire_less_than(ida, idb);
@@ -190,9 +190,9 @@ JsProxy_GetIter(PyObject* o)
 {
   JsProxy* self = (JsProxy*)o;
 
-  HwRef iditer = hiwire_get_iterator(self->js);
+  JsRef iditer = hiwire_get_iterator(self->js);
 
-  if (iditer == HW_ERROR) {
+  if (iditer == Js_ERROR) {
     PyErr_SetString(PyExc_TypeError, "Object is not iterable");
     return NULL;
   }
@@ -205,18 +205,18 @@ JsProxy_IterNext(PyObject* o)
 {
   JsProxy* self = (JsProxy*)o;
 
-  HwRef idresult = hiwire_next(self->js);
-  if (idresult == HW_ERROR) {
+  JsRef idresult = hiwire_next(self->js);
+  if (idresult == Js_ERROR) {
     return NULL;
   }
 
-  HwRef iddone = hiwire_get_member_string(idresult, "done");
+  JsRef iddone = hiwire_get_member_string(idresult, "done");
   int done = hiwire_nonzero(iddone);
   hiwire_decref(iddone);
 
   PyObject* pyvalue = NULL;
   if (!done) {
-    HwRef idvalue = hiwire_get_member_string(idresult, "value");
+    JsRef idvalue = hiwire_get_member_string(idresult, "value");
     pyvalue = js2python(idvalue);
     hiwire_decref(idvalue);
   }
@@ -232,15 +232,15 @@ JsProxy_New(PyObject* o, PyObject* args, PyObject* kwargs)
 
   Py_ssize_t nargs = PyTuple_Size(args);
 
-  HwRef idargs = hiwire_array();
+  JsRef idargs = hiwire_array();
 
   for (Py_ssize_t i = 0; i < nargs; ++i) {
-    HwRef idarg = python2js(PyTuple_GET_ITEM(args, i));
+    JsRef idarg = python2js(PyTuple_GET_ITEM(args, i));
     hiwire_push_array(idargs, idarg);
     hiwire_decref(idarg);
   }
 
-  HwRef idresult = hiwire_new(self->js, idargs);
+  JsRef idresult = hiwire_new(self->js, idargs);
   hiwire_decref(idargs);
   PyObject* pyresult = js2python(idresult);
   hiwire_decref(idresult);
@@ -260,10 +260,10 @@ JsProxy_subscript(PyObject* o, PyObject* pyidx)
 {
   JsProxy* self = (JsProxy*)o;
 
-  HwRef ididx = python2js(pyidx);
-  HwRef idresult = hiwire_get_member_obj(self->js, ididx);
+  JsRef ididx = python2js(pyidx);
+  JsRef idresult = hiwire_get_member_obj(self->js, ididx);
   hiwire_decref(ididx);
-  if (idresult == HW_ERROR) {
+  if (idresult == Js_ERROR) {
     PyErr_SetObject(PyExc_KeyError, pyidx);
     return NULL;
   }
@@ -276,11 +276,11 @@ static int
 JsProxy_ass_subscript(PyObject* o, PyObject* pyidx, PyObject* pyvalue)
 {
   JsProxy* self = (JsProxy*)o;
-  HwRef ididx = python2js(pyidx);
+  JsRef ididx = python2js(pyidx);
   if (pyvalue == NULL) {
     hiwire_delete_member_obj(self->js, ididx);
   } else {
-    HwRef idvalue = python2js(pyvalue);
+    JsRef idvalue = python2js(pyvalue);
     hiwire_set_member_obj(self->js, ididx, idvalue);
     hiwire_decref(idvalue);
   }
@@ -396,7 +396,7 @@ JsProxy_Dir(PyObject* o)
 {
   JsProxy* self = (JsProxy*)o;
 
-  HwRef iddir = hiwire_dir(self->js);
+  JsRef iddir = hiwire_dir(self->js);
   PyObject* pydir = js2python(iddir);
   hiwire_decref(iddir);
   return pydir;
@@ -466,7 +466,7 @@ static PyTypeObject JsProxyType = {
 };
 
 PyObject*
-JsProxy_cnew(HwRef idobj)
+JsProxy_cnew(JsRef idobj)
 {
   JsProxy* self;
   self = (JsProxy*)JsProxyType.tp_alloc(&JsProxyType, 0);
@@ -558,7 +558,7 @@ static PyTypeObject _Exc_JsException = {
 static PyObject* Exc_JsException = (PyObject*)&_Exc_JsException;
 
 PyObject*
-JsProxy_new_error(HwRef idobj)
+JsProxy_new_error(JsRef idobj)
 {
   PyObject* proxy = JsProxy_cnew(idobj);
   PyObject* result = PyObject_CallFunctionObjArgs(Exc_JsException, proxy, NULL);
@@ -572,7 +572,7 @@ JsProxy_new_error(HwRef idobj)
 
 typedef struct
 {
-  PyObject_HEAD HwRef this_;
+  PyObject_HEAD JsRef this_;
   const char* name;
 } JsBoundMethod;
 
@@ -590,15 +590,15 @@ JsBoundMethod_Call(PyObject* o, PyObject* args, PyObject* kwargs)
 
   Py_ssize_t nargs = PyTuple_Size(args);
 
-  HwRef idargs = hiwire_array();
+  JsRef idargs = hiwire_array();
 
   for (Py_ssize_t i = 0; i < nargs; ++i) {
-    HwRef idarg = python2js(PyTuple_GET_ITEM(args, i));
+    JsRef idarg = python2js(PyTuple_GET_ITEM(args, i));
     hiwire_push_array(idargs, idarg);
     hiwire_decref(idarg);
   }
 
-  HwRef idresult = hiwire_call_member(self->this_, self->name, idargs);
+  JsRef idresult = hiwire_call_member(self->this_, self->name, idargs);
   hiwire_decref(idargs);
   PyObject* pyresult = js2python(idresult);
   hiwire_decref(idresult);
@@ -616,7 +616,7 @@ static PyTypeObject JsBoundMethodType = {
 };
 
 static PyObject*
-JsBoundMethod_cnew(HwRef this_, const char* name)
+JsBoundMethod_cnew(JsRef this_, const char* name)
 {
   JsBoundMethod* self;
   self = (JsBoundMethod*)JsBoundMethodType.tp_alloc(&JsBoundMethodType, 0);
@@ -635,7 +635,7 @@ JsProxy_Check(PyObject* x)
           PyObject_TypeCheck(x, &JsBoundMethodType));
 }
 
-HwRef
+JsRef
 JsProxy_AsJs(PyObject* x)
 {
   JsProxy* js_proxy = (JsProxy*)x;
@@ -648,7 +648,7 @@ JsException_Check(PyObject* x)
   return PyObject_TypeCheck(x, (PyTypeObject*)Exc_JsException);
 }
 
-HwRef
+JsRef
 JsException_AsJs(PyObject* err)
 {
   JsExceptionObject* err_obj = (JsExceptionObject*)err;

--- a/src/type_conversion/jsproxy.h
+++ b/src/type_conversion/jsproxy.h
@@ -13,14 +13,14 @@
  *  \return The Python object wrapping the Javascript object.
  */
 PyObject*
-JsProxy_cnew(HwObject v);
+JsProxy_cnew(HwRef v);
 
 /** Make a new JsProxy Error.
  *  \param v The Javascript error object.
  *  \return The Python error object wrapping the Javascript error object.
  */
 PyObject*
-JsProxy_new_error(HwObject v);
+JsProxy_new_error(HwRef v);
 
 /** Check if a Python object is a JsProxy object.
  *  \param x The Python object
@@ -33,7 +33,7 @@ JsProxy_Check(PyObject* x);
  *  \param x The JsProxy object.  Must confirm that it is a JsProxy object using
  *    JsProxy_Check. \return The Javascript object.
  */
-HwObject
+HwRef
 JsProxy_AsJs(PyObject* x);
 
 /** Check if a Python object is a JsException object.
@@ -47,7 +47,7 @@ JsException_Check(PyObject* x);
  *  \param x The JsProxy object.  Must confirm that it is a JsException object
  * using JsProxy_Check. \return The Javascript object.
  */
-HwObject
+HwRef
 JsException_AsJs(PyObject* x);
 
 /** Initialize global state for the JsProxy functionality. */

--- a/src/type_conversion/jsproxy.h
+++ b/src/type_conversion/jsproxy.h
@@ -1,5 +1,6 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
+#include "hiwire.h"
 
 /** A Python object that a Javascript object inside. Used for any non-standard
  *  data types that are passed from Javascript to Python.
@@ -12,41 +13,41 @@
  *  \return The Python object wrapping the Javascript object.
  */
 PyObject*
-JsProxy_cnew(int v);
+JsProxy_cnew(HwObject v);
 
 /** Make a new JsProxy Error.
  *  \param v The Javascript error object.
  *  \return The Python error object wrapping the Javascript error object.
  */
 PyObject*
-JsProxy_new_error(int v);
+JsProxy_new_error(HwObject v);
 
 /** Check if a Python object is a JsProxy object.
  *  \param x The Python object
- *  \return 1 if the object is a JsProxy object.
+ *  \return true if the object is a JsProxy object.
  */
-int
+bool
 JsProxy_Check(PyObject* x);
 
 /** Grab the underlying Javascript object from the JsProxy object.
  *  \param x The JsProxy object.  Must confirm that it is a JsProxy object using
  *    JsProxy_Check. \return The Javascript object.
  */
-int
+HwObject
 JsProxy_AsJs(PyObject* x);
 
 /** Check if a Python object is a JsException object.
  *  \param x The Python object
  *  \return 1 if the object is a JsException object.
  */
-int
+bool
 JsException_Check(PyObject* x);
 
 /** Grab the underlying Javascript error from the JsException object.
  *  \param x The JsProxy object.  Must confirm that it is a JsException object
  * using JsProxy_Check. \return The Javascript object.
  */
-int
+HwObject
 JsException_AsJs(PyObject* x);
 
 /** Initialize global state for the JsProxy functionality. */

--- a/src/type_conversion/jsproxy.h
+++ b/src/type_conversion/jsproxy.h
@@ -13,14 +13,14 @@
  *  \return The Python object wrapping the Javascript object.
  */
 PyObject*
-JsProxy_cnew(HwRef v);
+JsProxy_cnew(JsRef v);
 
 /** Make a new JsProxy Error.
  *  \param v The Javascript error object.
  *  \return The Python error object wrapping the Javascript error object.
  */
 PyObject*
-JsProxy_new_error(HwRef v);
+JsProxy_new_error(JsRef v);
 
 /** Check if a Python object is a JsProxy object.
  *  \param x The Python object
@@ -33,7 +33,7 @@ JsProxy_Check(PyObject* x);
  *  \param x The JsProxy object.  Must confirm that it is a JsProxy object using
  *    JsProxy_Check. \return The Javascript object.
  */
-HwRef
+JsRef
 JsProxy_AsJs(PyObject* x);
 
 /** Check if a Python object is a JsException object.
@@ -47,7 +47,7 @@ JsException_Check(PyObject* x);
  *  \param x The JsProxy object.  Must confirm that it is a JsException object
  * using JsProxy_Check. \return The Javascript object.
  */
-HwRef
+JsRef
 JsException_AsJs(PyObject* x);
 
 /** Initialize global state for the JsProxy functionality. */

--- a/src/type_conversion/pyimport.c
+++ b/src/type_conversion/pyimport.c
@@ -7,7 +7,7 @@
 
 extern PyObject* globals;
 
-HwRef
+JsRef
 _pyimport(char* name)
 {
   PyObject* pyname = PyUnicode_FromString(name);
@@ -15,11 +15,11 @@ _pyimport(char* name)
   if (pyval == NULL) {
     Py_DECREF(pyname);
     pythonexc2js();
-    return HW_ERROR;
+    return Js_ERROR;
   }
 
   Py_DECREF(pyname);
-  HwRef idval = python2js(pyval);
+  JsRef idval = python2js(pyval);
   return idval;
 }
 

--- a/src/type_conversion/pyimport.c
+++ b/src/type_conversion/pyimport.c
@@ -7,7 +7,7 @@
 
 extern PyObject* globals;
 
-HwObject
+HwRef
 _pyimport(char* name)
 {
   PyObject* pyname = PyUnicode_FromString(name);
@@ -19,7 +19,7 @@ _pyimport(char* name)
   }
 
   Py_DECREF(pyname);
-  HwObject idval = python2js(pyval);
+  HwRef idval = python2js(pyval);
   return idval;
 }
 

--- a/src/type_conversion/pyimport.c
+++ b/src/type_conversion/pyimport.c
@@ -7,18 +7,19 @@
 
 extern PyObject* globals;
 
-int
+HwObject
 _pyimport(char* name)
 {
   PyObject* pyname = PyUnicode_FromString(name);
   PyObject* pyval = PyDict_GetItem(globals, pyname);
   if (pyval == NULL) {
     Py_DECREF(pyname);
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
   Py_DECREF(pyname);
-  int idval = python2js(pyval);
+  HwObject idval = python2js(pyval);
   return idval;
 }
 

--- a/src/type_conversion/pyproxy.c
+++ b/src/type_conversion/pyproxy.c
@@ -5,20 +5,18 @@
 #include "js2python.h"
 #include "python2js.h"
 
-int
-_pyproxy_has(int ptrobj, int idkey)
+HwObject
+_pyproxy_has(PyObject* pyobj, HwObject idkey)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
   PyObject* pykey = js2python(idkey);
-  int result = hiwire_bool(PyObject_HasAttr(pyobj, pykey));
+  HwObject result = hiwire_bool(PyObject_HasAttr(pyobj, pykey));
   Py_DECREF(pykey);
   return result;
 }
 
-int
-_pyproxy_get(int ptrobj, int idkey)
+HwObject
+_pyproxy_get(PyObject* pyobj, HwObject idkey)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
   PyObject* pykey = js2python(idkey);
   PyObject* pyattr = PyObject_GetAttr(pyobj, pykey);
   Py_DECREF(pykey);
@@ -27,15 +25,14 @@ _pyproxy_get(int ptrobj, int idkey)
     return hiwire_undefined();
   }
 
-  int idattr = python2js(pyattr);
+  HwObject idattr = python2js(pyattr);
   Py_DECREF(pyattr);
   return idattr;
 };
 
-int
-_pyproxy_set(int ptrobj, int idkey, int idval)
+HwObject
+_pyproxy_set(PyObject* pyobj, HwObject idkey, HwObject idval)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
   PyObject* pykey = js2python(idkey);
   PyObject* pyval = js2python(idval);
   int result = PyObject_SetAttr(pyobj, pykey, pyval);
@@ -43,42 +40,43 @@ _pyproxy_set(int ptrobj, int idkey, int idval)
   Py_DECREF(pyval);
 
   if (result) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
   return idval;
 }
 
-int
-_pyproxy_deleteProperty(int ptrobj, int idkey)
+HwObject
+_pyproxy_deleteProperty(PyObject* pyobj, HwObject idkey)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
   PyObject* pykey = js2python(idkey);
 
   int ret = PyObject_DelAttr(pyobj, pykey);
   Py_DECREF(pykey);
 
   if (ret) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
   return hiwire_undefined();
 }
 
-int
-_pyproxy_ownKeys(int ptrobj)
+HwObject
+_pyproxy_ownKeys(PyObject* pyobj)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
   PyObject* pydir = PyObject_Dir(pyobj);
 
   if (pydir == NULL) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
-  int iddir = hiwire_array();
+  HwObject iddir = hiwire_array();
   Py_ssize_t n = PyList_Size(pydir);
   for (Py_ssize_t i = 0; i < n; ++i) {
     PyObject* pyentry = PyList_GetItem(pydir, i);
-    int identry = python2js(pyentry);
+    HwObject identry = python2js(pyentry);
     hiwire_push_array(iddir, identry);
     hiwire_decref(identry);
   }
@@ -87,20 +85,19 @@ _pyproxy_ownKeys(int ptrobj)
   return iddir;
 }
 
-int
-_pyproxy_enumerate(int ptrobj)
+HwObject
+_pyproxy_enumerate(PyObject* pyobj)
 {
-  return _pyproxy_ownKeys(ptrobj);
+  return _pyproxy_ownKeys(pyobj);
 }
 
-int
-_pyproxy_apply(int ptrobj, int idargs)
+HwObject
+_pyproxy_apply(PyObject* pyobj, HwObject idargs)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
   Py_ssize_t length = hiwire_get_length(idargs);
   PyObject* pyargs = PyTuple_New(length);
   for (Py_ssize_t i = 0; i < length; ++i) {
-    int iditem = hiwire_get_member_int(idargs, i);
+    HwObject iditem = hiwire_get_member_int(idargs, i);
     PyObject* pyitem = js2python(iditem);
     PyTuple_SET_ITEM(pyargs, i, pyitem);
     hiwire_decref(iditem);
@@ -108,33 +105,34 @@ _pyproxy_apply(int ptrobj, int idargs)
   PyObject* pyresult = PyObject_Call(pyobj, pyargs, NULL);
   if (pyresult == NULL) {
     Py_DECREF(pyargs);
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
-  int idresult = python2js(pyresult);
+  HwObject idresult = python2js(pyresult);
   Py_DECREF(pyresult);
   Py_DECREF(pyargs);
   return idresult;
 }
 
 void
-_pyproxy_destroy(int ptrobj)
+_pyproxy_destroy(PyObject* ptrobj)
 {
-  PyObject* pyobj = (PyObject*)ptrobj;
+  PyObject* pyobj = ptrobj;
   Py_DECREF(ptrobj);
   EM_ASM(delete Module.PyProxies[ptrobj];);
 }
 
-EM_JS(int, pyproxy_use, (int ptrobj), {
+EM_JS(HwObject, pyproxy_use, (PyObject * ptrobj), {
   // Checks if there is already an existing proxy on ptrobj
 
   if (Module.PyProxies.hasOwnProperty(ptrobj)) {
     return Module.hiwire.new_value(Module.PyProxies[ptrobj]);
   }
 
-  return Module.hiwire.UNDEFINED;
+  return Module.hiwire.ERROR;
 })
 
-EM_JS(int, pyproxy_new, (int ptrobj), {
+EM_JS(HwObject, pyproxy_new, (PyObject * ptrobj), {
   // Technically, this leaks memory, since we're holding on to a reference
   // to the proxy forever.  But we have that problem anyway since we don't
   // have a destructor in Javascript to free the Python object.

--- a/src/type_conversion/pyproxy.c
+++ b/src/type_conversion/pyproxy.c
@@ -5,17 +5,17 @@
 #include "js2python.h"
 #include "python2js.h"
 
-HwObject
-_pyproxy_has(PyObject* pyobj, HwObject idkey)
+HwRef
+_pyproxy_has(PyObject* pyobj, HwRef idkey)
 {
   PyObject* pykey = js2python(idkey);
-  HwObject result = hiwire_bool(PyObject_HasAttr(pyobj, pykey));
+  HwRef result = hiwire_bool(PyObject_HasAttr(pyobj, pykey));
   Py_DECREF(pykey);
   return result;
 }
 
-HwObject
-_pyproxy_get(PyObject* pyobj, HwObject idkey)
+HwRef
+_pyproxy_get(PyObject* pyobj, HwRef idkey)
 {
   PyObject* pykey = js2python(idkey);
   PyObject* pyattr = PyObject_GetAttr(pyobj, pykey);
@@ -25,13 +25,13 @@ _pyproxy_get(PyObject* pyobj, HwObject idkey)
     return hiwire_undefined();
   }
 
-  HwObject idattr = python2js(pyattr);
+  HwRef idattr = python2js(pyattr);
   Py_DECREF(pyattr);
   return idattr;
 };
 
-HwObject
-_pyproxy_set(PyObject* pyobj, HwObject idkey, HwObject idval)
+HwRef
+_pyproxy_set(PyObject* pyobj, HwRef idkey, HwRef idval)
 {
   PyObject* pykey = js2python(idkey);
   PyObject* pyval = js2python(idval);
@@ -46,8 +46,8 @@ _pyproxy_set(PyObject* pyobj, HwObject idkey, HwObject idval)
   return idval;
 }
 
-HwObject
-_pyproxy_deleteProperty(PyObject* pyobj, HwObject idkey)
+HwRef
+_pyproxy_deleteProperty(PyObject* pyobj, HwRef idkey)
 {
   PyObject* pykey = js2python(idkey);
 
@@ -62,7 +62,7 @@ _pyproxy_deleteProperty(PyObject* pyobj, HwObject idkey)
   return hiwire_undefined();
 }
 
-HwObject
+HwRef
 _pyproxy_ownKeys(PyObject* pyobj)
 {
   PyObject* pydir = PyObject_Dir(pyobj);
@@ -72,11 +72,11 @@ _pyproxy_ownKeys(PyObject* pyobj)
     return HW_ERROR;
   }
 
-  HwObject iddir = hiwire_array();
+  HwRef iddir = hiwire_array();
   Py_ssize_t n = PyList_Size(pydir);
   for (Py_ssize_t i = 0; i < n; ++i) {
     PyObject* pyentry = PyList_GetItem(pydir, i);
-    HwObject identry = python2js(pyentry);
+    HwRef identry = python2js(pyentry);
     hiwire_push_array(iddir, identry);
     hiwire_decref(identry);
   }
@@ -85,19 +85,19 @@ _pyproxy_ownKeys(PyObject* pyobj)
   return iddir;
 }
 
-HwObject
+HwRef
 _pyproxy_enumerate(PyObject* pyobj)
 {
   return _pyproxy_ownKeys(pyobj);
 }
 
-HwObject
-_pyproxy_apply(PyObject* pyobj, HwObject idargs)
+HwRef
+_pyproxy_apply(PyObject* pyobj, HwRef idargs)
 {
   Py_ssize_t length = hiwire_get_length(idargs);
   PyObject* pyargs = PyTuple_New(length);
   for (Py_ssize_t i = 0; i < length; ++i) {
-    HwObject iditem = hiwire_get_member_int(idargs, i);
+    HwRef iditem = hiwire_get_member_int(idargs, i);
     PyObject* pyitem = js2python(iditem);
     PyTuple_SET_ITEM(pyargs, i, pyitem);
     hiwire_decref(iditem);
@@ -108,7 +108,7 @@ _pyproxy_apply(PyObject* pyobj, HwObject idargs)
     pythonexc2js();
     return HW_ERROR;
   }
-  HwObject idresult = python2js(pyresult);
+  HwRef idresult = python2js(pyresult);
   Py_DECREF(pyresult);
   Py_DECREF(pyargs);
   return idresult;
@@ -122,7 +122,7 @@ _pyproxy_destroy(PyObject* ptrobj)
   EM_ASM(delete Module.PyProxies[ptrobj];);
 }
 
-EM_JS(HwObject, pyproxy_use, (PyObject * ptrobj), {
+EM_JS(HwRef, pyproxy_use, (PyObject * ptrobj), {
   // Checks if there is already an existing proxy on ptrobj
 
   if (Module.PyProxies.hasOwnProperty(ptrobj)) {
@@ -132,7 +132,7 @@ EM_JS(HwObject, pyproxy_use, (PyObject * ptrobj), {
   return Module.hiwire.ERROR;
 })
 
-EM_JS(HwObject, pyproxy_new, (PyObject * ptrobj), {
+EM_JS(HwRef, pyproxy_new, (PyObject * ptrobj), {
   // Technically, this leaks memory, since we're holding on to a reference
   // to the proxy forever.  But we have that problem anyway since we don't
   // have a destructor in Javascript to free the Python object.

--- a/src/type_conversion/pyproxy.h
+++ b/src/type_conversion/pyproxy.h
@@ -7,10 +7,10 @@
 // This implements the Javascript Proxy handler interface as defined here:
 //     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
-HwObject
+HwRef
 pyproxy_use(PyObject* obj);
 
-HwObject
+HwRef
 pyproxy_new(PyObject* obj);
 
 int

--- a/src/type_conversion/pyproxy.h
+++ b/src/type_conversion/pyproxy.h
@@ -7,11 +7,11 @@
 // This implements the Javascript Proxy handler interface as defined here:
 //     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
-int
-pyproxy_use(int obj);
+HwObject
+pyproxy_use(PyObject* obj);
 
-int
-pyproxy_new(int obj);
+HwObject
+pyproxy_new(PyObject* obj);
 
 int
 pyproxy_init();

--- a/src/type_conversion/pyproxy.h
+++ b/src/type_conversion/pyproxy.h
@@ -7,10 +7,10 @@
 // This implements the Javascript Proxy handler interface as defined here:
 //     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 
-HwRef
+JsRef
 pyproxy_use(PyObject* obj);
 
-HwRef
+JsRef
 pyproxy_new(PyObject* obj);
 
 int

--- a/src/type_conversion/python2js.c
+++ b/src/type_conversion/python2js.c
@@ -314,7 +314,6 @@ _python2js_remove_from_cache(PyObject* map, PyObject* pyparent)
   return result;
 }
 
-
 HwRef
 _python2js_cache(PyObject* x, PyObject* map)
 {

--- a/src/type_conversion/python2js.c
+++ b/src/type_conversion/python2js.c
@@ -314,8 +314,6 @@ _python2js_remove_from_cache(PyObject* map, PyObject* pyparent)
   return result;
 }
 
-struct test
-{};
 
 HwObject
 _python2js_cache(PyObject* x, PyObject* map)

--- a/src/type_conversion/python2js.h
+++ b/src/type_conversion/python2js.h
@@ -18,7 +18,7 @@ pythonexc2js();
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
-HwRef
+JsRef
 python2js(PyObject* x);
 
 /** Set up the global state for this module.

--- a/src/type_conversion/python2js.h
+++ b/src/type_conversion/python2js.h
@@ -18,7 +18,7 @@ pythonexc2js();
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
-HwObject
+HwRef
 python2js(PyObject* x);
 
 /** Set up the global state for this module.

--- a/src/type_conversion/python2js.h
+++ b/src/type_conversion/python2js.h
@@ -4,12 +4,13 @@
 /** Utilities to convert Python objects to Javascript.
  */
 
+#include "hiwire.h"
 #include <Python.h>
 
-/** Convert the active Python exception into a Javascript Error object.
- *  \return A Javascript Error object
+/** Convert the active Python exception into a Javascript Error object
+ *  and print it to the console.
  */
-int
+void
 pythonexc2js();
 
 /** Convert a Python object to a Javascript object.
@@ -17,7 +18,7 @@ pythonexc2js();
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
-int
+HwObject
 python2js(PyObject* x);
 
 /** Set up the global state for this module.

--- a/src/type_conversion/python2js_buffer.c
+++ b/src/type_conversion/python2js_buffer.c
@@ -294,7 +294,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
 
   for (i = 0; i < n; ++i) {
     jsitem = _python2js_buffer_recursive(buff, ptr, dim + 1, convert);
-    if (hw_is_error(jsitem)) {
+    if (jsitem == HW_ERROR) {
       hiwire_decref(jsarray);
       return HW_ERROR;
     }
@@ -408,7 +408,7 @@ _python2js_shareable_buffer_recursive(Py_buffer* buff,
   for (i = 0; i < n; ++i) {
     jsitem = _python2js_shareable_buffer_recursive(
       buff, shareable, idarr, ptr, dim + 1);
-    if (hw_is_error(jsitem)) {
+    if (jsitem == HW_ERROR) {
       hiwire_decref(jsarray);
       return HW_ERROR;
     }
@@ -468,7 +468,7 @@ _python2js_buffer(PyObject* x)
 
   if (shareable != NOT_SHAREABLE) {
     HwObject idarr = _python2js_buffer_to_typed_array(buff);
-    if (hw_is_error(idarr)) {
+    if (idarr == HW_ERROR) {
       PyErr_SetString(
         PyExc_TypeError,
         "Internal error: Invalid type to convert to array buffer.");

--- a/src/type_conversion/python2js_buffer.c
+++ b/src/type_conversion/python2js_buffer.c
@@ -27,121 +27,121 @@
 // write code that doesn't rely on either behavior, but treats this simply as
 // the performance optimization that it is.
 
-typedef HwObject(scalar_converter)(char*);
+typedef HwRef(scalar_converter)(char*);
 
-static HwObject
+static HwRef
 _convert_bool(char* data)
 {
   char v = *((char*)data);
   return hiwire_bool((int)v);
 }
 
-static HwObject
+static HwRef
 _convert_int8(char* data)
 {
   i8 v = *((i8*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_uint8(char* data)
 {
   u8 v = *((u8*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_int16(char* data)
 {
   i16 v = *((i16*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_int16_swap(char* data)
 {
   i16 v = *((i16*)data);
   return hiwire_int(be16toh(v));
 }
 
-static HwObject
+static HwRef
 _convert_uint16(char* data)
 {
   u16 v = *((u16*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_uint16_swap(char* data)
 {
   u16 v = *((u16*)data);
   return hiwire_int(be16toh(v));
 }
 
-static HwObject
+static HwRef
 _convert_int32(char* data)
 {
   i32 v = *((i32*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_int32_swap(char* data)
 {
   i32 v = *((i32*)data);
   return hiwire_int(be32toh(v));
 }
 
-static HwObject
+static HwRef
 _convert_uint32(char* data)
 {
   u32 v = *((u32*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_uint32_swap(char* data)
 {
   u32 v = *((u32*)data);
   return hiwire_int(be32toh(v));
 }
 
-static HwObject
+static HwRef
 _convert_int64(char* data)
 {
   i64 v = *((i64*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_int64_swap(char* data)
 {
   i64 v = *((i64*)data);
   return hiwire_int(be64toh(v));
 }
 
-static HwObject
+static HwRef
 _convert_uint64(char* data)
 {
   u64 v = *((u64*)data);
   return hiwire_int(v);
 }
 
-static HwObject
+static HwRef
 _convert_uint64_swap(char* data)
 {
   u64 v = *((u64*)data);
   return hiwire_int(be64toh(v));
 }
 
-static HwObject
+static HwRef
 _convert_float32(char* data)
 {
   float v = *((float*)data);
   return hiwire_double(v);
 }
 
-static HwObject
+static HwRef
 _convert_float32_swap(char* data)
 {
   union float32_t
@@ -155,14 +155,14 @@ _convert_float32_swap(char* data)
   return hiwire_double(v.f);
 }
 
-static HwObject
+static HwRef
 _convert_float64(char* data)
 {
   double v = *((double*)data);
   return hiwire_double(v);
 }
 
-static HwObject
+static HwRef
 _convert_float64_swap(char* data)
 {
   union float64_t
@@ -271,7 +271,7 @@ _python2js_buffer_get_converter(Py_buffer* buff)
   }
 }
 
-static HwObject
+static HwRef
 _python2js_buffer_recursive(Py_buffer* buff,
                             char* ptr,
                             int dim,
@@ -281,7 +281,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
   // Numpy to use the Python buffer interface and output Javascript.
 
   Py_ssize_t i, n, stride;
-  HwObject jsarray, jsitem;
+  HwRef jsarray, jsitem;
 
   if (dim >= buff->ndim) {
     return convert(ptr);
@@ -307,7 +307,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
   return jsarray;
 }
 
-static HwObject
+static HwRef
 _python2js_buffer_to_typed_array(Py_buffer* buff)
 {
   // Uses Python's struct typecodes as defined here:
@@ -371,15 +371,15 @@ enum shareable_enum
   NOT_CONTIGUOUS
 };
 
-static HwObject
+static HwRef
 _python2js_shareable_buffer_recursive(Py_buffer* buff,
                                       enum shareable_enum shareable,
-                                      HwObject idarr,
+                                      HwRef idarr,
                                       int ptr,
                                       int dim)
 {
   Py_ssize_t i, n, stride;
-  HwObject jsarray, jsitem;
+  HwRef jsarray, jsitem;
 
   switch (shareable) {
     case NOT_CONTIGUOUS:
@@ -451,7 +451,7 @@ _python2js_buffer_is_shareable(Py_buffer* buff)
   return CONTIGUOUS;
 }
 
-HwObject
+HwRef
 _python2js_buffer(PyObject* x)
 {
   PyObject* memoryview = PyMemoryView_FromObject(x);
@@ -464,10 +464,10 @@ _python2js_buffer(PyObject* x)
   buff = PyMemoryView_GET_BUFFER(memoryview);
 
   enum shareable_enum shareable = _python2js_buffer_is_shareable(buff);
-  HwObject result;
+  HwRef result;
 
   if (shareable != NOT_SHAREABLE) {
-    HwObject idarr = _python2js_buffer_to_typed_array(buff);
+    HwRef idarr = _python2js_buffer_to_typed_array(buff);
     if (idarr == HW_ERROR) {
       PyErr_SetString(
         PyExc_TypeError,

--- a/src/type_conversion/python2js_buffer.c
+++ b/src/type_conversion/python2js_buffer.c
@@ -27,121 +27,121 @@
 // write code that doesn't rely on either behavior, but treats this simply as
 // the performance optimization that it is.
 
-typedef HwRef(scalar_converter)(char*);
+typedef JsRef(scalar_converter)(char*);
 
-static HwRef
+static JsRef
 _convert_bool(char* data)
 {
   char v = *((char*)data);
   return hiwire_bool((int)v);
 }
 
-static HwRef
+static JsRef
 _convert_int8(char* data)
 {
   i8 v = *((i8*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_uint8(char* data)
 {
   u8 v = *((u8*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_int16(char* data)
 {
   i16 v = *((i16*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_int16_swap(char* data)
 {
   i16 v = *((i16*)data);
   return hiwire_int(be16toh(v));
 }
 
-static HwRef
+static JsRef
 _convert_uint16(char* data)
 {
   u16 v = *((u16*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_uint16_swap(char* data)
 {
   u16 v = *((u16*)data);
   return hiwire_int(be16toh(v));
 }
 
-static HwRef
+static JsRef
 _convert_int32(char* data)
 {
   i32 v = *((i32*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_int32_swap(char* data)
 {
   i32 v = *((i32*)data);
   return hiwire_int(be32toh(v));
 }
 
-static HwRef
+static JsRef
 _convert_uint32(char* data)
 {
   u32 v = *((u32*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_uint32_swap(char* data)
 {
   u32 v = *((u32*)data);
   return hiwire_int(be32toh(v));
 }
 
-static HwRef
+static JsRef
 _convert_int64(char* data)
 {
   i64 v = *((i64*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_int64_swap(char* data)
 {
   i64 v = *((i64*)data);
   return hiwire_int(be64toh(v));
 }
 
-static HwRef
+static JsRef
 _convert_uint64(char* data)
 {
   u64 v = *((u64*)data);
   return hiwire_int(v);
 }
 
-static HwRef
+static JsRef
 _convert_uint64_swap(char* data)
 {
   u64 v = *((u64*)data);
   return hiwire_int(be64toh(v));
 }
 
-static HwRef
+static JsRef
 _convert_float32(char* data)
 {
   float v = *((float*)data);
   return hiwire_double(v);
 }
 
-static HwRef
+static JsRef
 _convert_float32_swap(char* data)
 {
   union float32_t
@@ -155,14 +155,14 @@ _convert_float32_swap(char* data)
   return hiwire_double(v.f);
 }
 
-static HwRef
+static JsRef
 _convert_float64(char* data)
 {
   double v = *((double*)data);
   return hiwire_double(v);
 }
 
-static HwRef
+static JsRef
 _convert_float64_swap(char* data)
 {
   union float64_t
@@ -271,7 +271,7 @@ _python2js_buffer_get_converter(Py_buffer* buff)
   }
 }
 
-static HwRef
+static JsRef
 _python2js_buffer_recursive(Py_buffer* buff,
                             char* ptr,
                             int dim,
@@ -281,7 +281,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
   // Numpy to use the Python buffer interface and output Javascript.
 
   Py_ssize_t i, n, stride;
-  HwRef jsarray, jsitem;
+  JsRef jsarray, jsitem;
 
   if (dim >= buff->ndim) {
     return convert(ptr);
@@ -294,9 +294,9 @@ _python2js_buffer_recursive(Py_buffer* buff,
 
   for (i = 0; i < n; ++i) {
     jsitem = _python2js_buffer_recursive(buff, ptr, dim + 1, convert);
-    if (jsitem == HW_ERROR) {
+    if (jsitem == Js_ERROR) {
       hiwire_decref(jsarray);
-      return HW_ERROR;
+      return Js_ERROR;
     }
     hiwire_push_array(jsarray, jsitem);
     hiwire_decref(jsitem);
@@ -307,7 +307,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
   return jsarray;
 }
 
-static HwRef
+static JsRef
 _python2js_buffer_to_typed_array(Py_buffer* buff)
 {
   // Uses Python's struct typecodes as defined here:
@@ -321,7 +321,7 @@ _python2js_buffer_to_typed_array(Py_buffer* buff)
       case '>':
       case '!':
         // This path can't handle byte-swapping
-        return HW_ERROR;
+        return Js_ERROR;
       case '=':
       case '<':
       case '@':
@@ -339,7 +339,7 @@ _python2js_buffer_to_typed_array(Py_buffer* buff)
     case 'B':
       return hiwire_uint8array((u8*)buff->buf, buff->len);
     case '?':
-      return HW_ERROR;
+      return Js_ERROR;
     case 'h':
       return hiwire_int16array((i16*)buff->buf, buff->len);
     case 'H':
@@ -354,13 +354,13 @@ _python2js_buffer_to_typed_array(Py_buffer* buff)
       return hiwire_uint32array((u32*)buff->buf, buff->len);
     case 'q':
     case 'Q':
-      return HW_ERROR;
+      return Js_ERROR;
     case 'f':
       return hiwire_float32array((f32*)buff->buf, buff->len);
     case 'd':
       return hiwire_float64array((f64*)buff->buf, buff->len);
     default:
-      return HW_ERROR;
+      return Js_ERROR;
   }
 }
 
@@ -371,15 +371,15 @@ enum shareable_enum
   NOT_CONTIGUOUS
 };
 
-static HwRef
+static JsRef
 _python2js_shareable_buffer_recursive(Py_buffer* buff,
                                       enum shareable_enum shareable,
-                                      HwRef idarr,
+                                      JsRef idarr,
                                       int ptr,
                                       int dim)
 {
   Py_ssize_t i, n, stride;
-  HwRef jsarray, jsitem;
+  JsRef jsarray, jsitem;
 
   switch (shareable) {
     case NOT_CONTIGUOUS:
@@ -408,9 +408,9 @@ _python2js_shareable_buffer_recursive(Py_buffer* buff,
   for (i = 0; i < n; ++i) {
     jsitem = _python2js_shareable_buffer_recursive(
       buff, shareable, idarr, ptr, dim + 1);
-    if (jsitem == HW_ERROR) {
+    if (jsitem == Js_ERROR) {
       hiwire_decref(jsarray);
-      return HW_ERROR;
+      return Js_ERROR;
     }
     hiwire_push_array(jsarray, jsitem);
     hiwire_decref(jsitem);
@@ -451,28 +451,28 @@ _python2js_buffer_is_shareable(Py_buffer* buff)
   return CONTIGUOUS;
 }
 
-HwRef
+JsRef
 _python2js_buffer(PyObject* x)
 {
   PyObject* memoryview = PyMemoryView_FromObject(x);
   if (memoryview == NULL) {
     PyErr_Clear();
-    return HW_ERROR;
+    return Js_ERROR;
   }
 
   Py_buffer* buff;
   buff = PyMemoryView_GET_BUFFER(memoryview);
 
   enum shareable_enum shareable = _python2js_buffer_is_shareable(buff);
-  HwRef result;
+  JsRef result;
 
   if (shareable != NOT_SHAREABLE) {
-    HwRef idarr = _python2js_buffer_to_typed_array(buff);
-    if (idarr == HW_ERROR) {
+    JsRef idarr = _python2js_buffer_to_typed_array(buff);
+    if (idarr == Js_ERROR) {
       PyErr_SetString(
         PyExc_TypeError,
         "Internal error: Invalid type to convert to array buffer.");
-      return HW_ERROR;
+      return Js_ERROR;
     }
 
     result =
@@ -481,7 +481,7 @@ _python2js_buffer(PyObject* x)
     scalar_converter* convert = _python2js_buffer_get_converter(buff);
     if (convert == NULL) {
       Py_DECREF(memoryview);
-      return HW_ERROR;
+      return Js_ERROR;
     }
 
     result = _python2js_buffer_recursive(buff, buff->buf, 0, convert);

--- a/src/type_conversion/python2js_buffer.c
+++ b/src/type_conversion/python2js_buffer.c
@@ -1,4 +1,5 @@
 #include "python2js_buffer.h"
+#include "types.h"
 
 #include <endian.h>
 #include <stdint.h>
@@ -26,126 +27,126 @@
 // write code that doesn't rely on either behavior, but treats this simply as
 // the performance optimization that it is.
 
-typedef int(scalar_converter)(char*);
+typedef HwObject(scalar_converter)(char*);
 
-static int
+static HwObject
 _convert_bool(char* data)
 {
   char v = *((char*)data);
   return hiwire_bool((int)v);
 }
 
-static int
+static HwObject
 _convert_int8(char* data)
 {
-  int8_t v = *((int8_t*)data);
+  i8 v = *((i8*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_uint8(char* data)
 {
-  uint8_t v = *((uint8_t*)data);
+  u8 v = *((u8*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_int16(char* data)
 {
-  int16_t v = *((int16_t*)data);
+  i16 v = *((i16*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_int16_swap(char* data)
 {
-  int16_t v = *((int16_t*)data);
+  i16 v = *((i16*)data);
   return hiwire_int(be16toh(v));
 }
 
-static int
+static HwObject
 _convert_uint16(char* data)
 {
-  uint16_t v = *((uint16_t*)data);
+  u16 v = *((u16*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_uint16_swap(char* data)
 {
-  uint16_t v = *((uint16_t*)data);
+  u16 v = *((u16*)data);
   return hiwire_int(be16toh(v));
 }
 
-static int
+static HwObject
 _convert_int32(char* data)
 {
-  int32_t v = *((int32_t*)data);
+  i32 v = *((i32*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_int32_swap(char* data)
 {
-  int32_t v = *((int32_t*)data);
+  i32 v = *((i32*)data);
   return hiwire_int(be32toh(v));
 }
 
-static int
+static HwObject
 _convert_uint32(char* data)
 {
-  uint32_t v = *((uint32_t*)data);
+  u32 v = *((u32*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_uint32_swap(char* data)
 {
-  uint32_t v = *((uint32_t*)data);
+  u32 v = *((u32*)data);
   return hiwire_int(be32toh(v));
 }
 
-static int
+static HwObject
 _convert_int64(char* data)
 {
-  int64_t v = *((int64_t*)data);
+  i64 v = *((i64*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_int64_swap(char* data)
 {
-  int64_t v = *((int64_t*)data);
+  i64 v = *((i64*)data);
   return hiwire_int(be64toh(v));
 }
 
-static int
+static HwObject
 _convert_uint64(char* data)
 {
-  uint64_t v = *((uint64_t*)data);
+  u64 v = *((u64*)data);
   return hiwire_int(v);
 }
 
-static int
+static HwObject
 _convert_uint64_swap(char* data)
 {
-  uint64_t v = *((uint64_t*)data);
+  u64 v = *((u64*)data);
   return hiwire_int(be64toh(v));
 }
 
-static int
+static HwObject
 _convert_float32(char* data)
 {
   float v = *((float*)data);
   return hiwire_double(v);
 }
 
-static int
+static HwObject
 _convert_float32_swap(char* data)
 {
   union float32_t
   {
-    uint32_t i;
+    u32 i;
     float f;
   } v;
 
@@ -154,19 +155,19 @@ _convert_float32_swap(char* data)
   return hiwire_double(v.f);
 }
 
-static int
+static HwObject
 _convert_float64(char* data)
 {
   double v = *((double*)data);
   return hiwire_double(v);
 }
 
-static int
+static HwObject
 _convert_float64_swap(char* data)
 {
   union float64_t
   {
-    uint64_t i;
+    u64 i;
     double f;
   } v;
 
@@ -270,7 +271,7 @@ _python2js_buffer_get_converter(Py_buffer* buff)
   }
 }
 
-static int
+static HwObject
 _python2js_buffer_recursive(Py_buffer* buff,
                             char* ptr,
                             int dim,
@@ -280,7 +281,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
   // Numpy to use the Python buffer interface and output Javascript.
 
   Py_ssize_t i, n, stride;
-  int jsarray, jsitem;
+  HwObject jsarray, jsitem;
 
   if (dim >= buff->ndim) {
     return convert(ptr);
@@ -293,7 +294,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
 
   for (i = 0; i < n; ++i) {
     jsitem = _python2js_buffer_recursive(buff, ptr, dim + 1, convert);
-    if (jsitem == HW_ERROR) {
+    if (hw_is_error(jsitem)) {
       hiwire_decref(jsarray);
       return HW_ERROR;
     }
@@ -306,7 +307,7 @@ _python2js_buffer_recursive(Py_buffer* buff,
   return jsarray;
 }
 
-static int
+static HwObject
 _python2js_buffer_to_typed_array(Py_buffer* buff)
 {
   // Uses Python's struct typecodes as defined here:
@@ -334,30 +335,30 @@ _python2js_buffer_to_typed_array(Py_buffer* buff)
   switch (format) {
     case 'c':
     case 'b':
-      return hiwire_int8array((int)buff->buf, buff->len);
+      return hiwire_int8array((i8*)buff->buf, buff->len);
     case 'B':
-      return hiwire_uint8array((int)buff->buf, buff->len);
+      return hiwire_uint8array((u8*)buff->buf, buff->len);
     case '?':
       return HW_ERROR;
     case 'h':
-      return hiwire_int16array((int)buff->buf, buff->len);
+      return hiwire_int16array((i16*)buff->buf, buff->len);
     case 'H':
-      return hiwire_uint16array((int)buff->buf, buff->len);
+      return hiwire_uint16array((u16*)buff->buf, buff->len);
     case 'i':
     case 'l':
     case 'n':
-      return hiwire_int32array((int)buff->buf, buff->len);
+      return hiwire_int32array((i32*)buff->buf, buff->len);
     case 'I':
     case 'L':
     case 'N':
-      return hiwire_uint32array((int)buff->buf, buff->len);
+      return hiwire_uint32array((u32*)buff->buf, buff->len);
     case 'q':
     case 'Q':
       return HW_ERROR;
     case 'f':
-      return hiwire_float32array((int)buff->buf, buff->len);
+      return hiwire_float32array((f32*)buff->buf, buff->len);
     case 'd':
-      return hiwire_float64array((int)buff->buf, buff->len);
+      return hiwire_float64array((f64*)buff->buf, buff->len);
     default:
       return HW_ERROR;
   }
@@ -370,15 +371,15 @@ enum shareable_enum
   NOT_CONTIGUOUS
 };
 
-static int
+static HwObject
 _python2js_shareable_buffer_recursive(Py_buffer* buff,
                                       enum shareable_enum shareable,
-                                      int idarr,
+                                      HwObject idarr,
                                       int ptr,
                                       int dim)
 {
   Py_ssize_t i, n, stride;
-  int jsarray, jsitem;
+  HwObject jsarray, jsitem;
 
   switch (shareable) {
     case NOT_CONTIGUOUS:
@@ -407,7 +408,7 @@ _python2js_shareable_buffer_recursive(Py_buffer* buff,
   for (i = 0; i < n; ++i) {
     jsitem = _python2js_shareable_buffer_recursive(
       buff, shareable, idarr, ptr, dim + 1);
-    if (jsitem == HW_ERROR) {
+    if (hw_is_error(jsitem)) {
       hiwire_decref(jsarray);
       return HW_ERROR;
     }
@@ -450,7 +451,7 @@ _python2js_buffer_is_shareable(Py_buffer* buff)
   return CONTIGUOUS;
 }
 
-int
+HwObject
 _python2js_buffer(PyObject* x)
 {
   PyObject* memoryview = PyMemoryView_FromObject(x);
@@ -463,11 +464,11 @@ _python2js_buffer(PyObject* x)
   buff = PyMemoryView_GET_BUFFER(memoryview);
 
   enum shareable_enum shareable = _python2js_buffer_is_shareable(buff);
-  int result;
+  HwObject result;
 
   if (shareable != NOT_SHAREABLE) {
-    int idarr = _python2js_buffer_to_typed_array(buff);
-    if (idarr == HW_ERROR) {
+    HwObject idarr = _python2js_buffer_to_typed_array(buff);
+    if (hw_is_error(idarr)) {
       PyErr_SetString(
         PyExc_TypeError,
         "Internal error: Invalid type to convert to array buffer.");

--- a/src/type_conversion/python2js_buffer.h
+++ b/src/type_conversion/python2js_buffer.h
@@ -4,6 +4,7 @@
 /** Utilities to convert Python buffer objects to Javascript.
  */
 
+#include "hiwire.h"
 #include <Python.h>
 
 /** Convert a Python buffer object to a Javascript object.
@@ -12,7 +13,7 @@
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
-int
+HwObject
 _python2js_buffer(PyObject* x);
 
 #endif /* PYTHON2JS_BUFFER_H */

--- a/src/type_conversion/python2js_buffer.h
+++ b/src/type_conversion/python2js_buffer.h
@@ -13,7 +13,7 @@
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
-HwRef
+JsRef
 _python2js_buffer(PyObject* x);
 
 #endif /* PYTHON2JS_BUFFER_H */

--- a/src/type_conversion/python2js_buffer.h
+++ b/src/type_conversion/python2js_buffer.h
@@ -13,7 +13,7 @@
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
-HwObject
+HwRef
 _python2js_buffer(PyObject* x);
 
 #endif /* PYTHON2JS_BUFFER_H */

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -13,14 +13,14 @@ PyObject* pyodide;
 _Py_IDENTIFIER(eval_code);
 _Py_IDENTIFIER(find_imports);
 
-HwRef
+JsRef
 _runPython(char* code)
 {
   PyObject* py_code;
   py_code = PyUnicode_FromString(code);
   if (py_code == NULL) {
     pythonexc2js();
-    return HW_ERROR;
+    return Js_ERROR;
   }
 
   PyObject* ret = _PyObject_CallMethodIdObjArgs(
@@ -28,21 +28,21 @@ _runPython(char* code)
 
   if (ret == NULL) {
     pythonexc2js();
-    return HW_ERROR;
+    return Js_ERROR;
   }
-  HwRef id = python2js(ret);
+  JsRef id = python2js(ret);
   Py_DECREF(ret);
   return id;
 }
 
-HwRef
+JsRef
 _findImports(char* code)
 {
   PyObject* py_code;
   py_code = PyUnicode_FromString(code);
   if (py_code == NULL) {
     pythonexc2js();
-    return HW_ERROR;
+    return Js_ERROR;
   }
 
   PyObject* ret =
@@ -50,10 +50,10 @@ _findImports(char* code)
 
   if (ret == NULL) {
     pythonexc2js();
-    return HW_ERROR;
+    return Js_ERROR;
   }
 
-  HwRef id = python2js(ret);
+  JsRef id = python2js(ret);
   Py_DECREF(ret);
   return id;
 }

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -13,7 +13,7 @@ PyObject* pyodide;
 _Py_IDENTIFIER(eval_code);
 _Py_IDENTIFIER(find_imports);
 
-HwObject
+HwRef
 _runPython(char* code)
 {
   PyObject* py_code;
@@ -30,12 +30,12 @@ _runPython(char* code)
     pythonexc2js();
     return HW_ERROR;
   }
-  HwObject id = python2js(ret);
+  HwRef id = python2js(ret);
   Py_DECREF(ret);
   return id;
 }
 
-HwObject
+HwRef
 _findImports(char* code)
 {
   PyObject* py_code;
@@ -53,7 +53,7 @@ _findImports(char* code)
     return HW_ERROR;
   }
 
-  HwObject id = python2js(ret);
+  HwRef id = python2js(ret);
   Py_DECREF(ret);
   return id;
 }

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -13,44 +13,53 @@ PyObject* pyodide;
 _Py_IDENTIFIER(eval_code);
 _Py_IDENTIFIER(find_imports);
 
-int
+HwObject
 _runPython(char* code)
 {
   PyObject* py_code;
   py_code = PyUnicode_FromString(code);
+  printf("rp1\n");
   if (py_code == NULL) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
+  printf("rp2\n");
   PyObject* ret = _PyObject_CallMethodIdObjArgs(
     pyodide, &PyId_eval_code, py_code, globals, NULL);
 
+  printf("rp3\n");
+
   if (ret == NULL) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
-  int id = python2js(ret);
+  printf("rp4\n");
+  HwObject id = python2js(ret);
   Py_DECREF(ret);
   return id;
 }
 
-int
+HwObject
 _findImports(char* code)
 {
   PyObject* py_code;
   py_code = PyUnicode_FromString(code);
   if (py_code == NULL) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
   PyObject* ret =
     _PyObject_CallMethodIdObjArgs(pyodide, &PyId_find_imports, py_code, NULL);
 
   if (ret == NULL) {
-    return pythonexc2js();
+    pythonexc2js();
+    return HW_ERROR;
   }
 
-  int id = python2js(ret);
+  HwObject id = python2js(ret);
   Py_DECREF(ret);
   return id;
 }

--- a/src/type_conversion/runpython.c
+++ b/src/type_conversion/runpython.c
@@ -18,24 +18,18 @@ _runPython(char* code)
 {
   PyObject* py_code;
   py_code = PyUnicode_FromString(code);
-  printf("rp1\n");
   if (py_code == NULL) {
     pythonexc2js();
     return HW_ERROR;
   }
 
-  printf("rp2\n");
   PyObject* ret = _PyObject_CallMethodIdObjArgs(
     pyodide, &PyId_eval_code, py_code, globals, NULL);
-
-  printf("rp3\n");
 
   if (ret == NULL) {
     pythonexc2js();
     return HW_ERROR;
   }
-
-  printf("rp4\n");
   HwObject id = python2js(ret);
   Py_DECREF(ret);
   return id;

--- a/src/type_conversion/types.h
+++ b/src/type_conversion/types.h
@@ -1,0 +1,49 @@
+#ifndef MY_TYPES_H
+#define MY_TYPES_H
+// https://elixir.bootlin.com/linux/latest/source/arch/powerpc/boot/types.h#L9
+
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef unsigned long long u64;
+typedef signed char i8;
+typedef short i16;
+typedef int i32;
+typedef long long i64;
+
+typedef float f32;
+typedef double f64;
+
+typedef int bool;
+
+#ifndef true
+#define true 1
+#endif
+
+#ifndef false
+#define false 0
+#endif
+
+// //
+// http://notanumber.net/archives/33/newtype-in-c-a-touch-of-strong-typing-using-compound-literals
+// /* this can be used for type safety, to avoid accidental casting of values
+// from
+//  * one type to another and allowing alias analysis by the compiler to
+//  * distinguish otherwise identical types
+//  *
+//  * NEWTYPE(new_type,old_type); declares new_type to be an alias for the
+//  already
+//  * exsiting old_type TO_NT(new_type,val)  converts a value to its newtype
+//  * representation FROM_NT(new_val)  opens up a newtyped value to get at its
+//  * internal representation
+//  */
+
+// #define NEWTYPE(nty, oty)                                                      \
+//   typedef struct                                                               \
+//   {                                                                            \
+//     oty v;                                                                     \
+//   } nty
+// #define FROM_NT(ntv) ((ntv).v)
+// #define TO_NT(nty, val) ((nty){ .v = (val) })
+
+#endif /* MY_LINUX_TYPES_H */

--- a/src/type_conversion/types.h
+++ b/src/type_conversion/types.h
@@ -1,8 +1,8 @@
 #ifndef MY_TYPES_H
 #define MY_TYPES_H
 // https://elixir.bootlin.com/linux/latest/source/arch/powerpc/boot/types.h#L9
-#include "stdint.h"
 #include "stdbool.h"
+#include "stdint.h"
 
 typedef uint8_t u8;
 typedef uint16_t u16;

--- a/src/type_conversion/types.h
+++ b/src/type_conversion/types.h
@@ -1,49 +1,18 @@
 #ifndef MY_TYPES_H
 #define MY_TYPES_H
 // https://elixir.bootlin.com/linux/latest/source/arch/powerpc/boot/types.h#L9
+#include "stdint.h"
+#include "stdbool.h"
 
-typedef unsigned char u8;
-typedef unsigned short u16;
-typedef unsigned int u32;
-typedef unsigned long long u64;
-typedef signed char i8;
-typedef short i16;
-typedef int i32;
-typedef long long i64;
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+typedef int8_t i8;
+typedef int16_t i16;
+typedef int32_t i32;
+typedef int64_t i64;
 
 typedef float f32;
 typedef double f64;
-
-typedef int bool;
-
-#ifndef true
-#define true 1
-#endif
-
-#ifndef false
-#define false 0
-#endif
-
-// //
-// http://notanumber.net/archives/33/newtype-in-c-a-touch-of-strong-typing-using-compound-literals
-// /* this can be used for type safety, to avoid accidental casting of values
-// from
-//  * one type to another and allowing alias analysis by the compiler to
-//  * distinguish otherwise identical types
-//  *
-//  * NEWTYPE(new_type,old_type); declares new_type to be an alias for the
-//  already
-//  * exsiting old_type TO_NT(new_type,val)  converts a value to its newtype
-//  * representation FROM_NT(new_val)  opens up a newtyped value to get at its
-//  * internal representation
-//  */
-
-// #define NEWTYPE(nty, oty)                                                      \
-//   typedef struct                                                               \
-//   {                                                                            \
-//     oty v;                                                                     \
-//   } nty
-// #define FROM_NT(ntv) ((ntv).v)
-// #define TO_NT(nty, val) ((nty){ .v = (val) })
-
 #endif /* MY_LINUX_TYPES_H */


### PR DESCRIPTION
Before this PR, hiwire effectively opts out of the C type system entirely by declaring everything as int. A `char*`? Cast it to `int`. What about a `PyObject*`? Better cast it to `int` too. This makes the calling code more verbose (at least if the calling code uses the type system) and is not good for maintainability.

I made a NewType called `HwObject` for hiwire keys. If you google how to make a NewType in C, people recommend a single field struct. However, `EM_JS` does not convert that compatibly: it converts any struct to the address of the struct, but an integer to the value of the integer. This created trouble. I decided instead to make a dummy empty struct and work with pointers to that struct. To ensure that converting to and from the `NewType` always requires an explicit cast, I added `-Werror=int-conversion -Werror=incompatible-pointer-types` to the compiler options. (I like this setting better in any case.) 

I added asserts to `main.c` checking that `HwObject` has the same alignment and size as `int`. Hopefully this will prevent confusing bugs if that ever changes.

Unfortunately this is going to have major merge conflicts with all my other open PRs but I think this is a very important improvement. 