### PR TITLE
Follow Python include advice

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
-#include "Python.h"
 #include "error_handling.h"
+#include "Python.h"
 #include "jsproxy.h"
 #include <emscripten.h>
 

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include "error_handling.h"
 #include "Python.h"
 #include "jsproxy.h"

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -1,5 +1,7 @@
+// clang-format off
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+// clang-format on
 #include "error_handling.h"
 #include "jsproxy.h"
 #include <emscripten.h>

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
-#include "error_handling.h"
 #include "Python.h"
+#include "error_handling.h"
 #include "jsproxy.h"
 #include <emscripten.h>
 

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -1,5 +1,7 @@
 #ifndef ERROR_HANDLING_H
 #define ERROR_HANDLING_H
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
 #include <emscripten.h>
 
 typedef int errcode;

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -1,7 +1,9 @@
 #ifndef ERROR_HANDLING_H
 #define ERROR_HANDLING_H
+// clang-format off
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+// clang-format on
 #include <emscripten.h>
 
 typedef int errcode;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -1,3 +1,6 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "error_handling.h"
 #include <emscripten.h>
 

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 
 #include "error_handling.h"
 #include <emscripten.h>

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -1,5 +1,6 @@
 #ifndef HIWIRE_H
 #define HIWIRE_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "stdalign.h"
 #include "types.h"

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -1,5 +1,8 @@
-#include "js2python.h"
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "error_handling.h"
+#include "js2python.h"
 
 #include <emscripten.h>
 

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 
 #include "error_handling.h"
 #include "js2python.h"

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -5,7 +5,7 @@
  * Utilities to convert Javascript objects to Python objects.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 #include "hiwire.h"
 
 /** Convert a Javascript object to a Python object.

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -5,8 +5,8 @@
  * Utilities to convert Javascript objects to Python objects.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "hiwire.h"
+#include <Python.h>
 
 /** Convert a Javascript object to a Python object.
  *  \param x The Javascript object.

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -4,7 +4,7 @@
 /**
  * Utilities to convert Javascript objects to Python objects.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include "hiwire.h"
 #include <Python.h>
 

--- a/src/core/js2python.h
+++ b/src/core/js2python.h
@@ -5,8 +5,8 @@
  * Utilities to convert Javascript objects to Python objects.
  */
 #define PY_SSIZE_T_CLEAN
-#include "hiwire.h"
 #include <Python.h>
+#include "hiwire.h"
 
 /** Convert a Javascript object to a Python object.
  *  \param x The Javascript object.

--- a/src/core/jsimport.c
+++ b/src/core/jsimport.c
@@ -1,3 +1,6 @@
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
 #include "jsimport.h"
 
 #include <emscripten.h>

--- a/src/core/jsimport.h
+++ b/src/core/jsimport.h
@@ -3,7 +3,7 @@
 
 /** Support "from js import …" from Python. */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 
 /** Install the import hook to support "from js import …". */
 int

--- a/src/core/jsimport.h
+++ b/src/core/jsimport.h
@@ -2,7 +2,7 @@
 #define JSIMPORT_H
 
 /** Support "from js import …" from Python. */
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 /** Install the import hook to support "from js import …". */

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -1,10 +1,12 @@
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
 #include "jsproxy.h"
 
 #include "hiwire.h"
 #include "js2python.h"
 #include "python2js.h"
 
-#include "Python.h"
 #include "structmember.h"
 
 static PyTypeObject* PyExc_BaseException_Type;

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,8 +1,8 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
 #define PY_SSIZE_T_CLEAN
-#include "hiwire.h"
 #include "Python.h"
+#include "hiwire.h"
 
 /** A Python object that a Javascript object inside. Used for any non-standard
  *  data types that are passed from Javascript to Python.

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,7 +1,9 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
+// clang-format off
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+// clang-format on
 #include "hiwire.h"
 
 /** A Python object that a Javascript object inside. Used for any non-standard

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,8 +1,8 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "hiwire.h"
+#include "Python.h"
 
 /** A Python object that a Javascript object inside. Used for any non-standard
  *  data types that are passed from Javascript to Python.

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,8 +1,8 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
 #define PY_SSIZE_T_CLEAN
-#include "hiwire.h"
 #include <Python.h>
+#include "hiwire.h"
 
 /** A Python object that a Javascript object inside. Used for any non-standard
  *  data types that are passed from Javascript to Python.

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,8 +1,8 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "hiwire.h"
+#include <Python.h>
 
 /** A Python object that a Javascript object inside. Used for any non-standard
  *  data types that are passed from Javascript to Python.

--- a/src/core/jsproxy.h
+++ b/src/core/jsproxy.h
@@ -1,12 +1,12 @@
 #ifndef JSPROXY_H
 #define JSPROXY_H
+#define PY_SSIZE_T_CLEAN
 #include "hiwire.h"
+#include <Python.h>
 
 /** A Python object that a Javascript object inside. Used for any non-standard
  *  data types that are passed from Javascript to Python.
  */
-
-#include <Python.h>
 
 /** Make a new JsProxy.
  *  \param v The Javascript object.

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 #include <assert.h>
 #include <emscripten.h>
 #include <stdalign.h>

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <assert.h>
 #include <emscripten.h>

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
-#include "error_handling.h"
 #include <Python.h>
+#include "error_handling.h"
 #include <emscripten.h>
 
 #include "hiwire.h"

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1,6 +1,6 @@
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "error_handling.h"
+#include <Python.h>
 #include <emscripten.h>
 
 #include "hiwire.h"

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 #include "error_handling.h"
 #include <emscripten.h>
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include "error_handling.h"
 #include <Python.h>
 #include <emscripten.h>

--- a/src/core/pyproxy.h
+++ b/src/core/pyproxy.h
@@ -1,5 +1,6 @@
 #ifndef PYPROXY_H
 #define PYPROXY_H
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 /** Makes Python objects usable from Javascript.

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -1,10 +1,11 @@
-#include "python2js.h"
-
-#include <emscripten.h>
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
 
 #include "hiwire.h"
 #include "jsproxy.h"
 #include "pyproxy.h"
+#include "python2js.h"
+#include <emscripten.h>
 
 #include "python2js_buffer.h"
 

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -3,8 +3,10 @@
 
 /** Utilities to convert Python objects to Javascript.
  */
