### PR TITLE
Customizable eval_code behavior

### DIFF
--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -52,6 +52,8 @@ class CodeRunner:
     ns
         `locals()` or `globals()` context where to execute code.
         This namespace is updated by the subsequent calls to `run()`.
+    filename:
+        file from which the code was read.
 
     Examples
     --------
@@ -64,9 +66,9 @@ class CodeRunner:
     6
     """
 
-    def __init__(self, ns: Dict[str, Any] = None):
+    def __init__(self, ns: Dict[str, Any] = None, filename: str = "<exec>"):
         self.ns = ns if ns is not None else {}
-        self.filename = "<exec>"
+        self.filename = filename
 
     def quiet(self, code: str) -> bool:
         """
@@ -185,7 +187,7 @@ class CodeRunner:
             return res
 
 
-def eval_code(code: str, ns: Dict[str, Any]) -> Any:
+def eval_code(code: str, ns: Dict[str, Any], filename: str = "<exec>") -> Any:
     """Runs a code string.
 
     Parameters
@@ -194,6 +196,8 @@ def eval_code(code: str, ns: Dict[str, Any]) -> Any:
        the Python code to run.
     ns
        `locals()` or `globals()` context where to execute code.
+    filename:
+       file from which the code was read.
 
     Returns
     -------
@@ -201,10 +205,12 @@ def eval_code(code: str, ns: Dict[str, Any]) -> Any:
     If the last statement is an expression, return the
     result of the expression.
     """
-    return CodeRunner(ns).run(code)
+    return CodeRunner(ns, filename).run(code)
 
 
-async def _eval_code_async(code: str, ns: Dict[str, Any]) -> Any:
+async def _eval_code_async(
+    code: str, ns: Dict[str, Any], filename: str = "<exec>"
+) -> Any:
     """ //!\\ WARNING //!\\
     This is not working yet. For use once we add an EventLoop.
 
@@ -215,7 +221,7 @@ async def _eval_code_async(code: str, ns: Dict[str, Any]) -> Any:
       - add tests
     """
     raise NotImplementedError("Async is not yet supported in Pyodide.")
-    return await CodeRunner(ns).run_async(code)
+    return await CodeRunner(ns, filename).run_async(code)
 
 
 def find_imports(code: str) -> List[str]:

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -8,7 +8,7 @@ import ast
 from asyncio import iscoroutine
 from io import StringIO
 from textwrap import dedent
-from typing import Dict, List, Any, Tuple
+from typing import Dict, List, Any, Tuple, Optional
 import tokenize
 
 
@@ -81,7 +81,7 @@ class CodeRunner:
 
     def __init__(
         self,
-        ns: Dict[str, Any] = None,
+        ns: Optional[Dict[str, Any]] = None,
         mode: str = "last_expr",
         quiet_trailing_semicolon: bool = True,
         filename: str = "<exec>",
@@ -199,7 +199,7 @@ class CodeRunner:
         return mod, last_expr
 
     def run(self, code: str) -> Any:
-        """
+        """Runs a code string.
 
         Parameters
         ----------

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -150,7 +150,7 @@ class CodeRunner:
             return
 
         target: Any
-        if isinstance(last_node, ast.Assign) and len(last_node.targets) == 1:
+        if isinstance(last_node, ast.Assign):
             target = last_node.targets[0]
         elif isinstance(last_node, single_targets_nodes):
             target = last_node.target

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -50,6 +50,7 @@ def test_eval_code():
     assert eval_code("x=7", ns) is None
     assert ns["x"] == 7
 
+    # default mode ('last_expr'), semicolon
     assert eval_code("1+1;", ns) is None
     assert eval_code("1+1#;", ns) == 2
     assert eval_code("5-2  # comment with trailing semicolon ;", ns) == 3
@@ -57,6 +58,20 @@ def test_eval_code():
     assert eval_code("2**1\n\n", ns) == 2
     assert eval_code("4//2;\n", ns) is None
     assert eval_code("2**1;\n\n", ns) is None
+
+    # 'last_expr_or_assign' mode, semicolon
+    assert eval_code("1 + 1", ns, mode="last_expr_or_assign") == 2
+    assert eval_code("x = 1 + 1", ns, mode="last_expr_or_assign") == 2
+    assert eval_code("a = 5 ; a += 1", ns, mode="last_expr_or_assign") == 6
+    assert eval_code("a = 5 ; a += 1;", ns, mode="last_expr_or_assign") is None
+    assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, mode="last_expr_or_assign") is None
+
+    # 'none' mode, (useless) semicolon
+    assert eval_code("1 + 1", ns, mode="none") is None
+    assert eval_code("x = 1 + 1", ns, mode="none") is None
+    assert eval_code("a = 5 ; a += 1", ns, mode="none") is None
+    assert eval_code("a = 5 ; a += 1;", ns, mode="none") is None
+    assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, mode="none") is None
 
 
 def test_monkeypatch_eval_code(selenium):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -74,6 +74,7 @@ def test_eval_code():
     assert eval_code("a = 5 ; a += 1", ns, mode="last_expr_or_assign") == 6
     assert eval_code("a = 5 ; a += 1;", ns, mode="last_expr_or_assign") is None
     assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, mode="last_expr_or_assign") is None
