### PR TITLE
Simplify code for pyodide.version field

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -31,22 +31,6 @@
     }                                                                          \
   } while (0)
 
-_Py_IDENTIFIER(__version__);
-
-static int
-version_info_init()
-{
-  PyObject* pyodide = PyImport_ImportModule("pyodide");
-  PyObject* pyodide_version = _PyObject_GetAttrId(pyodide, &PyId___version__);
-  const char* pyodide_version_utf8 = PyUnicode_AsUTF8(pyodide_version);
-
-  EM_ASM({ Module.version = UTF8ToString($0); }, pyodide_version_utf8);
-
-  Py_CLEAR(pyodide);
-  Py_CLEAR(pyodide_version);
-  return 0;
-}
-
 int
 main(int argc, char** argv)
 {
@@ -85,7 +69,6 @@ main(int argc, char** argv)
   TRY_INIT(python2js);
   TRY_INIT(runpython);
 
-  TRY_INIT(version_info);
   printf("Python initialization complete\n");
 
   emscripten_exit_with_live_runtime();

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -363,6 +363,7 @@ var languagePluginLoader = new Promise((resolve, reject) => {
 
   Module.locateFile = (path) => baseURL + path;
   Module.postRun = async () => {
+    Module.version = Module.pyodide_py.__version__;
     delete self.Module;
     let response = await fetch(`${baseURL}packages.json`);
     let json = await response.json();


### PR DESCRIPTION
Replaced 15 lines of version stuff in `main.c` with a single line in `pyodide.js` which achieves the same effect.