### PR TITLE
MAINT: Minor cleanup of pyproxy

### DIFF
--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -152,7 +152,7 @@ EM_JS_REF(PyObject*, __js2python, (JsRef id), {
   } else if (value === false) {
     return __js2python_false();
   } else if (Module.PyProxy.isPyProxy(value)) {
-    return __js2python_pyproxy(Module.PyProxy.getPtr(value));
+    return __js2python_pyproxy(Module.PyProxy._getPtr(value));
   } else if (value['byteLength'] !== undefined) {
     return __js2python_memoryview(id);
   } else if (is_error(value)) {

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -208,7 +208,7 @@ EM_JS(int, pyproxy_init, (), {
       Module.hiwire.decref(idresult);
       Module.hiwire.decref(idargs);
       return jsresult;
-    };
+    },
   };
 
   // See explanation of which methods should be defined here and what they do here:

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -120,12 +120,6 @@ _pyproxy_ownKeys(PyObject* pyobj)
 }
 
 JsRef
-_pyproxy_enumerate(PyObject* pyobj)
-{
-  return _pyproxy_ownKeys(pyobj);
-}
-
-JsRef
 _pyproxy_apply(PyObject* pyobj, JsRef idargs)
 {
   Py_ssize_t length = hiwire_get_length(idargs);

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -202,6 +202,7 @@ EM_JS(int, pyproxy_init, (), {
       this['$$']['ptr'] = null;
     },
     apply : function(jsthis, jsargs) {
+      let ptrobj = _getPtr(this);
       let idargs = Module.hiwire.new_value(jsargs);
       let idresult = __pyproxy_apply(ptrobj, idargs);
       let jsresult = Module.hiwire.get_value(idresult);

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -169,7 +169,8 @@ EM_JS_REF(JsRef, pyproxy_new, (PyObject * ptrobj), {
 
   let target = function(){};
   target['$$'] = { ptr : ptrobj, type : 'PyProxy' };
-  let proxy = new Proxy(target, Module.PyProxy);
+  Object.assign(target, Module.PyProxyPublicMethods);
+  let proxy = new Proxy(target, Module.PyProxyHandlers);
   Module.PyProxies[ptrobj] = proxy;
 
   return Module.hiwire.new_value(proxy);
@@ -178,58 +179,60 @@ EM_JS_REF(JsRef, pyproxy_new, (PyObject * ptrobj), {
 EM_JS(int, pyproxy_init, (), {
   // clang-format off
   Module.PyProxies = {};
+  function _getPtr(jsobj) {
+    let ptr = jsobj['$$']['ptr'];
+    if (ptr === null) {
+      throw new Error("Object has already been destroyed");
+    }
+    return ptr;
+  }
+  // Static methods
   Module.PyProxy = {
-    getPtr: function(jsobj) {
-      let ptr = jsobj['$$']['ptr'];
-      if (ptr === null) {
-        throw new Error("Object has already been destroyed");
-      }
-      return ptr;
-    },
+    _getPtr,
     isPyProxy: function(jsobj) {
       return jsobj['$$'] !== undefined && jsobj['$$']['type'] === 'PyProxy';
     },
-    addExtraKeys: function(result) {
-      result.push('toString');
-      result.push('prototype');
-      result.push('arguments');
-      result.push('caller');
+  };
+
+  Module.PyProxyPublicMethods = {
+    toString : function() {
+      let ptrobj = _getPtr(this);
+      let jsref_repr = __pyproxy_repr(ptrobj);
+      let repr = Module.hiwire.get_value(jsref_repr);
+      Module.hiwire.decref(jsref_repr);
+      return repr;
     },
+    destroy : function() {
+      let ptrobj = _getPtr(this);
+      __pyproxy_destroy(ptrobj);
+      this['$$']['ptr'] = null;
+    },
+    apply : function(jsthis, jsargs) {
+      let idargs = Module.hiwire.new_value(jsargs);
+      let idresult = __pyproxy_apply(ptrobj, idargs);
+      let jsresult = Module.hiwire.get_value(idresult);
+      Module.hiwire.decref(idresult);
+      Module.hiwire.decref(idargs);
+      return jsresult;
+    };
+  };
+
+  // See explanation of which methods should be defined here and what they do here:
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
+  Module.PyProxyHandlers = {
     isExtensible: function() { return true },
     has: function (jsobj, jskey) {
-      let ptrobj = this.getPtr(jsobj);
+      let ptrobj = _getPtr(jsobj);
       let idkey = Module.hiwire.new_value(jskey);
       let result = __pyproxy_has(ptrobj, idkey) !== 0;
       Module.hiwire.decref(idkey);
       return result;
     },
     get: function (jsobj, jskey) {
-      let ptrobj = this.getPtr(jsobj);
-      if (jskey === 'toString') {
-        return function() {
-          let jsref_repr = __pyproxy_repr(ptrobj);
-          let repr = Module.hiwire.get_value(jsref_repr);
-          Module.hiwire.decref(jsref_repr);
-          return repr;
-        }
-      } else if (jskey === '$$') {
-        return jsobj['$$'];
-      } else if (jskey === 'destroy') {
-        // See bug #1049
-        return function() {
-          __pyproxy_destroy(ptrobj);
-          jsobj['$$']['ptr'] = null;
-        }
-      } else if (jskey === 'apply') {
-        return function(jsthis, jsargs) {
-          let idargs = Module.hiwire.new_value(jsargs);
-          let idresult = __pyproxy_apply(ptrobj, idargs);
-          let jsresult = Module.hiwire.get_value(idresult);
-          Module.hiwire.decref(idresult);
-          Module.hiwire.decref(idargs);
-          return jsresult;
-        };
+      if(Reflect.has(jsobj, jskey)){
+        Reflect.get(jsobj, jskey);
       }
+      let ptrobj = _getPtr(jsobj);
       let idkey = Module.hiwire.new_value(jskey);
       let idresult = __pyproxy_get(ptrobj, idkey);
       let jsresult = Module.hiwire.get_value(idresult);
@@ -238,7 +241,7 @@ EM_JS(int, pyproxy_init, (), {
       return jsresult;
     },
     set: function (jsobj, jskey, jsval) {
-      let ptrobj = this.getPtr(jsobj);
+      let ptrobj = _getPtr(jsobj);
       let idkey = Module.hiwire.new_value(jskey);
       let idval = Module.hiwire.new_value(jsval);
       let idresult = __pyproxy_set(ptrobj, idkey, idval);
@@ -249,7 +252,7 @@ EM_JS(int, pyproxy_init, (), {
       return jsresult;
     },
     deleteProperty: function (jsobj, jskey) {
-      let ptrobj = this.getPtr(jsobj);
+      let ptrobj = _getPtr(jsobj);
       let idkey = Module.hiwire.new_value(jskey);
       let idresult = __pyproxy_deleteProperty(ptrobj, idkey);
       let jsresult = Module.hiwire.get_value(idresult);
@@ -258,29 +261,16 @@ EM_JS(int, pyproxy_init, (), {
       return jsresult;
     },
     ownKeys: function (jsobj) {
-      let ptrobj = this.getPtr(jsobj);
+      let result = Reflect.ownKeys(jsobj);
+      let ptrobj = _getPtr(jsobj);
       let idresult = __pyproxy_ownKeys(ptrobj);
       let jsresult = Module.hiwire.get_value(idresult);
       Module.hiwire.decref(idresult);
-      this.addExtraKeys(jsresult);
-      return jsresult;
-    },
-    enumerate: function (jsobj) {
-      let ptrobj = this.getPtr(jsobj);
-      let idresult = __pyproxy_enumerate(ptrobj);
-      let jsresult = Module.hiwire.get_value(idresult);
-      Module.hiwire.decref(idresult);
-      this.addExtraKeys(jsresult);
-      return jsresult;
+      result.push(...jsresult);
+      return result;
     },
     apply: function (jsobj, jsthis, jsargs) {
-      let ptrobj = this.getPtr(jsobj);
-      let idargs = Module.hiwire.new_value(jsargs);
-      let idresult = __pyproxy_apply(ptrobj, idargs);
-      let jsresult = Module.hiwire.get_value(idresult);
-      Module.hiwire.decref(idresult);
-      Module.hiwire.decref(idargs);
-      return jsresult;
+      return jsobj.apply(jsthis, jsargs);
     },
   };
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -190,7 +190,7 @@ EM_JS(int, pyproxy_init, (), {
   Module.PyProxy = {
     _getPtr,
     isPyProxy: function(jsobj) {
-      return jsobj['$$'] !== undefined && jsobj['$$']['type'] === 'PyProxy';
+      return jsobj && jsobj['$$'] !== undefined && jsobj['$$']['type'] === 'PyProxy';
     },
   };
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -225,7 +225,7 @@ EM_JS(int, pyproxy_init, (), {
     },
     get: function (jsobj, jskey) {
       if(Reflect.has(jsobj, jskey)){
-        Reflect.get(jsobj, jskey);
+        return Reflect.get(jsobj, jskey);
       }
       let ptrobj = _getPtr(jsobj);
       let idkey = Module.hiwire.new_value(jskey);

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -54,8 +54,6 @@ def test_pyproxy(selenium):
             "prototype",
             "apply",
             "destroy",
-            "name",
-            "length",
             "$$",
         ]
     )

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -52,8 +52,11 @@ def test_pyproxy(selenium):
             "get_value",
             "toString",
             "prototype",
-            "arguments",
-            "caller",
+            "apply",
+            "destroy",
+            "name",
+            "length",
+            "$$",
         ]
     )
     assert selenium.run("hasattr(f, 'baz')")


### PR DESCRIPTION
I separated `Module.PyProxy` into three objects: `Module.PyProxy` which has just the static methods, `Module.PyProxyPublicMethods` which has nonstatic public methods, and `Module.PyProxyHandlers` which has the [`Proxy` handlers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy).
I switched to using `Reflect` methods rather than listing out special cases. Also, I removed the `enumerate` handler because it has been removed from the standard.