### PR TITLE
More careful impl of hiwire_bool, added test cases

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,7 @@
 
 ### Fixed
 - getattr and dir on JsProxy now report consistent results and include all names defined on the Python dictionary backing JsProxy. [#1017](https://github.com/iodide-project/pyodide/pull/1017)
+- `JsProxy.__bool__` now produces better results: it used to be `bool(window)` and `bool(zero-arg-callback)` were `False`, and `bool(empty_js_set)` and `bool(empty_js_map)` were `True`. All four of these outputs have been negated. [#1061](https://github.com/iodide-project/pyodide/pull/1061)
 
 ## Version 0.16.1
 *December 25, 2020*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,7 +35,7 @@
 
 ### Fixed
 - getattr and dir on JsProxy now report consistent results and include all names defined on the Python dictionary backing JsProxy. [#1017](https://github.com/iodide-project/pyodide/pull/1017)
-- `JsProxy.__bool__` now produces better results: it used to be `bool(window)` and `bool(zero-arg-callback)` were `False`, and `bool(empty_js_set)` and `bool(empty_js_map)` were `True`. All four of these outputs have been negated. [#1061](https://github.com/iodide-project/pyodide/pull/1061)
+- `JsProxy.__bool__` now produces more consistent results: both `bool(window)` and `bool(zero-arg-callback)` were `False` but now are `True`. Conversely, `bool(empty_js_set)` and `bool(empty_js_map)` were `True` but now are `False`. [#1061](https://github.com/iodide-project/pyodide/pull/1061)
 
 ## Version 0.16.1
 *December 25, 2020*

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -346,7 +346,17 @@ EM_JS_NUM(int, hiwire_get_length, (JsRef idobj), {
 EM_JS_NUM(bool, hiwire_get_bool, (JsRef idobj), {
   var val = Module.hiwire.get_value(idobj);
   // clang-format off
-  return (val && (val.length === undefined || val.length)) ? 1 : 0;
+  if(!val){
+    return false;
+  }
+  if(val.size === 0){
+    // I think things with a size are all container types.
+    return false;
+  }
+  if(Array.isArray(val) && val.length === 0){
+    return false;
+  }
+  return true;
   // clang-format on
 });
 
@@ -376,8 +386,10 @@ EM_JS_REF(char*, hiwire_constructor_name, (JsRef idobj), {
 
 MAKE_OPERATOR(less_than, <);
 MAKE_OPERATOR(less_than_equal, <=);
-MAKE_OPERATOR(equal, ==);
-MAKE_OPERATOR(not_equal, !=);
+// clang-format off
+MAKE_OPERATOR(equal, ===);
+MAKE_OPERATOR(not_equal, !==);
+// clang-format on
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -346,14 +346,14 @@ EM_JS_NUM(int, hiwire_get_length, (JsRef idobj), {
 EM_JS_NUM(bool, hiwire_get_bool, (JsRef idobj), {
   var val = Module.hiwire.get_value(idobj);
   // clang-format off
-  if(!val){
+  if (!val) {
     return false;
   }
-  if(val.size === 0){
+  if (val.size === 0) {
     // I think things with a size are all container types.
     return false;
   }
-  if(Array.isArray(val) && val.length === 0){
+  if (Array.isArray(val) && val.length === 0) {
     return false;
   }
   return true;

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -128,6 +128,27 @@ def test_js2python(selenium):
     )
 
 
+def test_js2python_bool(selenium):
+    selenium.run_js(
+        """
+        window.f = ()=>{}
+        window.m0 = new Map();
+        window.m1 = new Map([[0, 1]]);
+        window.s0 = new Set();
+        window.s1 = new Set([0]);
+        """
+    )
+    assert (
+        selenium.run(
+            """
+        from js import window, f, m0, m1, s0, s1
+        [bool(x) for x in [f, m0, m1, s0, s1]]
+        """
+        )
+        == [True, False, True, False, True]
+    )
+
+
 @pytest.mark.parametrize("wasm_heap", (False, True))
 @pytest.mark.parametrize(
     "jstype, pytype",


### PR DESCRIPTION
For a jsproxy, `bool(val)` is defined as `(val && (val.length === undefined || val.length))`. This seems to encode the assumption that anything with a length field is some sort of container. However, there are many things that are not a container that have a length field. [`window.length` is the number of <frame> elements in the window](https://developer.mozilla.org/en-US/docs/Web/API/Window/length), typically zero, so it considers `window` to be falsey. Functions also have a length field which counts their arguments, zero argument javascript functions are currently falsey.

Also, this implementation doesn't know about `Set` or `Map`, empty javascript sets and maps are truthy. I replaced it with a smarter implementation.

I also replaced the `==` and `!=` in `hiwire_eq` resp `hiwire_neq` with `===` and `!==`. On the code paths that use `hiwire_eq` and `hiwire_neq`, these do the same thing, but `===` and `!==` are less confusing.

There is one more `!=` operator:
https://github.com/iodide-project/pyodide/blob/1cb32c304d3901a57e95226e6b528501047cff01/src/core/hiwire.c#L428

However, the one place that `!=` operator is used is in `JsProxy_IterNext`:
```C
  JsRef iddone = hiwire_get_member_string(idresult, "done");
  int done = hiwire_nonzero(iddone);
  hiwire_decref(iddone);
```
Here `iddone` is either `true` or `false` and `false !== 0` is `true` but `false != 0` is `false`. So if we corrected `hiwire_nonzero` to be sensible it would break `JsProxy_IterNext`.