### PR TITLE
Remove dataLoadPromise in pyodide.js

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -362,31 +362,15 @@ var languagePluginLoader = new Promise((resolve, reject) => {
   };
 
   Module.locateFile = (path) => baseURL + path;
-  var postRunPromise = new Promise((resolve, reject) => {
-    Module.postRun = () => {
-      delete self.Module;
-      fetch(`${baseURL}packages.json`)
-          .then((response) => response.json())
-          .then((json) => {
-            fixRecursionLimit(self.pyodide);
-            self.pyodide = makePublicAPI(self.pyodide, PUBLIC_API);
-            self.pyodide._module.packages = json;
-            resolve();
-          });
-    };
-  });
-
-  var dataLoadPromise = new Promise((resolve, reject) => {
-    Module.monitorRunDependencies =
-        (n) => {
-          if (n === 0) {
-            delete Module.monitorRunDependencies;
-            resolve();
-          }
-        }
-  });
-
-  Promise.all([ postRunPromise, dataLoadPromise ]).then(() => resolve());
+  Module.postRun = async () => {
+    delete self.Module;
+    let response = await fetch(`${baseURL}packages.json`);
+    let json = await response.json();
+    fixRecursionLimit(self.pyodide);
+    self.pyodide = makePublicAPI(self.pyodide, PUBLIC_API);
+    self.pyodide._module.packages = json;
+    resolve();
+  };
 
   const scriptSrc = `${baseURL}pyodide.asm.js`;
   loadScript(scriptSrc, () => {


### PR DESCRIPTION
This is not necessary, because postRun is not run until all dependencies are satisfied.

Since the definition of Module.postRun is slightly modified here, I took the opportunity to convert it to use async/await.
