### PR TITLE
TST Print failed tests instead of skipped ones

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [tool:pytest]
 norecursedirs = build cpython emsdk/
-addopts =
-    --doctest-modules
+addopts = --doctest-modules
 
 [bumpversion]
 current_version = 0.16.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [tool:pytest]
 norecursedirs = build cpython emsdk/
 addopts =
-    -r sxX
     --doctest-modules
 
 [bumpversion]


### PR DESCRIPTION
This is more useful for debugging, and is the default pytest configuration
