### PR TITLE
Fail macros

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -4,6 +4,11 @@
 #include "jsproxy.h"
 #include <emscripten.h>
 
+EM_JS_NUM(errcode, log_error, (char* msg), {
+  let jsmsg = UTF8ToString(msg);
+  console.error(jsmsg);
+});
+
 void
 PyodideErr_SetJsError(JsRef err)
 {

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -36,6 +36,7 @@ error_handling_init();
         Module.handle_js_error(e);                                             \
         return 0;                                                              \
     }                                                                          \
+    throw new Error("Assertion error: control reached end of function without return");\
   })
 
 #define EM_JS_NUM(ret, func_name, args, body...)                               \
@@ -49,7 +50,47 @@ error_handling_init();
         Module.handle_js_error(e);                                             \
         return -1;                                                             \
     }                                                                          \
+    return 0;  /* some of these were void */                                   \
   })
 // clang-format on
+
+#ifdef DEBUG_F
+#define FAIL()                                                                 \
+  do {                                                                         \
+    char* msg;                                                                 \
+    asprintf(&msg,                                                             \
+             "Raised exception on line %d in func %s, file %s\n",              \
+             __LINE__,                                                         \
+             __func__,                                                         \
+             __FILE__);                                                        \
+    hiwire_log_error(msg);                                                     \
+    free(msg);                                                                 \
+    goto finally                                                               \
+  } while (0)
+
+#else
+#define FAIL() goto finally
+#endif
+
+#define FAIL_IF_NULL(x)                                                        \
+  do {                                                                         \
+    if (x == NULL) {                                                           \
+      FAIL();                                                                  \
+    }                                                                          \
+  } while (0)
+
+#define FAIL_IF_MINUS_ONE(x)                                                   \
+  do {                                                                         \
+    if (x != 0) {                                                              \
+      FAIL();                                                                  \
+    }                                                                          \
+  } while (0)
+
+#define FAIL_IF_ERR_OCCURRED(x)                                                \
+  do {                                                                         \
+    if (PyErr_Occurred()) {                                                    \
+      FAIL();                                                                  \
+    }                                                                          \
+  } while (0)
 
 #endif // ERROR_HANDLING_H

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -20,6 +20,41 @@ error_handling_init();
 errcode
 log_error(char* msg);
 
+// Poor clang-format, both macros and javascript at once make it pretty sick.
+// clang-format off
+#ifdef EM_JS_TRACE_F
+// Tracing macros if compiled with "-D EM_JS_TRACE_F"
+// Print extra info whenever we enter or exit EM_JS calls.
+// Yes, the "do {} while(0)" trickworks in javascript too!
+#define EM_JS_TRACE_ENTER(func_name)                                           \
+  let ____haderr = false;                                                      \
+  do {                                                                         \
+    console.log(`Entering function func_name                                   \
+      (line __LINE__ file __FILE__ )`);                                        \
+    console.log("Arguments were:", arguments);                                 \
+  } while (0)
+
+#define EM_JS_TRACE_ERROR(func_name, err)                                      \
+  do {                                                                         \
+    ____haderr = true;                                                         \
+    console.log(`Exiting function with error func_name                         \
+      (line __LINE__ file __FILE__ )`);                                        \
+    console.error("error was:", err);                                          \
+  } while (0)
+
+#define EM_JS_TRACE_EXIT(func_name)                                            \
+  if(!____haderr){                                                             \
+    console.log(`Exiting function func_name                                    \
+      (line __LINE__ file __FILE__ )`);                                        \
+  }
+
+#else
+// Without "-D EM_JS_TRACE_F" these just do nothing.
+#define EM_JS_TRACE_ENTER(func_name)
+#define EM_JS_TRACE_ERROR(func_name, err)
+#define EM_JS_TRACE_EXIT(func_name)
+#endif
+
 // WARNING: These wrappers around EM_JS cause macros in body to be expanded.
 // This causes trouble with true and false.
 // In types.h we provide nonstandard definitions:
@@ -27,35 +62,40 @@ log_error(char* msg);
 // true ==> (!!1)
 // These work as expected in both C and javascript.
 
