### PR TITLE
Fine tuning of error_handling debug tools

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -11,6 +11,8 @@ EM_JS_NUM(errcode, log_error, (char* msg), {
   console.error(jsmsg);
 });
 
+// Right now this is dead code (probably), please don't remove it.
+// Intended for debugging purposes.
 EM_JS_NUM(errcode, log_error_obj, (JsRef obj), {
   console.error(Module.hiwire.get_value(obj));
 });

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -11,6 +11,10 @@ EM_JS_NUM(errcode, log_error, (char* msg), {
   console.error(jsmsg);
 });
 
+EM_JS_NUM(errcode, log_error_obj, (JsRef obj), {
+  console.error(Module.hiwire.get_value(obj));
+});
+
 void
 PyodideErr_SetJsError(JsRef err)
 {

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -15,6 +15,8 @@ error_handling_init();
 errcode
 log_error(char* msg);
 
+// Right now this is dead code (probably), please don't remove it.
+// Intended for debugging purposes.
 errcode
 log_error_obj(JsRef obj);
 

--- a/src/core/error_handling.h
+++ b/src/core/error_handling.h
@@ -7,12 +7,16 @@
 #include <emscripten.h>
 
 typedef int errcode;
+#include "hiwire.h"
 
 int
 error_handling_init();
 
 errcode
 log_error(char* msg);
+
+errcode
+log_error_obj(JsRef obj);
 
 /** EM_JS Wrappers
  * Wrap EM_JS so that it produces functions that follow the Python return
@@ -59,7 +63,7 @@ log_error(char* msg);
     try    /* intentionally no braces, body already has them */                \
       body /* <== body of func */                                              \
     catch (e) {                                                                \
-        LOG_EM_JS_ERROR(func_name, err);                                       \
+        LOG_EM_JS_ERROR(func_name, e);                                       \
         Module.handle_js_error(e);                                             \
         return 0;                                                              \
     }                                                                          \
@@ -74,7 +78,7 @@ log_error(char* msg);
     try    /* intentionally no braces, body already has them */                \
       body /* <== body of func */                                              \
     catch (e) {                                                                \
-        LOG_EM_JS_ERROR(func_name, err);                                       \
+        LOG_EM_JS_ERROR(func_name, e);                                       \
         Module.handle_js_error(e);                                             \
         return -1;                                                             \
     }                                                                          \


### PR DESCRIPTION
I fixed a typo in `EM_JS_REF` and `EM_JS_NUM`: namely `LOG_EM_JS_ERROR(func_name, err);` ==> `LOG_EM_JS_ERROR(func_name, e);`

Also added an extra function `log_error_obj` which takes a `JsRef` and does `console.error(jsobj)`, useful for debugging.