### PR TITLE
Fix commented trailing semicolon in eval_code.

### DIFF
--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -48,6 +48,15 @@ def quiet_code(code: str) -> bool:
     Does the last nonwhitespace character of code is a semicolon?
 
     This can be overridden to customize the way eval_code is silenced.
+
+    Examples
+    --------
+    >>> quiet_code('x + 1')
+    False
+    >>> quiet_code('x + 1 ;')
+    True
+    >>> quiet_code('x + 1 # comment ;')
+    False
     """
     # largely inspired from IPython:
     # https://github.com/ipython/ipython/blob/86d24741188b0cedd78ab080d498e775ed0e5272/IPython/core/displayhook.py#L84

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -58,7 +58,7 @@ def quiet_code(code: str) -> bool:
     for token in reversed(tokens):
         if token.type in (
             tokenize.ENDMARKER,
-            tokenize.NL,
+            tokenize.NL,  # ignoring empty lines (\n\n)
             tokenize.NEWLINE,
             tokenize.COMMENT,
         ):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -102,6 +102,8 @@ def test_eval_code():
     assert ns["x"] == 7
 
     assert eval_code("1+1;", ns) is None
+    assert eval_code("1+1#;", ns) == 2
+    assert eval_code("5-2  # comment with trailing semicolon ;", ns) == 3
 
 
 def test_monkeypatch_eval_code(selenium):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -104,6 +104,10 @@ def test_eval_code():
     assert eval_code("1+1;", ns) is None
     assert eval_code("1+1#;", ns) == 2
     assert eval_code("5-2  # comment with trailing semicolon ;", ns) == 3
+    assert eval_code("4//2\n", ns) == 2
+    assert eval_code("2**1\n\n", ns) == 2
+    assert eval_code("4//2;\n", ns) is None
+    assert eval_code("2**1;\n\n", ns) is None
 
 
 def test_monkeypatch_eval_code(selenium):


### PR DESCRIPTION
Semicolon at the end of a comment does not return last expression's result.

``` python
eval_code("1+1 # comment;")
```
returns `None` instead of `2`.

This should be fixed by this PR.