### PR TITLE
Build with -fPIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL := /bin/bash
 CC=emcc
 CXX=em++
 OPTFLAGS=-O2
-CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -Wno-warn-absolute-paths -Werror=int-conversion -Werror=incompatible-pointer-types
+CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -Wno-warn-absolute-paths -Werror=int-conversion -Werror=incompatible-pointer-types -fPIC
 
 LDFLAGS=\
 	-O2 \

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -86,7 +86,7 @@ $(SQLITEBUILD)/libsqlite3.la: $(SQLITETARBALL)
 	# as a CPPFLAG
 	( \
 		cd $(SQLITEBUILD); \
-		CPPFLAGS="-DSQLITE_OMIT_POPEN" emconfigure ./configure; \
+		emconfigure ./configure CFLAGS="-fPIC" CPPFLAGS="-DSQLITE_OMIT_POPEN"; \
 		emmake make -j $${PYODIDE_JOBS:-3}; \
 	)
 
@@ -96,7 +96,7 @@ $(BZIP2BUILD)/libbz2.a: $(BZIP2TARBALL)
 	tar -C $(ROOT)/build/ -xf $(BZIP2TARBALL)
 	( \
 		cd $(BZIP2BUILD); \
-		emmake make -j $${PYODIDE_JOBS:-3} CC=emcc CFLAGS="-Wall -Winline -O2 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64" AR=emar RANLIB=emranlib libbz2.a; \
+		emmake make -j $${PYODIDE_JOBS:-3} CC=emcc CFLAGS="-Wall -Winline -O2 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64 -fPIC" AR=emar RANLIB=emranlib libbz2.a; \
 	)
 
 
@@ -106,6 +106,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.configured $(SQLITEBUILD)/lib
 		cd $(BUILD); \
 		EMCC_CFLAGS="-s WASM=0" CONFIG_SITE=./config.site READELF=true LD_RUN_PATH="$(SQLITEBUILD):$(BZIP2BUILD)" emconfigure \
 		  ./configure \
+			  CFLAGS="-fPIC" \
 			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD) -I$(ZLIBBUILD)" \
 			  LDFLAGS="-L$(SQLITEBUILD) -L$(BZIP2BUILD)" \
 			  --without-pymalloc \

--- a/packages/libiconv/Makefile
+++ b/packages/libiconv/Makefile
@@ -34,7 +34,8 @@ $(SRC)/libiconv.a: $(SRC)/Makefile
 	( \
 		cd $(SRC) ; \
 		emconfigure ./configure \
+			CFLAGS="-fPIC" \
 			--disable-dependency-tracking \
 			--disable-shared ; \
-		emmake make -j $${PYODIDE_JOBS:-3} ; \
+		emmake make -j $${PYODIDE_JOBS:-3}; \
 	)

--- a/packages/libxml/Makefile
+++ b/packages/libxml/Makefile
@@ -35,6 +35,7 @@ $(SRC)/.libs/libxml2.a: $(SRC)/Makefile
 	( \
 		cd $(SRC) ; \
 		emconfigure ./configure \
+			CFLAGS="-fPIC" \
 			--disable-dependency-tracking \
 			--disable-shared \
 			--without-python \

--- a/packages/libxslt/Makefile
+++ b/packages/libxslt/Makefile
@@ -31,6 +31,7 @@ $(SRC)/Makefile: $(TARBALL)
 	( \
 		cd $(SRC) ; \
 		emconfigure ./configure \
+			CFLAGS="-fPIC" \
 			--disable-dependency-tracking \
 			--disable-shared \
 			--without-python \

--- a/packages/zlib/Makefile
+++ b/packages/zlib/Makefile
@@ -32,6 +32,6 @@ $(SRC)/Makefile: $(TARBALL)
 $(SRC)/zlib.a: $(SRC)/Makefile
 	( \
 		cd $(SRC) ; \
-		emconfigure ./configure  --prefix=$(SRC) ; \
+		CFLAGS="-fPIC" emconfigure ./configure --prefix=$(SRC) ; \
 		emmake make install -j $${PYODIDE_JOBS:-3} ; \
 	)

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -5,7 +5,8 @@ ROOTDIR = Path(__file__).parents[1].resolve()
 TOOLSDIR = ROOTDIR / "tools"
 PACKAGERDIR = ROOTDIR / "emsdk" / "emsdk" / "fastcomp" / "emscripten" / "tools"
 TARGETPYTHON = ROOTDIR / "cpython" / "installs" / "python-3.8.2"
-DEFAULTCFLAGS = ""
+# Leading space so that argparse doesn't think this is a flag
+DEFAULTCFLAGS = " -fPIC"
 # fmt: off
 DEFAULTLDFLAGS = " ".join(
     [


### PR DESCRIPTION
This is needed for the upstream backend, and I believe is a noop under the fastcomp backend (and some packages already build with `-fPIC`, but it doesn't hurt to specify twice)

This is part of the changes in #637, #531, and joemarshall's emsripten 2.0 branch