### PR TITLE
Add pillow as a requirement of imageio

### DIFF
--- a/packages/imageio/meta.yaml
+++ b/packages/imageio/meta.yaml
@@ -9,6 +9,7 @@ source:
 requirements:
   run:
   - numpy
+  - pillow
 test:
   imports:
   - imageio


### PR DESCRIPTION
imageio uses pillow to handle basic file formats such as jpg and png, it throws runtime error if not imported.

For example:
```py
image = imageio.imread('imageio:chelsea.png')
```
it causes the following error:
```js
Error: Traceback (most recent call last):
  File "<exec>", line 197, in shell_eval
  File "<exec>", line 165, in eval
  File "/lib/python3.8/site-packages/pyodide/_base.py", line 70, in eval_code
    eval(compile(mod, "<exec>", mode="exec"), ns, ns)
  File "<exec>", line 1, in <module>
  File "/lib/python3.8/site-packages/imageio/core/functions.py", line 265, in imread
    reader = read(uri, format, "i", **kwargs)
  File "/lib/python3.8/site-packages/imageio/core/functions.py", line 178, in get_reader
    format = formats.search_read_format(request)
  File "/lib/python3.8/site-packages/imageio/core/format.py", line 689, in search_read_format
    if format.can_read(request):
  File "/lib/python3.8/site-packages/imageio/core/format.py", line 192, in can_read
    return self._can_read(request)
  File "/lib/python3.8/site-packages/imageio/plugins/pillow.py", line 102, in _can_read
    Image = self._init_pillow()
  File "/lib/python3.8/site-packages/imageio/plugins/pillow.py", line 92, in _init_pillow
    raise RuntimeError("Imageio Pillow plugin requires " "Pillow lib.")
RuntimeError: Imageio Pillow plugin requires Pillow lib.
```

Therefore, it would be better if we add pillow as a requirement of imageio.