### PR TITLE
Fix build error for zlib

### DIFF
--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -9,5 +9,5 @@ source:
 build:
   library: true
   script: |
-     CFLAGS="-fPIC" emconfigure ./configure --prefix=.
+     CFLAGS="-fPIC" emconfigure ./configure --prefix=$PWD
      emmake make install -j ${PYODIDE_JOBS:-3}

--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -9,5 +9,5 @@ source:
 build:
   library: true
   script: |
-     CFLAGS="-fPIC" emconfigure ./configure --prefix=`cwd`
+     CFLAGS="-fPIC" emconfigure ./configure --prefix=.
      emmake make install -j ${PYODIDE_JOBS:-3}

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -173,7 +173,7 @@ def compile(path: Path, srcpath: Path, pkg: Dict[str, Any], args):
         site_packages_dir = srcpath / "install" / "lib" / "python3.8" / "site-packages"
         pkgdir = path.parent.resolve()
         env = {"SITEPACKAGES": str(site_packages_dir), "PKGDIR": str(pkgdir)}
-        subprocess.run(["bash", "-c", post], env=env, check=True)
+        subprocess.run(["bash", "-ce", post], env=env, check=True)
 
     with open(srcpath / ".built", "wb") as fd:
         fd.write(b"\n")
@@ -222,7 +222,7 @@ def run_script(buildpath: Path, srcpath: Path, pkg: Dict[str, Any]):
     orig_path = Path.cwd()
     os.chdir(srcpath)
     try:
-        subprocess.run(["bash", "-c", pkg["build"]["script"]], check=True)
+        subprocess.run(["bash", "-ce", pkg["build"]["script"]], check=True)
     finally:
         os.chdir(orig_path)
 


### PR DESCRIPTION
#1027 introduced build errors on my system. The \`cwd\` call in the script portion of zlib's meta.yaml is an undefined call (cwd is not a standard bash command) and results in the next line of the script attempting to install zlib to the root file system. This probably doesn't cause a CI error because of differences in the permissions on the CI system. On my system, this results in write permission errors. I replaced the \`cwd\` with a . since that's the intent. I also updated the bash calls in buildpkg.py to use the -e option in addition to the -c option. The -e option forces bash to exit on the first line that has an error. Without the -e, we only see the return status of the last command regardless of whether there were errors on lines before that. Incidentally, the -e wouldn't have caught the problem with \`cwd\` since bash does not bubble up back-tick command errors by default. With these changes, pyodide and all packages build cleanly on my system.