### PR TITLE
Add more noreturn markers

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -222,7 +222,7 @@ EM_JS_REF(JsRef, hiwire_float64array, (f64 * ptr, int len), {
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(void, hiwire_throw_error, (JsRef idmsg), {
+EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef idmsg), {
   let jsmsg = Module.hiwire.get_value(idmsg);
   Module.hiwire.decref(idmsg);
   throw new Error(jsmsg);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -312,7 +312,7 @@ hiwire_push_object_pair(JsRef idobj, JsRef idkey, JsRef idval);
  * The message is conventionally a Javascript string, but that is not required.
  * TODO: should be hiwire_set_error.
  */
-void
+void _Py_NO_RETURN
 hiwire_throw_error(JsRef idmsg);
 
 /**


### PR DESCRIPTION
A couple commits back I added a `_Py_NO_RETURN` marker to `pythonexc2js`, but I didn't add `_Py_NO_RETURN` to `hiwire_throw_error`, which made the compiler emit a warning. This adds a `_Py_NO_RETURN` marker to `hiwire_throw_error` suppressing that warning.