### PR TITLE
Remove some unneeded CPython patches

### DIFF
--- a/cpython/patches/0007-testing.patch
+++ b/cpython/patches/0007-testing.patch
@@ -83,35 +83,11 @@ index ab8677199f..8eefd57776 100644
          cgi.log("Testing")
  
          cgi.logfp = StringIO()
-diff --git a/Lib/test/test_code.py b/Lib/test/test_code.py
-index 0d80af44d9..a30a0c34fe 100644
---- a/Lib/test/test_code.py
-+++ b/Lib/test/test_code.py
-@@ -127,7 +127,10 @@ consts: ('None',)
- 
- import inspect
- import sys
--import threading
-+try:
-+    import threading
-+except ImportError:
-+    import dummy_threading as threading
- import unittest
- import weakref
- import opcode
 diff --git a/Lib/test/test_fcntl.py b/Lib/test/test_fcntl.py
 index c394f6945a..2ec020bd08 100644
 --- a/Lib/test/test_fcntl.py
 +++ b/Lib/test/test_fcntl.py
-@@ -5,7 +5,6 @@ import os
- import struct
- import sys
- import unittest
--from multiprocessing import Process
- from test.support import (verbose, TESTFN, unlink, run_unittest, import_module,
-                           cpython_only)
- 
-@@ -155,6 +154,7 @@ class TestFcntl(unittest.TestCase):
+@@ -155,6 +155,7 @@ class TestFcntl(unittest.TestCase):
  
      @unittest.skipIf(platform.system() == "AIX", "AIX returns PermissionError")
      def test_lockf_exclusive(self):
@@ -119,7 +95,7 @@ index c394f6945a..2ec020bd08 100644
          self.f = open(TESTFN, 'wb+')
          cmd = fcntl.LOCK_EX | fcntl.LOCK_NB
          fcntl.lockf(self.f, cmd)
-@@ -166,6 +166,7 @@ class TestFcntl(unittest.TestCase):
+@@ -166,6 +167,7 @@ class TestFcntl(unittest.TestCase):
  
      @unittest.skipIf(platform.system() == "AIX", "AIX returns PermissionError")
      def test_lockf_share(self):
@@ -147,35 +123,10 @@ index 646828621a..b9663082b9 100644
          args = sys.executable, '-m', 'gzip'
          with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
              out, err = proc.communicate(self.data)
-diff --git a/Lib/test/test_import/__init__.py b/Lib/test/test_import/__init__.py
-index f037821dda..cc358641de 100644
---- a/Lib/test/test_import/__init__.py
-+++ b/Lib/test/test_import/__init__.py
-@@ -11,7 +11,10 @@ import shutil
- import subprocess
- import stat
- import sys
--import threading
-+try:
-+    import threading
-+except ImportError:
-+    import dummy_threading as threading
- import time
- import unittest
- import unittest.mock as mock
 diff --git a/Lib/test/test_itertools.py b/Lib/test/test_itertools.py
 index eaa6197bec..95ff99d15c 100644
 --- a/Lib/test/test_itertools.py
 +++ b/Lib/test/test_itertools.py
-@@ -11,7 +11,7 @@ import pickle
- from functools import reduce
- import sys
- import struct
--import threading
-+import dummy_threading as threading
- maxsize = support.MAX_Py_ssize_t
- minsize = -maxsize-1
- 
 @@ -1511,6 +1511,7 @@ class TestBasicOps(unittest.TestCase):
              next(a)
  


### PR DESCRIPTION
Importing threading and multiprocessing now doesn't crash
