### PR TITLE
Added "make debug" which builds with DEBUG_F flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,4 +208,6 @@ minimal :
 	PYODIDE_PACKAGES="micropip" make
 
 debug :
-	EXTRA_C_FLAGS="-D DEBUG_F" PYODIDE_PACKAGES="micropip" make
+	EXTRA_C_FLAGS="-D DEBUG_F -s ASSERTIONS=2" \
+	PYODIDE_PACKAGES="micropip,pyparsing,pytz,packaging,kiwisolver" \
+	make

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ PYODIDE_CXX=$(PYODIDE_ROOT)/ccache/em++
 CC=emcc
 CXX=em++
 OPTFLAGS=-O2
-CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -Wno-warn-absolute-paths -Werror=int-conversion -Werror=incompatible-pointer-types -fPIC
+EXTRA_C_FLAGS=""
+CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -fPIC \
+	-Wno-warn-absolute-paths -Werror=int-conversion -Werror=incompatible-pointer-types \
+	$(EXTRA_C_FLAGS)
 
 LDFLAGS=\
 	-O2 \
@@ -203,3 +206,6 @@ check:
 
 minimal :
 	PYODIDE_PACKAGES="micropip" make
+
+debug :
+	EXTRA_C_FLAGS="-D DEBUG_F" PYODIDE_PACKAGES="micropip" make

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ LDFLAGS=\
 	-lstdc++ \
 	--memory-init-file 0 \
 	-s "BINARYEN_TRAP_MODE='clamp'" \
-	-s LZ4=1
+	-s LZ4=1	\
+	$(EXTRA_LDFLAGS)
 
 all: check \
 	build/pyodide.asm.js \
@@ -207,6 +208,7 @@ minimal :
 	PYODIDE_PACKAGES="micropip" make
 
 debug :
-	EXTRA_CFLAGS="-D DEBUG_F -s ASSERTIONS=2" \
+	EXTRA_CFLAGS="-D DEBUG_F" \
+	EXTRA_LDFLAGS="-s ASSERTIONS=2" \
 	PYODIDE_PACKAGES+="micropip,pyparsing,pytz,packaging,kiwisolver" \
 	make

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,9 @@ PYODIDE_CXX=$(PYODIDE_ROOT)/ccache/em++
 CC=emcc
 CXX=em++
 OPTFLAGS=-O2
-EXTRA_C_FLAGS=""
 CFLAGS=$(OPTFLAGS) -g -I$(PYTHONINCLUDE) -fPIC \
 	-Wno-warn-absolute-paths -Werror=int-conversion -Werror=incompatible-pointer-types \
-	$(EXTRA_C_FLAGS)
+	$(EXTRA_CFLAGS)
 
 LDFLAGS=\
 	-O2 \
@@ -208,6 +207,6 @@ minimal :
 	PYODIDE_PACKAGES="micropip" make
 
 debug :
-	EXTRA_C_FLAGS="-D DEBUG_F -s ASSERTIONS=2" \
-	PYODIDE_PACKAGES="micropip,pyparsing,pytz,packaging,kiwisolver" \
+	EXTRA_CFLAGS="-D DEBUG_F -s ASSERTIONS=2" \
+	PYODIDE_PACKAGES+="micropip,pyparsing,pytz,packaging,kiwisolver" \
 	make

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -98,7 +98,7 @@ log_error(char* msg);
              __FILE__);                                                        \
     log_error(msg);                                                            \
     free(msg);                                                                 \
-    goto finally                                                               \
+    goto finally;                                                              \
   } while (0)
 
 #else


### PR DESCRIPTION
DEBUG_F provides extra logging info: whenever `FAIL` is invoked, a messages is printed with a javascript stack trace, and the source line function and file where the failure happened. When #1080 is merged, it will add debug statements whenever an error occurs in `EM_JS`.

I also added a missing semicolon in the `DEBUG_F` version of `FAIL`.