### PR TITLE
Don't print duplicate error message in chrome

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -52,12 +52,12 @@ class JavascriptException(Exception):
     def __init__(self, msg, stack):
         self.msg = msg
         self.stack = stack
+        # In chrome the stack contains the message
+        if self.stack and self.stack.startswith(self.msg):
+            self.msg = ""
 
     def __str__(self):
-        if self.stack:
-            return self.msg + "\n\n" + self.stack
-        else:
-            return self.msg
+        return "\n\n".join(x for x in [self.msg, self.stack] if x)
 
 
 class SeleniumWrapper:


### PR DESCRIPTION
In chrome, the error message is contained in the stack. Avoid printing it twice.
