### PR TITLE
Correct error handling in pyproxy_set

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -61,9 +61,9 @@ _pyproxy_set(PyObject* pyobj, JsRef idkey, JsRef idval)
   // HC: HACK see comment in _pyproxy_get.
   int result;
   if (PyDict_Check(pyobj)) {
-    PyObject_SetItem(pyobj, pykey, pyval);
+    result = PyObject_SetItem(pyobj, pykey, pyval);
   } else {
-    PyObject_SetAttr(pyobj, pykey, pyval);
+    result = PyObject_SetAttr(pyobj, pykey, pyval);
   }
   Py_DECREF(pykey);
   Py_DECREF(pyval);


### PR DESCRIPTION
As @dalcde pointed out, there was undefined behavior in pyproxy_set: I declared a variable `result` and then checked it's value without ever initializing it. This fixes the problem by storing the error codes into `result` which I'd meant to write originally but failed to.