### PR TITLE
Simplify pythonexc2js and add more careful error handling

### DIFF
--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -73,16 +73,11 @@ finally__skip_print_tb:
   Py_CLEAR(pylines);
   Py_CLEAR(empty);
   Py_CLEAR(pystr);
-  if (excval != NULL) {
-    // this throws an error making it pretty difficult to decref excval.
-    // hiwire_throw_error will decref it for us (so it steals a reference to its
-    // argument).
-    hiwire_throw_error(excval);
-  } else {
-    // In this case there will be an error in the calling code, calling code
-    // currently expects us to throw no matter what.
-    PySys_WriteStderr("Internal error: failed to generate exception!\n");
-  }
+  // hiwire_string_ascii never fails so excval is guaranteed not to be null at
+  // this point. This throws an error making it pretty difficult to decref
+  // excval, so hiwire_throw_error will decref it for us (in other words
+  // hiwire_throw_error steals a reference to its argument).
+  hiwire_throw_error(excval);
 }
 
 int

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -52,8 +52,8 @@ pythonexc2js()
   FAIL_IF_NULL(pystr);
   const char* pystr_utf8 = PyUnicode_AsUTF8(pystr);
   FAIL_IF_NULL(pystr_utf8);
-  printf("Python exception:\n");
-  printf("%s\n", pystr_utf8);
+  PySys_WriteStderr("Python exception:\n");
+  PySys_WriteStderr("%s\n", pystr_utf8);
   excval = _python2js_unicode(pystr);
 
   success = true;

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -55,6 +55,7 @@ pythonexc2js()
   PySys_WriteStderr("Python exception:\n");
   PySys_WriteStderr("%s\n", pystr_utf8);
   excval = _python2js_unicode(pystr);
+  FAIL_IF_NULL(excval);
 
   success = true;
 finally:

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -69,14 +69,18 @@ finally__skip_print_tb:
   Py_CLEAR(type);
   Py_CLEAR(value);
   Py_CLEAR(traceback);
-  hiwire_CLEAR(excval);
   Py_CLEAR(pylines);
   Py_CLEAR(empty);
   Py_CLEAR(pystr);
   if (excval != NULL) {
+    // this throws an error making it pretty difficult to decref excval.
+    // hiwire_throw_error will decref it for us (so it steals a reference to its
+    // argument).
     hiwire_throw_error(excval);
   } else {
-    PySys_WriteStderr("Internal error: failed to generate exception!");
+    // In this case there will be an error in the calling code, calling code
+    // currently expects us to throw no matter what.
+    PySys_WriteStderr("Internal error: failed to generate exception!\n");
   }
 }
 

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -11,83 +11,73 @@
 
 static PyObject* tbmod = NULL;
 
