### PR TITLE
Stop hardcoding file_packager.py directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYODIDE_ROOT=$(abspath .)
 include Makefile.envs
 .PHONY=check
 
-FILEPACKAGER=$(PYODIDE_ROOT)/emsdk/emsdk/fastcomp/emscripten/tools/file_packager.py
+FILEPACKAGER=$$EM_DIR/tools/file_packager.py
 UGLIFYJS=$(PYODIDE_ROOT)/node_modules/.bin/uglifyjs
 LESSC=$(PYODIDE_ROOT)/node_modules/.bin/lessc
 

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -188,7 +188,7 @@ def package_files(buildpath: Path, srcpath: Path, pkg: Dict[str, Any], args):
     subprocess.run(
         [
             "python",
-            common.PACKAGERDIR / "file_packager.py",
+            common.PACKAGERPATH,
             name + ".data",
             "--lz4",
             "--preload",

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -188,7 +188,7 @@ def package_files(buildpath: Path, srcpath: Path, pkg: Dict[str, Any], args):
     subprocess.run(
         [
             "python",
-            common.PACKAGERPATH,
+            common.file_packager_path(),
             name + ".data",
             "--lz4",
             "--preload",

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -4,16 +4,8 @@ import shutil
 
 ROOTDIR = Path(__file__).parents[1].resolve()
 TOOLSDIR = ROOTDIR / "tools"
-
-# Use emcc.py because emcc may be a ccache symlink
-_EMCC_PATH = shutil.which("emcc.py")
-if _EMCC_PATH is None:
-    print("emcc.py not found. Setting file_packager.py path to /dev/null")
-    PACKAGERPATH = Path("/dev/null")
-else:
-    PACKAGERPATH = Path(_EMCC_PATH).parent / "tools" / "file_packager.py"
-
 TARGETPYTHON = ROOTDIR / "cpython" / "installs" / "python-3.8.2"
+
 # Leading space so that argparse doesn't think this is a flag
 DEFAULTCFLAGS = " -fPIC"
 DEFAULTCXXFLAGS = ""
@@ -58,3 +50,14 @@ def _parse_package_subset(query: Optional[str]) -> Optional[Set[str]]:
     packages = [el.strip() for el in packages]
     packages = ["micropip", "distlib"] + packages
     return set(packages)
+
+
+def file_packager_path() -> Path:
+    # Use emcc.py because emcc may be a ccache symlink
+    emcc_path = shutil.which("emcc.py")
+    if emcc_path is None:
+        raise RuntimeError(
+            "emcc.py not found. Setting file_packager.py path to /dev/null"
+        )
+
+    return Path(emcc_path).parent / "tools" / "file_packager.py"

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 from typing import Optional, Set
+import shutil
 
 ROOTDIR = Path(__file__).parents[1].resolve()
 TOOLSDIR = ROOTDIR / "tools"
-PACKAGERDIR = ROOTDIR / "emsdk" / "emsdk" / "fastcomp" / "emscripten" / "tools"
+
+# Use emcc.py because emcc may be a ccache symlink
+PACKAGERDIR = Path(shutil.which("emcc.py")).parent / "tools"
 TARGETPYTHON = ROOTDIR / "cpython" / "installs" / "python-3.8.2"
 # Leading space so that argparse doesn't think this is a flag
 DEFAULTCFLAGS = " -fPIC"

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -6,7 +6,13 @@ ROOTDIR = Path(__file__).parents[1].resolve()
 TOOLSDIR = ROOTDIR / "tools"
 
 # Use emcc.py because emcc may be a ccache symlink
-PACKAGERDIR = Path(shutil.which("emcc.py")).parent / "tools"
+_EMCC_PATH = shutil.which("emcc.py")
+if _EMCC_PATH is None:
+    print("emcc.py not found. Setting file_packager.py path to /dev/null")
+    PACKAGERPATH = Path("/dev/null")
+else:
+    PACKAGERPATH = Path(_EMCC_PATH).parent / "tools" / "file_packager.py"
+
 TARGETPYTHON = ROOTDIR / "cpython" / "installs" / "python-3.8.2"
 # Leading space so that argparse doesn't think this is a flag
 DEFAULTCFLAGS = " -fPIC"

--- a/pyodide_env.sh
+++ b/pyodide_env.sh
@@ -6,3 +6,4 @@ ROOT=`dirname ${BASH_SOURCE[0]}`
 # exist yet (i.e. before building emsdk)
 source "$ROOT/emsdk/emsdk/emsdk_env.sh" 2> /dev/null || true
 export PATH=$ROOT/ccache:$ROOT/node_modules/.bin/:$PATH
+export EM_DIR=$(dirname $(which emcc.py))


### PR DESCRIPTION
This makes our build system more flexible, especially if we start using unpatched emscripten in the future.