+    assert eval_code("a = b = 2", ns, mode="last_expr_or_assign") == 2
 
     # 'none' mode, (useless) semicolon
     assert eval_code("1 + 1", ns, mode="none") is None

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -29,6 +29,15 @@ def test_code_runner():
     assert not runner.quiet("5-2  # comment with trailing semicolon ;")
     assert runner.run("4//2\n") == 2
     assert runner.run("4//2;") is None
+    assert runner.run("x = 2\nx") == 2
+    assert runner.run("def f(x):\n    return x*x+1\n[f(x) for x in range(6)]") == [
+        1,
+        2,
+        5,
+        10,
+        17,
+        26,
+    ]
 
     # with 'quiet_trailing_semicolon' set to False
     runner = CodeRunner(quiet_trailing_semicolon=False)

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -28,6 +28,15 @@ def test_code_runner():
     assert not runner.quiet("1+1#;")
     assert not runner.quiet("5-2  # comment with trailing semicolon ;")
     assert runner.run("4//2\n") == 2
+    assert runner.run("4//2;") is None
+
+    # with 'quiet_trailing_semicolon' set to False
+    runner = CodeRunner(quiet_trailing_semicolon=False)
+    assert not runner.quiet("1+1;")
+    assert not runner.quiet("1+1#;")
+    assert not runner.quiet("5-2  # comment with trailing semicolon ;")
+    assert runner.run("4//2\n") == 2
+    assert runner.run("4//2;") == 2
 
 
 def test_eval_code():
@@ -72,6 +81,22 @@ def test_eval_code():
     assert eval_code("a = 5 ; a += 1", ns, mode="none") is None
     assert eval_code("a = 5 ; a += 1;", ns, mode="none") is None
     assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, mode="none") is None
+
+    # with 'quiet_trailing_semicolon' set to False
+    assert eval_code("1+1;", ns, quiet_trailing_semicolon=False) == 2
+    assert eval_code("1+1#;", ns, quiet_trailing_semicolon=False) == 2
+    assert (
+        eval_code(
+            "5-2  # comment with trailing semicolon ;",
+            ns,
+            quiet_trailing_semicolon=False,
+        )
+        == 3
+    )
+    assert eval_code("4//2\n", ns, quiet_trailing_semicolon=False) == 2
+    assert eval_code("2**1\n\n", ns, quiet_trailing_semicolon=False) == 2
+    assert eval_code("4//2;\n", ns, quiet_trailing_semicolon=False) == 2
+    assert eval_code("2**1;\n\n", ns, quiet_trailing_semicolon=False) == 2
 
 
 def test_monkeypatch_eval_code(selenium):


### PR DESCRIPTION
This is built on top of #1041.

#876 brings really interesting features. Some of them were not accepted, like returning last assignment value (by my fault), others does not reflect the CPython interpret behavior (like silencing by trailing semicolon).

I am totally agree with the current behavior but what if the user want something else?

This PR adds three customization to `eval_code` (and `eval_code_async`) without modifying the current behavior:

 - compilation filename (default is `"<exec>"`)
 - trailing semicolon behavior (quiet or not to switch between CPython and IPython behavior)
 - returned value:
   - last expression,
   - last expression and (named) assignment
   - nothing

WDYT?

I have added some tests.