### PR TITLE
docs: fix simple typo, convinience -> convenience

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -282,7 +282,7 @@ def handle_command(line, args, dryrun=False):
             module_name = Path(module_name).name.split(".")[0]
 
             lapack_dir = arg.replace("-L", "")
-            # For convinience we determine needed scipy link libraries
+            # For convenience we determine needed scipy link libraries
             # here, instead of in patch files
             link_libs = ["F2CLIBS/libf2c.a", "blas_WA.a"]
             if module_name in [


### PR DESCRIPTION
There is a small typo in pyodide_build/pywasmcross.py.

Should read `convenience` rather than `convinience`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md