### PR TITLE
BUGFIX: If python2js_buffer fails, python2js leaves the error flag in an invalid state

### DIFF
--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -111,12 +111,15 @@ def test_python2js_numpy_dtype(selenium_standalone):
 
 def test_py2js_buffer_clear_error_flag(selenium_standalone):
     selenium.run("x = np.array([['string1', 'string2'], ['string3', 'string4']])")
-    selenium.run_js("return pyodide.globals.x")
-    selenium.run_js("return pyodide.globals.x")
-    selenium.run_js("return pyodide.globals.x")
-    selenium.run_js("return pyodide.globals.x")
-    selenium.run_js("return pyodide.globals.x")
-    selenium.run_js("return pyodide.globals.x")
+    assert (
+        selenium.run_js(
+            """
+        pyodide.globals.x
+        return pyodide._module._PyErr_Occurred();
+        """
+        )
+        == 0
+    )
 
 
 def test_python2js_numpy_scalar(selenium_standalone):

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -109,7 +109,7 @@ def test_python2js_numpy_dtype(selenium_standalone):
     assert selenium.run_js("return pyodide.pyimport('x')[1][1]") == "string4"
 
 
-def test_py2js_buffer_clear_error_flag(selenium_standalone):
+def test_py2js_buffer_clear_error_flag(selenium):
     selenium.run("x = np.array([['string1', 'string2'], ['string3', 'string4']])")
     assert (
         selenium.run_js(

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -109,6 +109,16 @@ def test_python2js_numpy_dtype(selenium_standalone):
     assert selenium.run_js("return pyodide.pyimport('x')[1][1]") == "string4"
 
 
+def test_py2js_buffer_clear_error_flag(selenium_standalone):
+    selenium.run("x = np.array([['string1', 'string2'], ['string3', 'string4']])")
+    selenium.run_js("return pyodide.globals.x")
+    selenium.run_js("return pyodide.globals.x")
+    selenium.run_js("return pyodide.globals.x")
+    selenium.run_js("return pyodide.globals.x")
+    selenium.run_js("return pyodide.globals.x")
+    selenium.run_js("return pyodide.globals.x")
+
+
 def test_python2js_numpy_scalar(selenium_standalone):
     selenium = selenium_standalone
 

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -114,9 +114,9 @@ def test_py2js_buffer_clear_error_flag(selenium_standalone):
     assert (
         selenium.run_js(
             """
-        pyodide.globals.x
-        return pyodide._module._PyErr_Occurred();
-        """
+            pyodide.globals.x
+            return pyodide._module._PyErr_Occurred();
+            """
         )
         == 0
     )

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -110,6 +110,8 @@ def test_python2js_numpy_dtype(selenium_standalone):
 
 
 def test_py2js_buffer_clear_error_flag(selenium):
+    selenium.load_package("numpy")
+    selenium.run("import numpy as np")
     selenium.run("x = np.array([['string1', 'string2'], ['string3', 'string4']])")
     assert (
         selenium.run_js(

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -262,6 +262,7 @@ _python2js(PyObject* x, PyObject* map)
     if (ret != NULL) {
       return ret;
     }
+    PyErr_Clear();
     if (PySequence_Check(x)) {
       return _python2js_sequence(x, map);
     }

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -339,7 +339,7 @@ def test_memoryview_conversion(selenium):
     selenium.run_js(
         """
         pyodide.globals.a
-        if(pyodide._module._PyErr_Occurred){
+        if(pyodide._module._PyErr_Occurred()){
             pyodide._module._pythonexc2js();
         }
         """

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -327,3 +327,20 @@ def test_javascript_error_back_to_js(selenium):
         return pyodide.globals["py_err"] === err
         """
     )
+
+
+def test_memoryview_conversion(selenium):
+    selenium.run(
+        """
+        import array
+        a = array.array("Q", [1,2,3])
+        """
+    )
+    selenium.run_js(
+        """
+        pyodide.globals.a
+        if(pyodide._module._PyErr_Occurred){
+            pyodide._module._pythonexc2js();
+        }
+        """
+    )


### PR DESCRIPTION
I fixed #1110. If `python2js_buffer` fails, we need to clear the Python error flag before trying a backup approach.