### PR TITLE
Fix SHA256 hash checking

### DIFF
--- a/packages/CLAPACK/meta.yaml
+++ b/packages/CLAPACK/meta.yaml
@@ -3,9 +3,9 @@ package:
   version: 3.2.1
 
 source:
+  sha256: 6dc4c382164beec8aaed8fd2acc36ad24232c406eda6db462bd4c41d5e455fac
   url: http://www.netlib.org/clapack/clapack.tgz
   extract_dir: CLAPACK-3.2.1
-  sha256sum: 6dc4c382164beec8aaed8fd2acc36ad24232c406eda6db462bd4c41d5e455fac
   patches:
     - patches/0001-add-missing-import.patch
     - patches/0002-fix-arith-h.patch

--- a/packages/libxml/meta.yaml
+++ b/packages/libxml/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: 2.9.10
 
 source:
+  sha256: aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
   url: ftp://xmlsoft.org/libxml2/libxml2-2.9.10.tar.gz
-  sha256sum: aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
 
 requirements:
   run:

--- a/packages/libxslt/meta.yaml
+++ b/packages/libxslt/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: 1.1.33
 
 source:
+  sha256: 8e36605144409df979cab43d835002f63988f3dc94d5d3537c12796db90e38c8
   url: ftp://xmlsoft.org/libxml2/libxslt-1.1.33.tar.gz
-  sha256sum: 8e36605144409df979cab43d835002f63988f3dc94d5d3537c12796db90e38c8
 
 requirements:
   run:

--- a/packages/zlib/meta.yaml
+++ b/packages/zlib/meta.yaml
@@ -3,8 +3,8 @@ package:
   version: 1.2.11
 
 source:
+  sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
   url: https://zlib.net/zlib-1.2.11.tar.gz
-  sha256sum: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 build:
   library: true


### PR DESCRIPTION
An incorrect (old?) key was used in meta.yaml, they do not seem to fail on the incorrect hash.