### PR TITLE
Remove linker flags when building cpython

### DIFF
--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -109,11 +109,10 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.configured $(SQLITEBUILD)/lib
 	cp config.site $(BUILD)/
 	( \
 		cd $(BUILD); \
-		EMCC_CFLAGS="-s WASM=0" CONFIG_SITE=./config.site READELF=true LD_RUN_PATH="$(SQLITEBUILD):$(BZIP2BUILD)" emconfigure \
+		EMCC_CFLAGS="-s WASM=0" CONFIG_SITE=./config.site READELF=true emconfigure \
 		  ./configure \
 			  CFLAGS="-fPIC" \
 			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD) -I$(ZLIBBUILD)" \
-			  LDFLAGS="-L$(SQLITEBUILD) -L$(BZIP2BUILD)" \
 			  --without-pymalloc \
 			  --disable-shared \
 			  --disable-ipv6 \


### PR DESCRIPTION
We never link when building cpython; we simply generate object files and put them in an archive.