### PR TITLE
Use replace-libs for matplotlib

### DIFF
--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -23,6 +23,8 @@ source:
 build:
   cflags: -s USE_FREETYPE=1 -s USE_LIBPNG=1 -s USE_ZLIB=1
   ldflags: ../../../../emsdk/emsdk/fastcomp/emscripten/cache/asmjs/libpng.bc
+  replace-libs:
+    - png16=png
   post: |
     wget -O $SITEPACKAGES/matplotlib/mpl-data/fonts/ttf/Humor-Sans.ttf http://antiyawn.com/uploads/Humor-Sans-1.0.ttf
     rm -rf $SITEPACKAGES/matplotlib/backends/qt_editor

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -330,7 +330,7 @@ def handle_command(line, args, dryrun=False):
             continue
 
         # See https://github.com/emscripten-core/emscripten/issues/8650
-        if arg in ["-lfreetype", "-lz", "-lpng16", "-lgfortran"]:
+        if arg in ["-lfreetype", "-lz", "-lpng", "-lgfortran"]:
             continue
 
         new_args.append(arg)


### PR DESCRIPTION
The library that is supplied by USE_PNG is png, but matplotlib seeks png16. With the fastcomp backend, we end up ignoring it anyway, but with the upstream backend this will be the correct course of action
