### PR TITLE
Lower selenium timeout to 10s

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -70,7 +70,7 @@ class SeleniumWrapper:
             build_dir = BUILD_PATH
 
         self.driver = self.get_driver()
-        self.driver.set_script_timeout(10)
+        self.driver.set_script_timeout(15)
         self.server_port = server_port
         self.server_hostname = server_hostname
         self.server_log = server_log

--- a/conftest.py
+++ b/conftest.py
@@ -70,6 +70,7 @@ class SeleniumWrapper:
             build_dir = BUILD_PATH
 
         self.driver = self.get_driver()
+        self.driver.set_script_timeout(10)
         self.server_port = server_port
         self.server_hostname = server_hostname
         self.server_log = server_log


### PR DESCRIPTION
It used to be 30s, and can cause long delays when some tests hang.
