### PR TITLE
Fix pywasmcross race condition

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -111,8 +111,10 @@ def make_symlinks(env):
         if os.path.lexists(symlink_path) and not symlink_path.exists():
             # remove broken symlink so it can be re-created
             symlink_path.unlink()
-        if not symlink_path.exists():
+        try:
             symlink_path.symlink_to(exec_path)
+        except FileExistsError:
+            pass
         if symlink == "c++":
             var = "CXX"
         else:


### PR DESCRIPTION
When building packages in parallel, it is possible that the symlink is created by a different thread between the check and the linking, which causes the build to fail. This has happened multiple times in CI.

Instead, just try to create the symlink and pass if it already exists, which is the pythonic way of doing this.
