### PR TITLE
Explicitly tell sqlite popen is not available

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -82,9 +82,10 @@ $(ZLIBBUILD)/.configured: $(ZLIBTARBALL)
 $(SQLITEBUILD)/libsqlite3.la: $(SQLITETARBALL)
 	[ -d $(ROOT)/build ] || (mkdir $(ROOT)/build)
 	tar -C $(ROOT)/build/ -xf $(SQLITETARBALL)
+	# sqlite fails to detect that popen is not available. We have to set it
+	# as a CPPFLAG
 	( \
 		cd $(SQLITEBUILD); \
-		# sqlite fails to detect that popen is not available
 		CPPFLAGS="-DSQLITE_OMIT_POPEN" emconfigure ./configure; \
 		emmake make -j $${PYODIDE_JOBS:-3}; \
 	)

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -84,7 +84,8 @@ $(SQLITEBUILD)/libsqlite3.la: $(SQLITETARBALL)
 	tar -C $(ROOT)/build/ -xf $(SQLITETARBALL)
 	( \
 		cd $(SQLITEBUILD); \
-		emconfigure ./configure; \
+		# sqlite fails to detect that popen is not available
+		CPPFLAGS="-DSQLITE_OMIT_POPEN" emconfigure ./configure; \
 		emmake make -j $${PYODIDE_JOBS:-3}; \
 	)
 


### PR DESCRIPTION
sqlite isn't able to detect that, and this becomes a hard error in future versions of emscripten.
