### PR TITLE
Added a monkey patch disabling _path_importer_cache

### DIFF
--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,5 +1,10 @@
 from ._base import open_url, eval_code, find_imports, as_nested_list, JsException
+from . import _importhooks
 from .console import get_completions
+
+# "Use" _importhooks to disable mypy unused import error,
+# we need to execute _importhooks.
+_importhooks = _importhooks
 
 __version__ = "0.16.1"
 

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,10 +1,9 @@
 from ._base import open_url, eval_code, find_imports, as_nested_list, JsException
-from . import _importhooks
+from ._importhooks import _monkeypatch_path_importer_cache
 from .console import get_completions
 
-# "Use" _importhooks to disable mypy unused import error,
-# we need to execute _importhooks.
-_importhooks = _importhooks
+_monkeypatch_path_importer_cache()
+del _monkeypatch_path_importer_cache
 
 __version__ = "0.16.1"
 

--- a/src/pyodide-py/pyodide/_importhooks.py
+++ b/src/pyodide-py/pyodide/_importhooks.py
@@ -69,7 +69,3 @@ def _monkeypatch_path_importer_cache():
         return cls._path_hooks(path)
 
     PathFinder._path_importer_cache = _path_importer_cache
-
-
-_monkeypatch_path_importer_cache()
-del _monkeypatch_path_importer_cache

--- a/src/pyodide-py/pyodide/_importhooks.py
+++ b/src/pyodide-py/pyodide/_importhooks.py
@@ -1,0 +1,75 @@
+# mypy gets angry about PathFinder._path_importer_cache.
+# mypy: ignore-errors
+import os
+import inspect
+from textwrap import dedent
+from importlib.machinery import PathFinder
+
+
+def _monkeypatch_path_importer_cache():
+    """ Get rid of _path_importer_cache, which causes trouble for us. """
+    # Future proofing: Double check that the original source of _path_importer_cache
+    # is what we expect. (TODO: do we want this?)
+    #
+    # inspect.getsourcefile returns the wrong thing on PathFinder._path_importer_cache
+    # but it behaves correctly on PathFinder. Temporarily monkey patch getsourcefile
+    sourcefile = inspect.getsourcefile(PathFinder)
+    save_inspect_getsourcefile = inspect.getsourcefile
+
+    def temp_inspect_getsourcefile(object):
+        return sourcefile
+
+    inspect.getsourcefile = temp_inspect_getsourcefile
+    orig_source = inspect.getsource(PathFinder._path_importer_cache)
+    # Restore getsourcefile
+    inspect.getsourcefile = save_inspect_getsourcefile
+
+    supposed_orig_source = '''\
+    @classmethod
+    def _path_importer_cache(cls, path):
+        """Get the finder for the path entry from sys.path_importer_cache.
+
+        If the path entry is not in the cache, find the appropriate finder
+        and cache it. If no finder is available, store None.
+
+        """
+        if path == '':
+            try:
+                path = _os.getcwd()
+            except FileNotFoundError:
+                # Don't cache the failure as the cwd can easily change to
+                # a valid directory later on.
+                return None
+        try:
+            finder = sys.path_importer_cache[path]
+        except KeyError:
+            finder = cls._path_hooks(path)
+            sys.path_importer_cache[path] = finder
+        return finder
+    '''
+
+    if dedent(orig_source) != dedent(supposed_orig_source):
+        raise RuntimeWarning(
+            "Unexpected definition of _path_importer_cache, skipping monkey patch."
+        )
+
+    @classmethod
+    def _path_importer_cache(cls, path):
+        """
+        Monkey path for PathFinder._path_importer_cache.
+        The import cache has given us various troubles over time. End these problems once
+        and for all by never using it!
+        """
+        if path == "":
+            try:
+                path = os.getcwd()
+            except FileNotFoundError:
+                return None
+        # Jinx: don't cache anything!
+        return cls._path_hooks(path)
+
+    PathFinder._path_importer_cache = _path_importer_cache
+
+
+_monkeypatch_path_importer_cache()
+del _monkeypatch_path_importer_cache

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -249,12 +249,6 @@ var languagePluginLoader = new Promise((resolve, reject) => {
           }
         });
       }
-
-      // We have to invalidate Python's import caches, or it won't
-      // see the new files. This is done here so it happens in parallel
-      // with the fetching over the network.
-      self.pyodide.runPython('import importlib as _importlib\n' +
-                             '_importlib.invalidate_caches()\n');
     });
 
     return promise;


### PR DESCRIPTION
I'm not sure if this is a good choice, but it seems like an option to consider.

We've had various troubles with the import cache and the EmscriptenFS date modified times. This completely disables the cache which should prevent any need for `importlib.invalidate_cache` and any bugs related to import cache from ever coming up again.

I'm not sure what the performance implications of this are. We could also implement a different caching strategy which is more conservative than the normal one but less conservative than always refetching from scratch.