### PR TITLE
build .o files rather than .bc files. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,16 +61,16 @@ all: check \
 	echo -e "\nSUCCESS!"
 
 
-build/pyodide.asm.js: src/core/main.bc src/core/jsimport.bc \
-	        src/core/jsproxy.bc src/core/js2python.bc \
-		src/core/pyproxy.bc \
-		src/core/python2js.bc \
-		src/core/python2js_buffer.bc \
-		src/core/runpython.bc src/core/hiwire.bc \
+build/pyodide.asm.js: src/core/main.o src/core/jsimport.o \
+	        src/core/jsproxy.o src/core/js2python.o \
+		src/core/pyproxy.o \
+		src/core/python2js.o \
+		src/core/python2js_buffer.o \
+		src/core/runpython.o src/core/hiwire.o \
 		root/.built
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d build ] || mkdir build
-	$(CXX) -s EXPORT_NAME="'pyodide'" -o build/pyodide.asm.js $(filter %.bc,$^) \
+	$(CXX) -s EXPORT_NAME="'pyodide'" -o build/pyodide.asm.js $(filter %.o,$^) \
 		$(LDFLAGS) -s FORCE_FILESYSTEM=1 --preload-file root/lib@lib
 	date +"[%F %T] done building pyodide.asm.js."
 
@@ -127,7 +127,7 @@ benchmark: all
 clean:
 	rm -fr root
 	rm -fr build/*
-	rm -fr src/*.bc
+	rm -fr src/*.o
 	rm -fr node_modules
 	make -C packages clean
 	make -C packages/jedi clean
@@ -143,7 +143,7 @@ clean-all: clean
 	make -C cpython clean
 	rm -fr cpython/build
 
-%.bc: %.c $(CPYTHONLIB) $(wildcard src/**/*.h)
+%.o: %.c $(CPYTHONLIB) $(wildcard src/**/*.h)
 	$(CC) -o $@ -c $< $(CFLAGS) -Isrc/core/
 
 

--- a/packages/CLAPACK/Makefile
+++ b/packages/CLAPACK/Makefile
@@ -8,16 +8,16 @@ ROOT=$(abspath .)
 SRC=$(ROOT)/CLAPACK-WA
 
 
-all: $(SRC)/lapack_WA.bc
+all: $(SRC)/lapack_WA.a
 
 clean:
 	rm -rf CLAPACK-WA
 
-$(SRC)/lapack_WA.bc:  $(SRC)/Makefile
+$(SRC)/lapack_WA.a:  $(SRC)/Makefile
 	# We build BLAS/LAPACK only for target.
 	# On host we include -LCLAPACK-WA path which has no effect on host.
 	# On target it gets rewritten by pywasmcross to the full patch of
-	# blas_WA.bc, lapack_WA.bc which are linked statically in scipy
+	# blas_WA.a, lapack_WA.a which are linked statically in scipy
 	# in each module that needs them.
 	emmake make -C CLAPACK-WA/ -j $${PYODIDE_JOBS:-3} blaslib lapacklib
 

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -271,10 +271,7 @@ def handle_command(line, args, dryrun=False):
         # The native build is possibly multithreaded, but the emscripten one
         # definitely isn't
         arg = re.sub(r"/python([0-9]\.[0-9]+)m", r"/python\1", arg)
-        if arg.endswith(".o"):
-            arg = arg[:-2] + ".bc"
-            output = arg
-        elif arg.endswith(".so"):
+        if arg.endswith(".so"):
             arg = arg[:-3] + ".wasm"
             output = arg
 

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -37,21 +37,21 @@ def test_handle_command():
     assert handle_command_wrap("gcc test.c", args) == "emcc test.c"
     assert (
         handle_command_wrap("gcc -shared -c test.o -o test.so", args)
-        == "emcc -shared -c test.bc -o test.wasm"
+        == "emcc -shared -c test.o -o test.wasm"
     )
 
     # check cxxflags injection and cpp detection
     args = Args(cflags="-I./lib2", cxxflags="-std=c++11", ldflags="-lm", host="")
     assert (
         handle_command_wrap("gcc -I./lib1 test.cpp -o test.o", args)
-        == "em++ -I./lib2 -std=c++11 -I./lib1 test.cpp -o test.bc"
+        == "em++ -I./lib2 -std=c++11 -I./lib1 test.cpp -o test.o"
     )
 
     # check ldflags injection
     args = Args(cflags="", cxxflags="", ldflags="-lm", host="")
     assert (
         handle_command_wrap("gcc -shared -c test.o -o test.so", args)
-        == "emcc -lm -shared -c test.bc -o test.wasm"
+        == "emcc -lm -shared -c test.o -o test.wasm"
     )
 
     # compilation checks in numpy
@@ -73,4 +73,4 @@ def test_conda_compiler_compat():
     args = Args(cflags="", cxxflags="", ldflags="", host="")
     assert handle_command_wrap(
         "gcc -shared -c test.o -B /compiler_compat -o test.so", args
-    ) == ("emcc -shared -c test.bc -o test.wasm")
+    ) == ("emcc -shared -c test.o -o test.wasm")


### PR DESCRIPTION
asm.js fastcomp build doesn't care about the file extension. upstream (wasm direct) build needs it to be .o

