### PR TITLE
Clean up workspace after core-python build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,12 @@ jobs:
             - ~/.ccache
           key: -{{ checksum "Makefile.envs" }}-v20201205-{{ .BuildNum }}
 
+      - run:
+          name: Clean up workspace
+          command: |
+            rm -rf cpython/{build,downloads}
+            rm -rf emsdk/emsdk/binaryen
+
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
Persisting fewer artifacts between jobs should give a slightly faster build. This also guarantees that all we need to build packages are `emsdk` and `cpython/installs`, which is useful for third party packages building.