### PR TITLE
Simplifying eval_code and avoid injecting dummy variable.

### DIFF
--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -43,7 +43,7 @@ def open_url(url: str) -> StringIO:
     return StringIO(req.response)
 
 
-class CodeRunner(object):
+class CodeRunner:
     """
     A code runner to serve eval_code and eval_code_async.
 
@@ -61,9 +61,9 @@ class CodeRunner(object):
         Parameters
         ----------
         code
-        the Python code to run.
+           the Python code to run.
         ns
-        `locals()` or `globals()` context where to execute code.
+           `locals()` or `globals()` context where to execute code.
         """
         # handle mis-indented input from multi-line strings
         code = dedent(code)
@@ -93,11 +93,11 @@ class CodeRunner(object):
 
         Examples
         --------
-        >>> CodeRunner('x + 1', {}).quiet()
+        >>> CodeRunner('1 + 1', {}).quiet()
         False
-        >>> CodeRunner('x + 1 ;', {}).quiet()
+        >>> CodeRunner('1 + 1 ;', {}).quiet()
         True
-        >>> CodeRunner('x + 1 # comment ;', {}).quiet()
+        >>> CodeRunner('1 + 1 # comment ;', {}).quiet()
         False
         """
         # largely inspired from IPython:

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -65,8 +65,6 @@ class CodeRunner:
     """
 
     def __init__(self, ns: Dict[str, Any] = None):
-        # handle mis-indented input from multi-line strings
-
         self.ns = ns if ns is not None else {}
         self.filename = "<exec>"
 
@@ -119,6 +117,7 @@ class CodeRunner:
         code object
             last expression's code object (or None)
         """
+        # handle mis-indented input from multi-line strings
         code = dedent(code)
 
         mod = ast.parse(code)

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -47,25 +47,27 @@ class CodeRunner:
     """
     A code runner to serve eval_code and eval_code_async.
 
+    Parameters
+    ----------
+    ns
+        `locals()` or `globals()` context where to execute code.
+        This namespace is updated by the subsequent calls to `run()`.
+
     Examples
     --------
     >>> CodeRunner().run("1+1")
     2
     >>> CodeRunner().run("1+1;")
+    >>> runner = CodeRunner()
+    >>> runner.run("x = 5")
+    >>> runner.run("x + 1")
+    6
     """
 
-    def __init__(self, ns: Dict[str, Any] = {}):
-        """
-        Constructor.
-
-        Parameters
-        ----------
-        ns
-           `locals()` or `globals()` context where to execute code.
-        """
+    def __init__(self, ns: Dict[str, Any] = None):
         # handle mis-indented input from multi-line strings
 
-        self.ns = ns
+        self.ns = ns if ns is not None else {}
         self.filename = "<exec>"
 
     def quiet(self, code: str) -> bool:

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1,5 +1,3 @@
-import ast
-from copy import deepcopy
 from pathlib import Path
 import sys
 from textwrap import dedent
@@ -7,7 +5,6 @@ from textwrap import dedent
 sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
 from pyodide import find_imports, eval_code  # noqa: E402
-from pyodide._base import _adjust_ast_to_store_result
 
 
 def test_find_imports():
@@ -22,63 +19,6 @@ def test_find_imports():
         )
     )
     assert set(res) == {"numpy", "scipy", "matplotlib"}
-
-
-def test_adjust_ast():
-    target_name = "<EXEC-LAST-EXPRESSION>"
-
-    def helper(code):
-        code = dedent(code)
-        mod = ast.parse(code)
-        return [mod, _adjust_ast_to_store_result(target_name, deepcopy(mod), code)]
-
-    def assert_stored_last_line(code):
-        [mod, adjusted_mod] = helper(code)
-        assert (
-            ast.dump(adjusted_mod.body[-1].targets[0])
-            == f"Name(id='{target_name}', ctx=Store())"
-        )
-        assert ast.dump(adjusted_mod.body[-1].value) == ast.dump(mod.body[-1].value)
-        mod.body.pop()
-        adjusted_mod.body.pop()
-        assert ast.dump(mod) == ast.dump(adjusted_mod)
-
-    def assert_stored_none(code):
-        [mod, adjusted_mod] = helper(code)
-        assert (
-            ast.dump(adjusted_mod.body[-1].targets[0])
-            == f"Name(id='{target_name}', ctx=Store())"
-        )
-        assert (
-            ast.dump(adjusted_mod.body[-1].value) == "Constant(value=None, kind=None)"
-        )
-        adjusted_mod.body.pop()
-        assert ast.dump(mod) == ast.dump(adjusted_mod)
-
-    assert_stored_last_line("1+1")
-    assert_stored_last_line("await 1+1")
-    assert_stored_last_line("print(2)")
-    assert_stored_last_line("(x:=4)")
-
-    assert_stored_none("x=4")
-    assert_stored_none("1+1;")
-    assert_stored_none("def f(): 4")
-    assert_stored_none(
-        """
-        def f():
-            print(9)
-            return 2*7 + 5
-    """
-    )
-
-    assert_stored_last_line(
-        """
-        def f(x):
-            print(9)
-            return 2*x + 5
-        f(77)
-    """
-    )
 
 
 def test_eval_code():

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
 from pyodide import find_imports, eval_code  # noqa: E402
+from pyodide._base import CodeRunner  # noqa: E402
 
 
 def test_find_imports():
@@ -19,6 +20,14 @@ def test_find_imports():
         )
     )
     assert set(res) == {"numpy", "scipy", "matplotlib"}
+
+
+def test_code_runner():
+    ns = {}
+    assert CodeRunner("1+1;", ns).quiet()
+    assert not CodeRunner("1+1#;", ns).quiet()
+    assert not CodeRunner("5-2  # comment with trailing semicolon ;", ns).quiet()
+    assert CodeRunner("4//2\n", ns).run() == 2
 
 
 def test_eval_code():

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -23,11 +23,11 @@ def test_find_imports():
 
 
 def test_code_runner():
-    ns = {}
-    assert CodeRunner("1+1;", ns).quiet()
-    assert not CodeRunner("1+1#;", ns).quiet()
-    assert not CodeRunner("5-2  # comment with trailing semicolon ;", ns).quiet()
-    assert CodeRunner("4//2\n", ns).run() == 2
+    runner = CodeRunner()
+    assert runner.quiet("1+1;")
+    assert not runner.quiet("1+1#;")
+    assert not runner.quiet("5-2  # comment with trailing semicolon ;")
+    assert runner.run("4//2\n") == 2
 
 
 def test_eval_code():


### PR DESCRIPTION
#876 brings interesting features to `eval_code`. However, I am not an `AST` expert but the resulting code looks overly complicated to me:

- is the introduction of ̀`<EXEC-LAST-EXPRESSION>` to assign last expression considered good practice?
- is it really safe?
- the redundancy between `eval_code` and `_eval_code_async` doesn't follow the DRY principle
- the previous `mod.body` splitting was nice and clear and can be kept
- `_adjust_ast_to_store_result` and `_adjust_ast_to_store_result_helper` can be avoided (no need to test them!)

This PR aims at recovering the clearness of `eval_code` while supporting the semicolon feature and factorizing  `eval_code` and `_eval_code_async`.

A review by @hoodmane will be nice as he probably wrote it like this for some reason that eludes me.

Lastly, I should mention that this splitting method is what is [used in IPython ](https://github.com/ipython/ipython/blob/3587f5bb6c8570e7bbb06cf5f7e3bc9b9467355a/IPython/core/interactiveshell.py#L3229) apart from the fact that last expression is evaluated in `single`mode (the result is then caught by `sys.displayhook`).