+// clang-format off
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+// clang-format on
 #include "hiwire.h"
 
 /** Convert the active Python exception into a Javascript Error object

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -4,8 +4,8 @@
 /** Utilities to convert Python objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include "hiwire.h"
 #include "Python.h"
+#include "hiwire.h"
 
 /** Convert the active Python exception into a Javascript Error object
  *  and print it to the console.

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -4,8 +4,8 @@
 /** Utilities to convert Python objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include "hiwire.h"
 #include <Python.h>
+#include "hiwire.h"
 
 /** Convert the active Python exception into a Javascript Error object
  *  and print it to the console.

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -3,7 +3,7 @@
 
 /** Utilities to convert Python objects to Javascript.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include "hiwire.h"
 #include <Python.h>
 

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -4,8 +4,8 @@
 /** Utilities to convert Python objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "hiwire.h"
+#include "Python.h"
 
 /** Convert the active Python exception into a Javascript Error object
  *  and print it to the console.

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -4,8 +4,8 @@
 /** Utilities to convert Python objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "hiwire.h"
+#include <Python.h>
 
 /** Convert the active Python exception into a Javascript Error object
  *  and print it to the console.

--- a/src/core/python2js_buffer.c
+++ b/src/core/python2js_buffer.c
@@ -1,3 +1,6 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "python2js_buffer.h"
 #include "types.h"
 

--- a/src/core/python2js_buffer.c
+++ b/src/core/python2js_buffer.c
@@ -1,5 +1,5 @@
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 
 #include "python2js_buffer.h"
 #include "types.h"

--- a/src/core/python2js_buffer.h
+++ b/src/core/python2js_buffer.h
@@ -4,7 +4,7 @@
 /** Utilities to convert Python buffer objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 #include "hiwire.h"
 
 /** Convert a Python buffer object to a Javascript object.

--- a/src/core/python2js_buffer.h
+++ b/src/core/python2js_buffer.h
@@ -3,7 +3,7 @@
 
 /** Utilities to convert Python buffer objects to Javascript.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include "hiwire.h"
 #include <Python.h>
 

--- a/src/core/python2js_buffer.h
+++ b/src/core/python2js_buffer.h
@@ -4,8 +4,8 @@
 /** Utilities to convert Python buffer objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include "hiwire.h"
 #include <Python.h>
+#include "hiwire.h"
 
 /** Convert a Python buffer object to a Javascript object.
  *

--- a/src/core/python2js_buffer.h
+++ b/src/core/python2js_buffer.h
@@ -4,8 +4,8 @@
 /** Utilities to convert Python buffer objects to Javascript.
  */
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
 #include "hiwire.h"
+#include <Python.h>
 
 /** Convert a Python buffer object to a Javascript object.
  *

--- a/src/core/python2js_buffer.h
+++ b/src/core/python2js_buffer.h
@@ -3,8 +3,10 @@
 
 /** Utilities to convert Python buffer objects to Javascript.
  */
+// clang-format off
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+// clang-format on
 #include "hiwire.h"
 
 /** Convert a Python buffer object to a Javascript object.

--- a/src/core/runpython.c
+++ b/src/core/runpython.c
@@ -1,10 +1,12 @@
-#include "runpython.h"
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+
 #include "error_handling.h"
 #include "hiwire.h"
 #include "pyproxy.h"
 #include "python2js.h"
+#include "runpython.h"
 
-#include <Python.h>
 #include <emscripten.h>
 
 static PyObject* pyodide_py;

--- a/src/core/runpython.h
+++ b/src/core/runpython.h
@@ -1,7 +1,7 @@
 #ifndef RUNPYTHON_H
 #define RUNPYTHON_H
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 
 /** The primary entry point function that runs Python code.
  */

--- a/src/core/runpython.h
+++ b/src/core/runpython.h
@@ -1,5 +1,7 @@
 #ifndef RUNPYTHON_H
 #define RUNPYTHON_H
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
 
 /** The primary entry point function that runs Python code.
  */

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -1,6 +1,9 @@
 #ifndef MY_TYPES_H
 #define MY_TYPES_H
 // https://elixir.bootlin.com/linux/latest/source/arch/powerpc/boot/types.h#L9
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
 #include "stdbool.h"
 #include "stdint.h"
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -2,7 +2,7 @@
 #define MY_TYPES_H
 // https://elixir.bootlin.com/linux/latest/source/arch/powerpc/boot/types.h#L9
 #define PY_SSIZE_T_CLEAN
-#include <Python.h>
+#include "Python.h"
 
 #include "stdbool.h"
 #include "stdint.h"


### PR DESCRIPTION
It says [here](https://docs.python.org/3/c-api/intro.html#include-files) that:

1. you _must_ include `Python.h` before any standard headers are included, and
2. it is recommended to always define `PY_SSIZE_T_CLEAN` before including `Python.h`.

We aren't doing either of these things. It doesn't seem to be causing any harm anywhere, but I figure it's good to follow recommendations. I adjusted the files so that `Python.h` is always the first include and before including it we always `#define PY_SSIZE_T_CLEAN`.