### PR TITLE
Remove unneeded test/imports in package meta.yaml

### DIFF
--- a/packages/asciitree/meta.yaml
+++ b/packages/asciitree/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e
   url: https://files.pythonhosted.org/packages/2d/6a/885bc91484e1aa8f618f6f0228d76d0e67000b0fdd6090673b777e311913/asciitree-0.3.3.tar.gz
-test:
-  imports:
-  - asciitree

--- a/packages/astropy/meta.yaml
+++ b/packages/astropy/meta.yaml
@@ -9,7 +9,3 @@ source:
 requirements:
   run:
     - numpy
-
-test:
-  imports:
-    - astropy

--- a/packages/atomicwrites/meta.yaml
+++ b/packages/atomicwrites/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a
   url: https://files.pythonhosted.org/packages/55/8d/74a75635f2c3c914ab5b3850112fd4b0c8039975ecb320e4449aa363ba54/atomicwrites-1.4.0.tar.gz
-test:
-  imports:
-  - atomicwrites

--- a/packages/autograd/meta.yaml
+++ b/packages/autograd/meta.yaml
@@ -4,9 +4,6 @@ package:
 source:
   sha256: a15d147577e10de037de3740ca93bfa3b5a7cdfbc34cfb9105429c3580a33ec4
   url: https://files.pythonhosted.org/packages/23/12/b58522dc2cbbd7ab939c7b8e5542c441c9a06a8eccb00b3ecac04a739896/autograd-1.3.tar.gz
-test:
-  imports:
-  - autograd
 requirements:
   run:
     - numpy

--- a/packages/bleach/meta.yaml
+++ b/packages/bleach/meta.yaml
@@ -9,6 +9,3 @@ requirements:
 source:
   sha256: 3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b
   url: https://files.pythonhosted.org/packages/a9/ac/dc881fca3ac66d6f2c4c3ac46633af4e9c05ed5a0aa2e7e36dc096687dd7/bleach-3.1.5.tar.gz
-test:
-  imports:
-  - bleach

--- a/packages/cloudpickle/meta.yaml
+++ b/packages/cloudpickle/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 820c9245cebdec7257211cbe88745101d5d6a042bca11336d78ebd4897ddbc82
   url: https://files.pythonhosted.org/packages/2b/42/1a742ae7a85e8e15a60696b0519f71db8ee04839fef6007c3859184fbe71/cloudpickle-1.5.0.tar.gz
-test:
-  imports:
-  - cloudpickle

--- a/packages/cssselect/meta.yaml
+++ b/packages/cssselect/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc
   url: https://files.pythonhosted.org/packages/70/54/37630f6eb2c214cdee2ae56b7287394c8aa2f3bafb8b4eb8c3791aae7a14/cssselect-1.1.0.tar.gz
-test:
-  imports:
-  - cssselect

--- a/packages/cycler/meta.yaml
+++ b/packages/cycler/meta.yaml
@@ -5,7 +5,3 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/c2/4b/137dea450d6e1e3d474e1d873cd1d4f7d3beed7e0dc973b06e8e10d32488/cycler-0.10.0.tar.gz
   md5: 4cb42917ac5007d1cdff6cccfe2d016b
-
-test:
-  imports:
-    - cycler

--- a/packages/cytoolz/meta.yaml
+++ b/packages/cytoolz/meta.yaml
@@ -8,6 +8,3 @@ requirements:
   run:
   - nose
   - toolz
-test:
-  imports:
-  - cytoolz

--- a/packages/decorator/meta.yaml
+++ b/packages/decorator/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7
   url: https://files.pythonhosted.org/packages/da/93/84fa12f2dc341f8cf5f022ee09e109961055749df2d0c75c5f98746cfe6c/decorator-4.4.2.tar.gz
-test:
-  imports:
-  - decorator

--- a/packages/distlib/meta.yaml
+++ b/packages/distlib/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1
   url: https://files.pythonhosted.org/packages/2f/83/1eba07997b8ba58d92b3e51445d5bf36f9fba9cb8166bcae99b9c3464841/distlib-0.3.1.zip
-test:
-  imports:
-  - distlib

--- a/packages/docutils/meta.yaml
+++ b/packages/docutils/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc
   url: https://files.pythonhosted.org/packages/2f/e0/3d435b34abd2d62e8206171892f174b180cd37b09d57b924ca5c2ef2219d/docutils-0.16.tar.gz
-test:
-  imports:
-  - docutils

