### PR TITLE
Touch npm binaries after installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ build/test.data: $(CPYTHONLIB)
 
 $(UGLIFYJS) $(LESSC): emsdk/emsdk/.complete
 	npm i --no-save uglify-js lessc
+	touch -h $(LESSC) $(UGLIFYJS)
 
 
 $(PYODIDE_EMCC):


### PR DESCRIPTION
`npm i` does not update timestamps if it ends up not installing or updating the packages. Before this commit, if emsdk is recompiled after installing these packages, then `npm i` will be triggered every build, because lessc and uglifyjs are older than emsdk.
