### PR TITLE
Don't copy artifacts to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ host
 installs
 ccache
 
-/root/
-
 /emsdk/emsdk
 
 *.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,8 @@ build/pyodide.asm.js: src/core/main.o src/core/jsimport.o \
 		--preload-file src/_testcapi.py@/lib/python$(PYMINOR)/_testcapi.py \
 		--preload-file src/pystone.py@/lib/python$(PYMINOR)/pystone.py \
 		--preload-file src/pyodide-py/pyodide@/lib/python$(PYMINOR)/site-packages/pyodide \
-		--exclude-file __pycache__ \
-		--exclude-file /lib/python$(PYMINOR)/test/
+		--exclude-file "*__pycache__*" \
+		--exclude-file "*/test/*"
 	date +"[%F %T] done building pyodide.asm.js."
 
 

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ LDFLAGS=\
 	-s "BINARYEN_TRAP_MODE='clamp'" \
 	-s LZ4=1
 
-SITEPACKAGES=root/lib/python$(PYMINOR)/site-packages
-
 all: check \
 	build/pyodide.asm.js \
 	build/pyodide.js \
@@ -61,11 +59,22 @@ build/pyodide.asm.js: src/core/main.o src/core/jsimport.o \
 		src/core/python2js.o \
 		src/core/python2js_buffer.o \
 		src/core/runpython.o src/core/hiwire.o \
-		root/.built
+		src/webbrowser.py \
+		src/_testcapi.py \
+		src/pystone.py \
+		$(wildcard src/pyodide-py/pyodide/*.py) \
+		$(CPYTHONLIB)
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d build ] || mkdir build
 	$(CXX) -s EXPORT_NAME="'pyodide'" -o build/pyodide.asm.js $(filter %.o,$^) \
-		$(LDFLAGS) -s FORCE_FILESYSTEM=1 --preload-file root/lib@lib
+		$(LDFLAGS) -s FORCE_FILESYSTEM=1 \
+		--preload-file $(CPYTHONLIB)@/lib/python$(PYMINOR) \
+		--preload-file src/webbrowser.py@/lib/python$(PYMINOR)/webbrowser.py \
+		--preload-file src/_testcapi.py@/lib/python$(PYMINOR)/_testcapi.py \
+		--preload-file src/pystone.py@/lib/python$(PYMINOR)/pystone.py \
+		--preload-file src/pyodide-py/pyodide@/lib/python$(PYMINOR)/site-packages/pyodide \
+		--exclude-file __pycache__ \
+		--exclude-file /lib/python$(PYMINOR)/test/
 	date +"[%F %T] done building pyodide.asm.js."
 
 
@@ -119,7 +128,6 @@ benchmark: all
 
 
 clean:
-	rm -fr root
 	rm -fr build/*
 	rm -fr src/*.o
 	rm -fr node_modules
@@ -149,27 +157,6 @@ build/test.data: $(CPYTHONLIB)
 
 $(UGLIFYJS) $(LESSC): emsdk/emsdk/.complete
 	npm i --no-save uglify-js lessc
-
-root/.built: \
-		$(CPYTHONLIB) \
-		src/webbrowser.py \
-		$(wildcard src/pyodide-py/pyodide/*.py) \
-		cpython/remove_modules.txt
-	rm -rf root
-	mkdir -p root/lib
-	cp -r $(CPYTHONLIB) root/lib
-	mkdir -p $(SITEPACKAGES)
-	cp src/webbrowser.py root/lib/python$(PYMINOR)
-	cp src/_testcapi.py	root/lib/python$(PYMINOR)
-	cp src/pystone.py root/lib/python$(PYMINOR)
-	cp -r src/pyodide-py/pyodide/ $(SITEPACKAGES)
-	( \
-		cd root/lib/python$(PYMINOR); \
-		rm -fr `cat ../../../cpython/remove_modules.txt`; \
-		rm -fr test; \
-		find . -type d -name __pycache__ -prune -exec rm -rf {} \; \
-	)
-	touch root/.built
 
 
 $(PYODIDE_EMCC):

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -27,7 +27,7 @@ BZIP2URL=ftp://sourceware.org/pub/bzip2/v102/bzip2-1.0.2.tar.gz
 all: $(INSTALL)/lib/$(LIB)
 
 
-$(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB)
+$(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB) remove_modules.txt
 	( \
 		cd $(BUILD); \
 		sed -i -e 's/libinstall:.*/libinstall:/' Makefile; \
@@ -41,6 +41,7 @@ $(INSTALL)/lib/$(LIB): $(BUILD)/$(LIB)
 	mv `cat pybuilddir.txt`/$(SYSCONFIG_NAME).py $(INSTALL)/lib/python$(PYMINOR)/
 	rmdir `cat pybuilddir.txt`
 	rm pybuilddir.txt
+	cd $(INSTALL)/lib/python$(PYMINOR)/ && rm -rf `cat $(ROOT)/remove_modules.txt`
 
 
 clean:

--- a/cpython/remove_modules.txt
+++ b/cpython/remove_modules.txt
@@ -10,3 +10,4 @@ turtle.py
 turtledemo
 venv
 distutils/command/wininst-*.exe
+webbrowser.py


### PR DESCRIPTION
Load them directly with --preload-file. Avoids issues such as #1069
