### PR TITLE
Fix version type in the glpk package

### DIFF
--- a/packages/glpk/meta.yaml
+++ b/packages/glpk/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: glpk
-  version: 4.65
+  version: "4.65"
 
 source:
   sha256: 4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10


### PR DESCRIPTION
Following https://github.com/iodide-project/pyodide/pull/1105
This should fix CI on master.