+_Py_IDENTIFIER(format_exception);
+
 static JsRef
 _python2js_unicode(PyObject* x);
 
 void
 pythonexc2js()
 {
-  PyObject* type;
-  PyObject* value;
-  PyObject* traceback;
-  int no_traceback = 0;
+  bool success = false;
+  PyObject* type = NULL;
+  PyObject* value = NULL;
+  PyObject* traceback = NULL;
+  JsRef excval = NULL;
+  PyObject* pylines = NULL;
+  PyObject* empty = NULL;
+  PyObject* pystr = NULL;
 
   PyErr_Fetch(&type, &value, &traceback);
   PyErr_NormalizeException(&type, &value, &traceback);
 
-  JsRef excval = NULL;
-  int exc;
-
   if (type == NULL || type == Py_None || value == NULL || value == Py_None) {
     excval = hiwire_string_ascii("No exception type or value");
+    PySys_WriteStderr("No exception type or value\n");
+    goto finally__skip_print_tb;
+    return;
+  }
+
+  if (traceback == NULL) {
+    traceback = Py_None;
+    Py_INCREF(traceback);
+  }
+
+  pylines = _PyObject_CallMethodIdObjArgs(
+    tbmod, &PyId_format_exception, type, value, traceback, NULL);
+  FAIL_IF_NULL(pylines);
+  empty = PyUnicode_New(0, 0);
+  FAIL_IF_NULL(empty);
+  pystr = PyUnicode_Join(empty, pylines);
+  FAIL_IF_NULL(pystr);
+  const char* pystr_utf8 = PyUnicode_AsUTF8(pystr);
+  FAIL_IF_NULL(pystr_utf8);
+  printf("Python exception:\n");
+  printf("%s\n", pystr_utf8);
+  excval = _python2js_unicode(pystr);
+
+  success = true;
+finally:
+  if (!success) {
+    excval = hiwire_string_ascii("Error occurred while formatting traceback");
+    PySys_WriteStderr("Error occurred while formatting traceback:\n");
     PyErr_Print();
-    PyErr_Clear();
-    goto exit;
+    PySys_WriteStderr("\nOriginal exception was:\n");
+    PyErr_Display(type, value, traceback);
   }
-
-  if (tbmod == NULL) {
-    tbmod = PyImport_ImportModule("traceback");
-    if (tbmod == NULL) {
-      PyObject* repr = PyObject_Repr(value);
-      if (repr == NULL) {
-        excval = hiwire_string_ascii("Could not get repr for exception");
-      } else {
-        excval = _python2js_unicode(repr);
-        Py_DECREF(repr);
-      }
-      goto exit;
-    }
-  }
-
-  PyObject* format_exception;
-  if (traceback == NULL || traceback == Py_None) {
-    no_traceback = 1;
-    format_exception = PyObject_GetAttrString(tbmod, "format_exception_only");
+finally__skip_print_tb:
+  Py_CLEAR(type);
+  Py_CLEAR(value);
+  Py_CLEAR(traceback);
+  hiwire_CLEAR(excval);
+  Py_CLEAR(pylines);
+  Py_CLEAR(empty);
+  Py_CLEAR(pystr);
+  if (excval != NULL) {
+    hiwire_throw_error(excval);
   } else {
-    format_exception = PyObject_GetAttrString(tbmod, "format_exception");
+    PySys_WriteStderr("Internal error: failed to generate exception!");
   }
-  if (format_exception == NULL) {
-    excval = hiwire_string_ascii("Could not get format_exception function");
-  } else {
-    PyObject* pylines;
-    if (no_traceback) {
-      pylines =
-        PyObject_CallFunctionObjArgs(format_exception, type, value, NULL);
-    } else {
-      pylines = PyObject_CallFunctionObjArgs(
-        format_exception, type, value, traceback, NULL);
-    }
-    if (pylines == NULL) {
-      excval = hiwire_string_ascii("Error calling traceback.format_exception");
-      PyErr_Print();
-      PyErr_Clear();
-      goto exit;
-    } else {
-      PyObject* empty = PyUnicode_FromString("");
-      PyObject* pystr = PyUnicode_Join(empty, pylines);
-      printf("Python exception:\n");
-      printf("%s\n", PyUnicode_AsUTF8(pystr));
-      excval = _python2js_unicode(pystr);
-      Py_DECREF(pystr);
-      Py_DECREF(empty);
-      Py_DECREF(pylines);
-    }
-    Py_DECREF(format_exception);
-  }
-
-exit:
-  PyErr_Clear();
-  hiwire_throw_error(excval);
 }
 
 int
@@ -344,5 +334,10 @@ python2js(PyObject* x)
 int
 python2js_init()
 {
-  return 0;
+  bool success = false;
+  tbmod = PyImport_ImportModule("traceback");
+  FAIL_IF_NULL(tbmod);
+  success = true;
+finally:
+  return success ? 0 : -1;
 }


### PR DESCRIPTION
I simplified the logic in `pythonexc2js` and implemented better error handling. I'm pretty sure that the original version actually always leaks the exception state because `PyErr_Fetch` takes ownership of `type`, `value`, and `traceback` but it never decref'd them. 

Another issue with the original code is that it calls `PyErr_Print()` when the error indicator is unset. The docs say that `PyErr_Print()` may cause a fatal system error if called when the error indicator is unset:
https://docs.python.org/3/c-api/exceptions.html?highlight=pyerr_print#c.PyErr_PrintEx
This is not apparently true, looking at the source code of `PyErr_Print`, there is a guard check whether the error indicator is set, if not just does nothing. (This is really what it should do, not like it costs much to be reasonable.) Anyways, because the documented behavior of `PyErr_Print` says it triggers a fatal error in this case, I figure we ought to try to avoid calling it in that condition.

In future PRs I am hoping to update the error formatting to alternate between Python and javascript stack traces as the code crosses between languages and to implement fatal error trapping.