### PR TITLE
MAINT: Small fixes to fail macros

### DIFF
--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -124,14 +124,14 @@ log_error(char* msg);
 
 #define FAIL_IF_NULL(ref)                                                      \
   do {                                                                         \
-    if (ref == NULL) {                                                         \
+    if ((ref) == NULL) {                                                       \
       FAIL();                                                                  \
     }                                                                          \
   } while (0)
 
 #define FAIL_IF_MINUS_ONE(num)                                                 \
   do {                                                                         \
-    if (num != 0) {                                                            \
+    if ((num) != 0) {                                                          \
       FAIL();                                                                  \
     }                                                                          \
   } while (0)

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -131,7 +131,7 @@ log_error(char* msg);
 
 #define FAIL_IF_MINUS_ONE(num)                                                 \
   do {                                                                         \
-    if ((num) != 0) {                                                          \
+    if ((num) == -1) {                                                         \
       FAIL();                                                                  \
     }                                                                          \
   } while (0)


### PR DESCRIPTION
`FAIL_IF_MINUS_ONE` was checking if `arg != 0`, which is `FAIL_IF_NONZERO`. I changed that to `== -1` as it should be.

Also, I added parenthesis guards for the arguments, without them, the macro contains subtle bugs: for example the conditional in `FAIL_IF_MINUS_ONE(1 | 0)` evaluated to `true` even though `1 | 0` evaluates to `1` which is not equal to -1:
Before:
```C
1 | 0 == -1    ===>    1 | (0 == -1)    ===>    1 | 0    ===>    1 (true!)
```
After:
```C
(1 | 0) == -1    ===>   0 == -1    ===>    0 (false)
```