### PR TITLE
MAINT: Use PyConfig to configure python interpreter

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -44,7 +44,7 @@ initialize_python()
   PyStatus status;
   PyConfig config;
   PyConfig_InitPythonConfig(&config);
-  status = PyConfig_SetString(config, &config.home, "/");
+  status = PyConfig_SetBytesString(&config, &config.home, "/");
   FAIL_IF_STATUS_EXCEPTION(status);
   config.write_bytecode = false;
   config.install_signal_handlers = false;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -110,7 +110,6 @@ main(int argc, char** argv)
   // They should appear last so that core_module is ready.
   TRY_INIT(runpython);
 
-  Py_CLEAR(sys);
   Py_CLEAR(core_module);
   printf("Python initialization complete\n");
   emscripten_exit_with_live_runtime();


### PR DESCRIPTION
Prior to Python 3.8, configuring Python was an ad-hoc process. [PEP 587](https://www.python.org/dev/peps/pep-0587/) added a systematic way to configure Python. Using this leads to simpler, clearer code with compile time checking for the config fields, better error handling and more discoverable documentation.

For example, in `Py_InitializeEx(0)` the `0` means "don't install signal handlers". This is opaque and requires looking `Py_InitializeEx` in the docs to interpret. (Of course a comment could fix that.) Instead we now say:
```C
config.install_signal_handlers = false;
```