--- a/packages/freesasa/meta.yaml
+++ b/packages/freesasa/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: dca2a71f5a315aff3ad8ee96130d0e17003265d82241378ffc0dcb0f98bf2203
   url: https://files.pythonhosted.org/packages/a8/af/66991b63b705cd1e1c77fdaec157747275ba5c27b5c9dff7a2e35a43477a/freesasa-2.1.0.tar.gz
-test:
-  imports:
-  - freesasa

--- a/packages/future/meta.yaml
+++ b/packages/future/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
   url: https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz
-test:
-  imports:
-  - future

--- a/packages/html5lib/meta.yaml
+++ b/packages/html5lib/meta.yaml
@@ -7,6 +7,3 @@ requirements:
 source:
   sha256: b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
   url: https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz
-test:
-  imports:
-  - html5lib

--- a/packages/imageio/meta.yaml
+++ b/packages/imageio/meta.yaml
@@ -10,6 +10,3 @@ requirements:
   run:
   - numpy
   - pillow
-test:
-  imports:
-  - imageio

--- a/packages/joblib/meta.yaml
+++ b/packages/joblib/meta.yaml
@@ -9,7 +9,3 @@ source:
   patches:
     - patches/use-setuptools.patch
     - patches/ctypes-import.patch
-
-test:
-  imports:
-    - joblib

--- a/packages/kiwisolver/meta.yaml
+++ b/packages/kiwisolver/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f
   url: https://files.pythonhosted.org/packages/62/b8/db619d97819afb52a3ff5ff6ad3f7de408cc83a8ec2dfb31a1731c0a97c2/kiwisolver-1.2.0.tar.gz
-test:
-  imports:
-  - kiwisolver

--- a/packages/micropip/meta.yaml
+++ b/packages/micropip/meta.yaml
@@ -6,6 +6,3 @@ requirements:
     - distlib
 source:
   path: micropip
-test:
-  imports:
-  - micropip

--- a/packages/mne/meta.yaml
+++ b/packages/mne/meta.yaml
@@ -10,7 +10,3 @@ requirements:
   run:
     - numpy
     - scipy
-
-test:
-  imports:
-    - mne

--- a/packages/more-itertools/meta.yaml
+++ b/packages/more-itertools/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20
   url: https://files.pythonhosted.org/packages/d6/03/37d7c431c4c1c17507fb7b89240ddb7be70f2027277960d525f1679363c1/more-itertools-8.5.0.tar.gz
-test:
-  imports:
-  - more_itertools

--- a/packages/mpmath/meta.yaml
+++ b/packages/mpmath/meta.yaml
@@ -8,7 +8,3 @@ source:
 
   patches:
     - patches/fix-warnings.patch
-
-test:
-  imports:
-    - mpmath

--- a/packages/msgpack/meta.yaml
+++ b/packages/msgpack/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984
   url: https://files.pythonhosted.org/packages/59/04/87fc6708659c2ed3b0b6d4954f270b6e931def707b227c4554f99bd5401e/msgpack-1.0.2.tar.gz
-test:
-  imports:
-  - msgpack

--- a/packages/networkx/meta.yaml
+++ b/packages/networkx/meta.yaml
@@ -12,31 +12,3 @@ requirements:
 source:
   sha256: f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64
   url: https://files.pythonhosted.org/packages/bf/63/7b579dd3b1c49ce6b7fd8f6f864038f255201410905dd183cf7f4a3845cf/networkx-2.4.tar.gz
-test:
-  imports:
-  - networkx
-  - networkx.algorithms
-  - networkx.algorithms.approximation
-  - networkx.algorithms.assortativity
-  - networkx.algorithms.bipartite
-  - networkx.algorithms.centrality
-  - networkx.algorithms.chordal
-  - networkx.algorithms.coloring
-  - networkx.algorithms.community
-  - networkx.algorithms.components
-  - networkx.algorithms.connectivity
-  - networkx.algorithms.flow
-  - networkx.algorithms.isomorphism
-  - networkx.algorithms.link_analysis
-  - networkx.algorithms.node_classification
-  - networkx.algorithms.operators
-  - networkx.algorithms.shortest_paths
-  - networkx.algorithms.traversal
-  - networkx.algorithms.tree
-  - networkx.classes
-  - networkx.drawing
-  - networkx.generators
-  - networkx.linalg
-  - networkx.readwrite
-  - networkx.readwrite.json_graph
-  - networkx.utils

--- a/packages/nltk/meta.yaml
+++ b/packages/nltk/meta.yaml
@@ -7,6 +7,3 @@ source:
 requirements:
   run:
     - regex
