### PR TITLE
Fix mistake in merging #1047 and #1083

### DIFF
--- a/pyodide_build/testing.py
+++ b/pyodide_build/testing.py
@@ -39,7 +39,13 @@ def run_in_pyodide(
                 # containing the source. This results in a more helpful
                 # traceback
                 selenium.run_js(
-                    """pyodide._module.pyodide_py.eval_code({!r}, pyodide._module.globals, "last_expr", true, {!r})""".format(
+                    """pyodide._module.pyodide_py.eval_code({!r}, // code
+                            pyodide._module.globals, // globals
+                            pyodide._module.globals, // locals
+                            "last_expr", // return_mode
+                            true, // quiet_trailing_semicolon
+                            {!r} // filename
+                        )""".format(
                         source, inspect.getsourcefile(f)
                     )
                 )

--- a/src/tests/test_testing.py
+++ b/src/tests/test_testing.py
@@ -1,7 +1,13 @@
 import pathlib
+from pyodide_build.testing import run_in_pyodide
 
 
 def test_web_server_secondary(selenium, web_server_secondary):
     host, port, logs = web_server_secondary
     assert pathlib.Path(logs).exists()
     assert selenium.server_port != port
+
+
+@run_in_pyodide
+def test_run_in_pyodide():
+    pass


### PR DESCRIPTION
#1083 changed the signature of `eval_code` and #1047 cares about the method signature of `eval_code`. Due to a merging race condition these both got merged into master even though they don't like each other. This adjusts #1047 to reflect the change in #1083.