### PR TITLE
Separate ns variable in eval_code into globals and locals

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,8 @@
 - Reduce the size of the core pyodide package
   [#987](https://github.com/iodide-project/pyodide/pull/987).
 - Updated packages: bleach 3.2.1, packaging 20.8
+- `eval_code` now accepts separate `globals` and `locals` parameters.
+  [#1083](https://github.com/iodide-project/pyodide/pull/1083)
 
 ### Fixed
 - getattr and dir on JsProxy now report consistent results and include all names defined on the Python dictionary backing JsProxy. [#1017](https://github.com/iodide-project/pyodide/pull/1017)

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -49,9 +49,12 @@ class CodeRunner:
 
     Parameters
     ----------
-    ns
-        `locals()` or `globals()` context where to execute code.
-        This namespace is updated by the subsequent calls to `run()`.
+    globals
+        The global scope in which to execute code. This is used as the `exec` `globals` parameter.
+        See [the exec documentation](https://docs.python.org/3/library/functions.html#exec) for more info.
+    locals
+        The local scope in which to execute code. This is used as the `eval` `globals` parameter.
+        See [the exec documentation](https://docs.python.org/3/library/functions.html#exec) for more info.
     mode
         'last_expr' , 'last_expr_or_assign' or 'none',
         specifying what should be evaluated and what should be executed.
@@ -265,8 +268,12 @@ def eval_code(
     ----------
     code
        the Python code to run.
-    ns
-       `locals()` or `globals()` context where to execute code.
+    globals
+        The global scope in which to execute code. This is used as the `exec` `globals` parameter.
+        See [the exec documentation](https://docs.python.org/3/library/functions.html#exec) for more info.
+    locals
+        The local scope in which to execute code. This is used as the `eval` `globals` parameter.
+        See [the exec documentation](https://docs.python.org/3/library/functions.html#exec) for more info.
     mode
        'last_expr' , 'last_expr_or_assign' or 'none',
        specifying what should be evaluated and what should be executed.

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -67,7 +67,7 @@ class CodeRunner:
         'last_expr' -- return the last expression
         'last_expr_or_assign' -- return the last expression or the last
         (named) assignment.
-        `None` -- always return `None`.
+        'none' -- always return `None`.
     quiet_trailing_semicolon
         wether a trailing semicolon should 'quiet' the result or not.
         Setting this to `True` (default) mimic the CPython's interpret
@@ -99,7 +99,7 @@ class CodeRunner:
         self.locals = locals if locals is not None else self.globals
         self.quiet_trailing_semicolon = quiet_trailing_semicolon
         self.filename = filename
-        if return_mode not in ["last_expr", "last_expr_or_assign", None]:
+        if return_mode not in ["last_expr", "last_expr_or_assign", 'none', None]:
             raise ValueError(f"Unrecognized return_mode {return_mode!r}")
         self.return_mode = return_mode
 
@@ -294,7 +294,7 @@ def eval_code(
         'last_expr' -- return the last expression
         'last_expr_or_assign' -- return the last expression or the last
         (named) assignment.
-        `None` -- always return `None`.
+        'none' -- always return `None`.
     quiet_trailing_semicolon
         whether a trailing semicolon should 'quiet' the result or not.
         Setting this to `True` (default) mimic the CPython's interpret

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -99,7 +99,7 @@ class CodeRunner:
         self.locals = locals if locals is not None else self.globals
         self.quiet_trailing_semicolon = quiet_trailing_semicolon
         self.filename = filename
-        if return_mode not in ["last_expr", "last_expr_or_assign", 'none', None]:
+        if return_mode not in ["last_expr", "last_expr_or_assign", "none", None]:
             raise ValueError(f"Unrecognized return_mode {return_mode!r}")
         self.return_mode = return_mode
 

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -69,7 +69,7 @@ def test_eval_code():
     assert eval_code("x=7", ns) is None
     assert ns["x"] == 7
 
-    # default mode ('last_expr'), semicolon
+    # default return_mode ('last_expr'), semicolon
     assert eval_code("1+1;", ns) is None
     assert eval_code("1+1#;", ns) == 2
     assert eval_code("5-2  # comment with trailing semicolon ;", ns) == 3
@@ -78,20 +78,23 @@ def test_eval_code():
     assert eval_code("4//2;\n", ns) is None
     assert eval_code("2**1;\n\n", ns) is None
 
-    # 'last_expr_or_assign' mode, semicolon
-    assert eval_code("1 + 1", ns, mode="last_expr_or_assign") == 2
-    assert eval_code("x = 1 + 1", ns, mode="last_expr_or_assign") == 2
-    assert eval_code("a = 5 ; a += 1", ns, mode="last_expr_or_assign") == 6
-    assert eval_code("a = 5 ; a += 1;", ns, mode="last_expr_or_assign") is None
-    assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, mode="last_expr_or_assign") is None
-    assert eval_code("a = b = 2", ns, mode="last_expr_or_assign") == 2
+    # 'last_expr_or_assign' return_mode, semicolon
+    assert eval_code("1 + 1", ns, return_mode="last_expr_or_assign") == 2
+    assert eval_code("x = 1 + 1", ns, return_mode="last_expr_or_assign") == 2
+    assert eval_code("a = 5 ; a += 1", ns, return_mode="last_expr_or_assign") == 6
+    assert eval_code("a = 5 ; a += 1;", ns, return_mode="last_expr_or_assign") is None
+    assert (
+        eval_code("l = [1, 1, 2] ; l[0] = 0", ns, return_mode="last_expr_or_assign")
+        is None
+    )
+    assert eval_code("a = b = 2", ns, return_mode="last_expr_or_assign") == 2
 
-    # 'none' mode, (useless) semicolon
-    assert eval_code("1 + 1", ns, mode="none") is None
-    assert eval_code("x = 1 + 1", ns, mode="none") is None
-    assert eval_code("a = 5 ; a += 1", ns, mode="none") is None
-    assert eval_code("a = 5 ; a += 1;", ns, mode="none") is None
-    assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, mode="none") is None
+    # 'none' return_mode, (useless) semicolon
+    assert eval_code("1 + 1", ns, return_mode="none") is None
+    assert eval_code("x = 1 + 1", ns, return_mode="none") is None
+    assert eval_code("a = 5 ; a += 1", ns, return_mode="none") is None
+    assert eval_code("a = 5 ; a += 1;", ns, return_mode="none") is None
+    assert eval_code("l = [1, 1, 2] ; l[0] = 0", ns, return_mode="none") is None
 
     # with 'quiet_trailing_semicolon' set to False
     assert eval_code("1+1;", ns, quiet_trailing_semicolon=False) == 2

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 import sys
 from textwrap import dedent
@@ -107,6 +108,25 @@ def test_eval_code():
     assert eval_code("2**1\n\n", ns, quiet_trailing_semicolon=False) == 2
     assert eval_code("4//2;\n", ns, quiet_trailing_semicolon=False) == 2
     assert eval_code("2**1;\n\n", ns, quiet_trailing_semicolon=False) == 2
+
+
+def test_eval_code_locals():
+    globals = {}
+    eval_code("x=2", globals, {})
+    with pytest.raises(NameError):
+        eval_code("x", globals, {})
+
+    eval_code("import sys; sys.getrecursionlimit()", globals, {})
+    with pytest.raises(NameError):
+        eval_code("sys.getrecursionlimit()", globals, {})
+
+    locals = {}
+    eval_code(
+        "from importlib import invalidate_caches; invalidate_caches()", globals, locals
+    )
+    with pytest.raises(NameError):
+        eval_code("invalidate_caches()", globals, globals)
+    eval_code("invalidate_caches()", globals, locals)
 
 
 def test_monkeypatch_eval_code(selenium):

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -116,11 +116,12 @@ def test_eval_code_locals():
     with pytest.raises(NameError):
         eval_code("x", globals, {})
 
-    eval_code("import sys; sys.getrecursionlimit()", globals, {})
+    locals = {}
+    eval_code("import sys; sys.getrecursionlimit()", globals, locals)
     with pytest.raises(NameError):
         eval_code("sys.getrecursionlimit()", globals, {})
+    eval_code("sys.getrecursionlimit()", globals, locals)
 
-    locals = {}
     eval_code(
         "from importlib import invalidate_caches; invalidate_caches()", globals, locals
     )


### PR DESCRIPTION
This will allow `pyodide.js` to avoid pollution of global namespace by using `eval_code` with new empty dict.