-// clang-format off
-#define EM_JS_REF(ret, func_name, args, body...)                               \
-  EM_JS(ret, func_name, args, {                                                \
+
+#define _EM_JS_WRAP_HELPER2(ret, func_name, args, body...)  \
+  EM_JS(ret, func_name, args, body)
+
+#define _EM_JS_WRAP_HELPER(succ_ret, err_ret, ret, func_name, args, body...) \
+  _EM_JS_WRAP_HELPER2(ret, func_name, args, {                                  \
     /* "use strict";  TODO: enable this. */                                    \
+    EM_JS_TRACE_ENTER(func_name);                                              \
     try    /* intentionally no braces, body already has them */                \
       body /* <== body of func */                                              \
     catch (e) {                                                                \
-        /* Dummied out until calling code is ready to catch these errors */    \
-        throw e;                                                               \
-        Module.handle_js_error(e);                                             \
-        return 0;                                                              \
+      EM_JS_TRACE_ERROR(func_name, e);                                         \
+      /* Dummied out until calling code is ready to catch these errors */      \
+      throw e;                                                                 \
+      Module.handle_js_error(e);                                               \
+      err_ret;                                                                 \
+    } finally {                                                                \
+      EM_JS_TRACE_EXIT(func_name);                                             \
     }                                                                          \
-    throw new Error("Assertion error: control reached end of function without return");\
+    succ_ret;                                                                  \
   })
 
+#define EM_JS_REF(ret, func_name, args, body...)                                 \
+  _EM_JS_WRAP_HELPER(                                                            \
+    Module.handle_js_error("Control reached end of nonvoid function w/o return"),\
+    return 0,                                                                     \
+    ret, func_name, args, body)
+
 #define EM_JS_NUM(ret, func_name, args, body...)                               \
-  EM_JS(ret, func_name, args, {                                                \
-    /* "use strict";  TODO: enable this. */                                    \
-    try    /* intentionally no braces, body already has them */                \
-      body /* <== body of func */                                              \
-    catch (e) {                                                                \
-        /* Dummied out until calling code is ready to catch these errors */    \
-        throw e;                                                               \
-        Module.handle_js_error(e);                                             \
-        return -1;                                                             \
-    }                                                                          \
-    return 0;  /* some of these were void */                                   \
-  })
-// clang-format on
+  _EM_JS_WRAP_HELPER(
+    return 0,  /* if control reaches end with no error return 0 */
+    return -1, /* on failure return -1 */
+    ret, func_name, args, body)
+    // clang-format on
 
 #ifdef DEBUG_F
 #define FAIL()                                                                 \
@@ -68,7 +108,7 @@ log_error(char* msg);
              __FILE__);                                                        \
     log_error(msg);                                                            \
     free(msg);                                                                 \
-    goto finally                                                               \
+    goto finally;                                                              \
   } while (0)
 
 #else

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -66,7 +66,7 @@ log_error(char* msg);
 #define _EM_JS_WRAP_HELPER2(ret, func_name, args, body...)  \
   EM_JS(ret, func_name, args, body)
 
-#define _EM_JS_WRAP_HELPER(succ_ret, err_ret, ret, func_name, args, body...) \
+#define _EM_JS_WRAP_HELPER(succ_ret, err_ret, ret, func_name, args, body...)   \
   _EM_JS_WRAP_HELPER2(ret, func_name, args, {                                  \
     /* "use strict";  TODO: enable this. */                                    \
     EM_JS_TRACE_ENTER(func_name);                                              \
@@ -84,18 +84,22 @@ log_error(char* msg);
     succ_ret;                                                                  \
   })
 
-#define EM_JS_REF(ret, func_name, args, body...)                                 \
-  _EM_JS_WRAP_HELPER(                                                            \
-    Module.handle_js_error("Control reached end of nonvoid function w/o return"),\
-    return 0,                                                                     \
+#define EM_JS_REF(ret, func_name, args, body...)                               \
+  _EM_JS_WRAP_HELPER(                                                          \
+    /* In this case, throw error if we don't return otherwise */               \
+    Module.handle_js_error(                                                    \
+      new Error("Control reached end of nonvoid function w/o return")          \
+    );                                                                         \
+    return 0;,                                                                 \
+    return 0,  /* on failure return 0 (null) */                                \
     ret, func_name, args, body)
 
 #define EM_JS_NUM(ret, func_name, args, body...)                               \
-  _EM_JS_WRAP_HELPER(
-    return 0,  /* if control reaches end with no error return 0 */
-    return -1, /* on failure return -1 */
+  _EM_JS_WRAP_HELPER(                                                          \
+    return 0,  /* if control reaches end with no error return 0 */             \
+    return -1, /* on failure return -1 */                                      \
     ret, func_name, args, body)
-    // clang-format on
+// clang-format on
 
 #ifdef DEBUG_F
 #define FAIL()                                                                 \

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -17,6 +17,9 @@ typedef int errcode;
 int
 error_handling_init();
 
+errcode
+log_error(char* msg);
+
 // WARNING: These wrappers around EM_JS cause macros in body to be expanded.
 // This causes trouble with true and false.
 // In types.h we provide nonstandard definitions:
@@ -63,7 +66,7 @@ error_handling_init();
              __LINE__,                                                         \
              __func__,                                                         \
              __FILE__);                                                        \
-    hiwire_log_error(msg);                                                     \
+    log_error(msg);                                                            \
     free(msg);                                                                 \
     goto finally                                                               \
   } while (0)

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -118,6 +118,11 @@ EM_JS_NUM(errcode, hiwire_decref, (JsRef idval), {
   Module.hiwire.decref(idval);
 });
 