-test:
-  imports:
-  - nltk

--- a/packages/nose/meta.yaml
+++ b/packages/nose/meta.yaml
@@ -9,7 +9,3 @@ source:
 requirements:
   run:
     - setuptools
-
-test:
-  imports:
-    - nose

--- a/packages/numcodecs/meta.yaml
+++ b/packages/numcodecs/meta.yaml
@@ -12,6 +12,3 @@ requirements:
   run:
     - numpy
     - msgpack
-test:
-  imports:
-  - numcodecs

--- a/packages/numpy/meta.yaml
+++ b/packages/numpy/meta.yaml
@@ -20,8 +20,3 @@ source:
 build:
   skip_host: False
   cflags: -include math.h -I../../config
-
-
-test:
-  imports:
-    - numpy

--- a/packages/packaging/meta.yaml
+++ b/packages/packaging/meta.yaml
@@ -8,7 +8,3 @@ source:
 requirements:
   run:
     - pyparsing
-
-test:
-  imports:
-  - packaging

--- a/packages/pandas/meta.yaml
+++ b/packages/pandas/meta.yaml
@@ -14,7 +14,3 @@ requirements:
     - numpy
     - python-dateutil
     - pytz
-
-test:
-  imports:
-    - pandas

--- a/packages/patsy/meta.yaml
+++ b/packages/patsy/meta.yaml
@@ -10,7 +10,3 @@ source:
 requirements:
   run:
     - numpy
-
-test:
-  imports:
-    - patsy

--- a/packages/pluggy/meta.yaml
+++ b/packages/pluggy/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0
   url: https://files.pythonhosted.org/packages/f8/04/7a8542bed4b16a65c2714bf76cf5a0b026157da7f75e87cc88774aa10b14/pluggy-0.13.1.tar.gz
-test:
-  imports:
-  - pluggy

--- a/packages/py/meta.yaml
+++ b/packages/py/meta.yaml
@@ -4,7 +4,3 @@ package:
 source:
   sha256: 9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342
   url: https://files.pythonhosted.org/packages/97/a6/ab9183fe08f69a53d06ac0ee8432bc0ffbb3989c575cc69b73a0229a9a99/py-1.9.0.tar.gz
-test:
-  imports:
-  - py
-  - py.code

--- a/packages/pyodide-interrupts/meta.yaml
+++ b/packages/pyodide-interrupts/meta.yaml
@@ -5,7 +5,3 @@ package:
 source:
   url: https://files.pythonhosted.org/packages/b1/c2/918c52e47bf91570d9883a1c761c4d78a59cf4d1d8f8c67c25a4e164ff87/pyodide-interrupts-0.1.1.tar.gz
   sha256: b85bc38b92cd5c35dd1a5192a71495abe4cd57eadccfacbc0421fb44fb6c9e74
-
-test:
-  imports:
-    - pyodide_interrupts

--- a/packages/pyparsing/meta.yaml
+++ b/packages/pyparsing/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1
   url: https://files.pythonhosted.org/packages/c1/47/dfc9c342c9842bbe0036c7f763d2d6686bcf5eb1808ba3e170afdb282210/pyparsing-2.4.7.tar.gz
-test:
-  imports:
-  - pyparsing

--- a/packages/pytest/meta.yaml
+++ b/packages/pytest/meta.yaml
@@ -17,7 +17,3 @@ requirements:
     - pluggy
     - py
     - setuptools
-
-test:
-  imports:
-    - pytest

--- a/packages/pytz/meta.yaml
+++ b/packages/pytz/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048
   url: https://files.pythonhosted.org/packages/f4/f6/94fee50f4d54f58637d4b9987a1b862aeb6cd969e73623e02c5c00755577/pytz-2020.1.tar.gz
-test:
-  imports:
-  - pytz

--- a/packages/regex/meta.yaml
+++ b/packages/regex/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb
   url: https://files.pythonhosted.org/packages/09/c3/ddaa87500f31ed86290e3d014c0302a51fde28d7139eda0b5f33733726db/regex-2020.7.14.tar.gz
-test:
-  imports:
-  - regex

--- a/packages/scipy/meta.yaml
+++ b/packages/scipy/meta.yaml
@@ -30,19 +30,3 @@ requirements:
   run:
     - numpy
     - CLAPACK
-
-test:
-  imports:
-    - scipy
-    - scipy.cluster
-    - scipy.constants
-    - scipy.fftpack
-    - scipy.odr
-    - scipy.sparse
-    - scipy.interpolate
-    - scipy.integrate
-    - scipy.linalg
-    - scipy.misc
-    - scipy.ndimage
-    - scipy.spatial
-    - scipy.special