+EM_JS_NUM(errcode, hiwire_log_error, (char* msg), {
+  let jsmsg = UTF8ToString(msg);
+  console.error(jsmsg);
+});
+
 EM_JS_REF(JsRef, hiwire_int, (int val), {
   return Module.hiwire.new_value(val);
 });

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -118,11 +118,6 @@ EM_JS_NUM(errcode, hiwire_decref, (JsRef idval), {
   Module.hiwire.decref(idval);
 });
 
-EM_JS_NUM(errcode, hiwire_log_error, (char* msg), {
-  let jsmsg = UTF8ToString(msg);
-  console.error(jsmsg);
-});
-
 EM_JS_REF(JsRef, hiwire_int, (int val), {
   return Module.hiwire.new_value(val);
 });

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -43,6 +43,12 @@ typedef struct _JsRefStruct* JsRef;
 #define Js_FALSE ((JsRef)(6))
 #define Js_NULL ((JsRef)(8))
 
+#define hiwire_CLEAR(x)                                                        \
+  do {                                                                         \
+    hiwire_decref(x);                                                          \
+    x = NULL;                                                                  \
+  } while (0)
+
 /**
  * Initialize the variables and functions required for hiwire.
  */

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -363,20 +363,6 @@ JsProxy_HasBytes(PyObject* o)
   }
 }
 
-#define QUIT_IF_NULL(x)                                                        \
-  do {                                                                         \
-    if (x == NULL) {                                                           \
-      goto finally;                                                            \
-    }                                                                          \
-  } while (0)
-
-#define QUIT_IF_NZ(x)                                                          \
-  do {                                                                         \
-    if (x != 0) {                                                              \
-      goto finally;                                                            \
-    }                                                                          \
-  } while (0)
-
 #define GET_JSREF(x) (((JsProxy*)x)->js)
 
 static PyObject*
@@ -396,23 +382,23 @@ JsProxy_Dir(PyObject* self)
   // Would have been nice if they'd supplied PyObject_GenericDir...
   object__dir__ =
     _PyObject_GetAttrId((PyObject*)&PyBaseObject_Type, &PyId___dir__);
-  QUIT_IF_NULL(object__dir__);
+  FAIL_IF_NULL(object__dir__);
   keys = PyObject_CallFunctionObjArgs(object__dir__, self, NULL);
-  QUIT_IF_NULL(keys);
+  FAIL_IF_NULL(keys);
   result_set = PySet_New(keys);
-  QUIT_IF_NULL(result_set);
+  FAIL_IF_NULL(result_set);
 
   // Now get attributes of js object
   iddir = hiwire_dir(GET_JSREF(self));
   pydir = js2python(iddir);
-  QUIT_IF_NULL(pydir);
+  FAIL_IF_NULL(pydir);
   // Merge and sort
-  QUIT_IF_NZ(_PySet_Update(result_set, pydir));
+  FAIL_IF_MINUS_ONE(_PySet_Update(result_set, pydir));
   result = PyList_New(0);
-  QUIT_IF_NULL(result);
+  FAIL_IF_NULL(result);
   null_or_pynone = _PyList_Extend((PyListObject*)result, result_set);
-  QUIT_IF_NULL(null_or_pynone);
-  QUIT_IF_NZ(PyList_Sort(result));
+  FAIL_IF_NULL(null_or_pynone);
+  FAIL_IF_MINUS_ONE(PyList_Sort(result));
 
   success = true;
 finally:
@@ -689,6 +675,7 @@ JsException_AsJs(PyObject* err)
 int
 JsProxy_init()
 {
+  bool success = false;
   PyExc_BaseException_Type = (PyTypeObject*)PyExc_BaseException;
   _Exc_JsException.tp_base = (PyTypeObject*)PyExc_Exception;
 
@@ -697,18 +684,15 @@ JsProxy_init()
 
   // Add JsException to the pyodide module so people can catch it if they want.
   module = PyImport_ImportModule("pyodide");
-  if (module == NULL) {
-    goto fail;
-  }
-  if (PyObject_SetAttrString(module, "JsException", Exc_JsException)) {
-    goto fail;
-  }
+  FAIL_IF_NULL(module);
+  FAIL_IF_MINUS_ONE(
+    PyObject_SetAttrString(module, "JsException", Exc_JsException));
+  FAIL_IF_MINUS_ONE(PyType_Ready(&JsProxyType));
+  FAIL_IF_MINUS_ONE(PyType_Ready(&JsBoundMethodType));
+  FAIL_IF_MINUS_ONE(PyType_Ready(&_Exc_JsException));
 
+  success = true;
+finally:
   Py_CLEAR(module);
-  return (PyType_Ready(&JsProxyType) || PyType_Ready(&JsBoundMethodType) ||
-          PyType_Ready(&_Exc_JsException));
-
-fail:
-  Py_CLEAR(module);
-  return -1;
+  return success ? 0 : -1;
 }

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -59,21 +59,21 @@ JsProxy_typeof(PyObject* self, void* _unused)
 static PyObject*
 JsProxy_GetAttr(PyObject* self, PyObject* attr)
 {
-  PyObject* result = PyObject_GenericGetAttr(o, attr);
+  PyObject* result = PyObject_GenericGetAttr(self, attr);
   if (result != NULL) {
     return result;
   }
   PyErr_Clear();
 
   bool success = false;
-  JsRef idresult
-    // result:
-    PyObject* pyresult;
+  JsRef idresult;
+  // result:
+  PyObject* pyresult;
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);
 
-  JsRef idresult = hiwire_get_member_string(JsProxy_REF(self), key);
+  idresult = hiwire_get_member_string(JsProxy_REF(self), key);
   if (idresult == NULL) {
     PyErr_SetString(PyExc_AttributeError, key);
     FAIL();

--- a/src/core/runpython.c
+++ b/src/core/runpython.c
@@ -60,20 +60,6 @@ EM_JS_NUM(int,
             return 0;
           });
 
-#define QUIT_IF_NULL(x)                                                        \
-  do {                                                                         \
-    if (x == NULL) {                                                           \
-      goto fail;                                                               \
-    }                                                                          \
-  } while (0)
-
-#define QUIT_IF_NZ(x)                                                          \
-  do {                                                                         \
-    if (x) {                                                                   \
-      goto fail;                                                               \
-    }                                                                          \
-  } while (0)
-
 int
 runpython_init()
 {
@@ -83,26 +69,26 @@ runpython_init()
 
   // borrowed
   PyObject* builtins = PyImport_AddModule("builtins");
-  QUIT_IF_NULL(builtins);
+  FAIL_IF_NULL(builtins);
 
   // borrowed
   PyObject* builtins_dict = PyModule_GetDict(builtins);
-  QUIT_IF_NULL(builtins_dict);
+  FAIL_IF_NULL(builtins_dict);
 
   // borrowed
   PyObject* __main__ = PyImport_AddModule("__main__");
-  QUIT_IF_NULL(__main__);
+  FAIL_IF_NULL(__main__);
 
   // globals is static variable, borrowed
   globals = PyModule_GetDict(__main__);
-  QUIT_IF_NULL(globals);
+  FAIL_IF_NULL(globals);
   Py_INCREF(globals); // to owned
 
-  QUIT_IF_NZ(PyDict_Update(globals, builtins_dict));
+  FAIL_IF_MINUS_ONE(PyDict_Update(globals, builtins_dict));
 
   // pyodide_py is static variable, new
   pyodide_py = PyImport_ImportModule("pyodide");
-  QUIT_IF_NULL(pyodide_py);
+  FAIL_IF_NULL(pyodide_py);
 
   pyodide_py_proxy = python2js(pyodide_py);
   if (pyodide_py_proxy == NULL) {
@@ -121,7 +107,7 @@ runpython_init()
   if (globals_proxy == NULL) {
     goto fail;
   }
-  QUIT_IF_NZ(runpython_init_js(pyodide_py_proxy, globals_proxy));
+  FAIL_IF_MINUS_ONE(runpython_init_js(pyodide_py_proxy, globals_proxy));
 
   return 0;
 fail:


### PR DESCRIPTION
I unified the QUIT macros into `error_handling.h` and renamed them `FAIL`. There are four of them:

1. `FAIL()` -- unconditional failure
2. `FAIL_IF_NULL(ref)` -- fail if `ref == NULL` 
3. `FAIL_IF_MINUS_ONE(num)` -- fail if `num == -1` 
4. `FAIL_IF_ERR_OCCURRED(num)` -- fail if `PyErr_Occurred()`.

Additionally if the feature flag `DEBUG_F` is defined `FAIL` prints a message like:
`Raised exception on line 231 in func JsImport_GetAttr, file jsimport.c` with a javascript / wasm stack trace.

I also added a new macro `hiwire_CLEAR` which is like `Py_CLEAR`. The point is that unlike `hiwire_decref`, `hiwire_CLEAR` is idempotent so I don't have to worry about doing it twice. This eliminates error handling case work and reduces the pain of handling errors in C.

I also went through the beginning of `JsProxy` and applied new error handling approach to a few functions there.