--- a/packages/soupsieve/meta.yaml
+++ b/packages/soupsieve/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232
   url: https://files.pythonhosted.org/packages/3e/db/5ba900920642414333bdc3cb397075381d63eafc7e75c2373bbc560a9fa1/soupsieve-2.0.1.tar.gz
-test:
-  imports:
-  - soupsieve

--- a/packages/statsmodels/meta.yaml
+++ b/packages/statsmodels/meta.yaml
@@ -13,7 +13,3 @@ requirements:
     - scipy
     - pandas
     - patsy
-
-test:
-  imports:
-    - statsmodels

--- a/packages/sympy/meta.yaml
+++ b/packages/sympy/meta.yaml
@@ -7,6 +7,3 @@ requirements:
 source:
   sha256: 1cfadcc80506e4b793f5b088558ca1fcbeaec24cd6fc86f1fdccaa3ee1d48708
   url: https://files.pythonhosted.org/packages/8a/43/d433f66b01a355d12602ccc7de409aea4b3a1cfdb7a2fb5dac57eb4b09c1/sympy-1.6.2.tar.gz
-test:
-  imports:
-  - sympy

--- a/packages/toolz/meta.yaml
+++ b/packages/toolz/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 08fdd5ef7c96480ad11c12d472de21acd32359996f69a5259299b540feba4560
   url: https://files.pythonhosted.org/packages/22/8e/037b9ba5c6a5739ef0dcde60578c64d49f45f64c5e5e886531bfbc39157f/toolz-0.10.0.tar.gz
-test:
-  imports:
-  - toolz

--- a/packages/traits/meta.yaml
+++ b/packages/traits/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 807da52ee0d4fc1241c8f8a04d274a28d4b23d3a5f942152497d19405482d04f
   url: https://files.pythonhosted.org/packages/94/d4/be3765c4c1ada555a91daa5cc9df3b6c2557ec4b55ba181c23ef5682e1f8/traits-6.1.1.tar.gz
-test:
-  imports:
-  - traits

--- a/packages/uncertainties/meta.yaml
+++ b/packages/uncertainties/meta.yaml
@@ -7,6 +7,3 @@ source:
 requirements:
   run:
     - future
-test:
-  imports:
-  - uncertainties

--- a/packages/webencodings/meta.yaml
+++ b/packages/webencodings/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
   url: https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz
-test:
-  imports:
-  - webencodings

--- a/packages/xlrd/meta.yaml
+++ b/packages/xlrd/meta.yaml
@@ -4,6 +4,3 @@ package:
 source:
   sha256: 546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2
   url: https://files.pythonhosted.org/packages/aa/05/ec9d4fcbbb74bbf4da9f622b3b61aec541e4eccf31d3c60c5422ec027ce2/xlrd-1.2.0.tar.gz
-test:
-  imports:
-  - xlrd

--- a/packages/yt/meta.yaml
+++ b/packages/yt/meta.yaml
@@ -15,7 +15,3 @@ requirements:
     - matplotlib
     - sympy
     - setuptools
-
-test:
-  imports:
-    - yt

--- a/packages/zarr/meta.yaml
+++ b/packages/zarr/meta.yaml
@@ -11,6 +11,3 @@ requirements:
     - numpy
     - asciitree
     - numcodecs
-test:
-  imports:
-  - zarr

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -232,7 +232,7 @@ def build_packages(packages_dir: Path, outputdir: Path, args) -> None:
         package_data["dependencies"][name] = [
             x for x in pkg.dependencies if x not in libraries
         ]
-        for imp in pkg.meta.get("test", {}).get("imports", [name]):
+        for imp in pkg.meta.get("test", {}).get("imports", [name.replace("-", "_")]):
             package_data["import_name_to_package_name"][imp] = name
 
     with open(outputdir / "packages.json", "w") as fd:

--- a/pyodide_build/mkpkg.py
+++ b/pyodide_build/mkpkg.py
@@ -67,7 +67,6 @@ def make_package(package: str, version: Optional[str] = None):
     yaml_content = {
         "package": {"name": package, "version": version},
         "source": {"url": url, "sha256": sha256},
-        "test": {"imports": [package]},
     }
 
     if not (PACKAGES_ROOT / package).is_dir():


### PR DESCRIPTION
In particular, in the cases of e.g. scipy, the scipy.\* ones are not needed because when we find imports, we strip everything after the first dot.
