### PR TITLE
Add mixed js/python traceback formatting

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -227,7 +227,9 @@ EM_JS_REF(JsRef, hiwire_float64array, (f64 * ptr, int len), {
 EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
   let jserr = Module.hiwire.get_value(iderr);
   Module.hiwire.decref(iderr);
-  if (typeof(jserr) == = "string") {
+  // clang-format off
+  if (typeof(jserr) === "string") {
+  // clang-format on
     jserr = new Error(jserr);
   }
   throw jserr;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -227,7 +227,7 @@ EM_JS_REF(JsRef, hiwire_float64array, (f64 * ptr, int len), {
 EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
   let jserr = Module.hiwire.get_value(iderr);
   Module.hiwire.decref(iderr);
-  if(typeof(jserr) === "string"){
+  if (typeof(jserr) == = "string") {
     jserr = new Error(jserr);
   }
   throw jserr;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -222,10 +222,15 @@ EM_JS_REF(JsRef, hiwire_float64array, (f64 * ptr, int len), {
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef idmsg), {
-  let jsmsg = Module.hiwire.get_value(idmsg);
-  Module.hiwire.decref(idmsg);
-  throw new Error(jsmsg);
+// The whole point of is it throw an error, it'd better not be wrapped
+// in EM_JS_NUM which'd just catch the error again.
+EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
+  let jserr = Module.hiwire.get_value(iderr);
+  Module.hiwire.decref(iderr);
+  if(typeof(jserr) === "string"){
+    jserr = new Error(jserr);
+  }
+  throw jserr;
 });
 
 EM_JS_REF(JsRef, hiwire_array, (), { return Module.hiwire.new_value([]); });

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -17,10 +17,13 @@ static JsRef
 _python2js_unicode(PyObject* x);
 
 EM_JS_REF(JsRef, pyproxy_to_js_error, (JsRef pyproxy), {
-  return Module.hiwire.new_value(new Module.PythonError(Module.hiwire.get_value(pyproxy)));
+  return Module.hiwire.new_value(
+    new Module.PythonError(Module.hiwire.get_value(pyproxy)));
 });
 
-JsRef wrap_exception(PyObject* pyexc){
+JsRef
+wrap_exception(PyObject* pyexc)
+{
   JsRef pyexc_proxy = pyproxy_new(pyexc);
   JsRef exc_proxy = pyproxy_to_js_error(pyexc_proxy);
   hiwire_decref(pyexc_proxy);
@@ -55,19 +58,6 @@ pythonexc2js()
 
   PyException_SetTraceback(value, traceback);
   excval = wrap_exception(value);
-
-  pylines = _PyObject_CallMethodIdObjArgs(
-    tbmod, &PyId_format_exception, type, value, traceback, NULL);
-  FAIL_IF_NULL(pylines);
-  empty = PyUnicode_New(0, 0);
-  FAIL_IF_NULL(empty);
-  pystr = PyUnicode_Join(empty, pylines);
-  FAIL_IF_NULL(pystr);
-  const char* pystr_utf8 = PyUnicode_AsUTF8(pystr);
-  FAIL_IF_NULL(pystr_utf8);
-  PySys_WriteStderr("Python exception:\n");
-  PySys_WriteStderr("%s\n", pystr_utf8);
-
   success = true;
 finally:
   if (!success) {
@@ -410,15 +400,16 @@ python2js_init()
   FAIL_IF_NULL(globals);
 
   EM_ASM({
-    class PythonError extends Error {
-      constructor(pythonError) {
+    class PythonError extends Error
+    {
+      constructor(pythonError)
+      {
         let message = "Python Error";
         super(message);
         this.name = this.constructor.name;
         this.pythonError = pythonError;
       }
-    }
-    Module.PythonError = PythonError;
+    } Module.PythonError = PythonError;
 
     Module.test_python2js_with_depth = function(name, depth)
     {

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,6 +1,7 @@
 from ._base import open_url, eval_code, find_imports, as_nested_list
 from ._core import JsException  # type: ignore
 from ._importhooks import JsFinder
+from .traceback import format_error
 import sys
 
 jsfinder = JsFinder()
@@ -8,37 +9,6 @@ register_js_module = jsfinder.register_js_module
 unregister_js_module = jsfinder.unregister_js_module
 sys.meta_path.append(jsfinder)  # type: ignore
 
-
-import traceback
-_cause_message = (
-    "\nThe above exception was the direct cause "
-    "of the following exception:\n\n")
-
-_context_message = (
-    "\nDuring handling of the above exception, "
-    "another exception occurred:\n\n")
-
-
-def format_error(e, cur_tb=""):
-    from pyodide_js._module import formatError
-    if(isinstance(e, JsException)):
-        if not cur_tb:
-            cur_tb += "Traceback (most recent call last):\n" 
-        cur_tb += "".join(traceback.format_tb(e.__traceback__))
-        cur_tb = formatError(e.js_error, cur_tb)
-    else:
-        tb = traceback.format_exception(type(e), e, e.__traceback__, chain=False)
-        if cur_tb and tb[0].startswith('Traceback'):
-            tb = tb[1:]
-        cur_tb += "".join(tb)
-    if e.__cause__ is not None:
-        cause_format = format_error(e.__cause__)
-        cur_tb = cause_format + _cause_message + cur_tb
-    elif (e.__context__ is not None and
-        not e.__suppress_context__):
-        context_format = format_error(e.__context__)
-        cur_tb = context_format + _context_message + cur_tb
-    return cur_tb
 
 __version__ = "0.16.1"
 
@@ -50,4 +20,5 @@ __all__ = [
     "JsException",
     "register_js_module",
     "unregister_js_module",
+    "format_error",
 ]

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -9,6 +9,37 @@ unregister_js_module = jsfinder.unregister_js_module
 sys.meta_path.append(jsfinder)  # type: ignore
 
 
+import traceback
+_cause_message = (
+    "\nThe above exception was the direct cause "
+    "of the following exception:\n\n")
+
+_context_message = (
+    "\nDuring handling of the above exception, "
+    "another exception occurred:\n\n")
+
+
+def format_error(e, cur_tb=""):
+    from pyodide_js._module import formatError
+    if(isinstance(e, JsException)):
+        if not cur_tb:
+            cur_tb += "Traceback (most recent call last):\n" 
+        cur_tb += "".join(traceback.format_tb(e.__traceback__))
+        cur_tb = formatError(e.js_error, cur_tb)
+    else:
+        tb = traceback.format_exception(type(e), e, e.__traceback__, chain=False)
+        if cur_tb and tb[0].startswith('Traceback'):
+            tb = tb[1:]
+        cur_tb += "".join(tb)
+    if e.__cause__ is not None:
+        cause_format = format_error(e.__cause__)
+        cur_tb = cause_format + _cause_message + cur_tb
+    elif (e.__context__ is not None and
+        not e.__suppress_context__):
+        context_format = format_error(e.__context__)
+        cur_tb = context_format + _context_message + cur_tb
+    return cur_tb
+
 __version__ = "0.16.1"
 
 __all__ = [

--- a/src/pyodide-py/pyodide/console.py
+++ b/src/pyodide-py/pyodide/console.py
@@ -4,7 +4,6 @@ import io
 import sys
 import platform
 
-
 __all__ = ["InteractiveConsole"]
 
 

--- a/src/pyodide-py/pyodide/traceback.py
+++ b/src/pyodide-py/pyodide/traceback.py
@@ -1,0 +1,25 @@
+from ._core import JsException  # type: ignore
+
+import traceback
+
+
+def format_error(e, cur_tb=""):
+    from pyodide_js._module import formatError
+
+    if isinstance(e, JsException):
+        if not cur_tb:
+            cur_tb += "Traceback (most recent call last):\n"
+        cur_tb += "".join(traceback.format_tb(e.__traceback__))
+        cur_tb = formatError(e.js_error, cur_tb)
+    else:
+        tb = traceback.format_exception(type(e), e, e.__traceback__, chain=False)
+        if cur_tb and tb[0].startswith("Traceback"):
+            tb = tb[1:]
+        cur_tb += "".join(tb)
+    if e.__cause__ is not None:
+        cause_format = format_error(e.__cause__)
+        cur_tb = cause_format + traceback._cause_message + cur_tb
+    elif e.__context__ is not None and not e.__suppress_context__:
+        context_format = format_error(e.__context__)
+        cur_tb = context_format + traceback._context_message + cur_tb
+    return cur_tb

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -360,19 +360,20 @@ globalThis.languagePluginLoader = new Promise((resolve, reject) => {
     }
   };
   // clang-format on
-  Module.formatError = function formatError(e, cur_tb=""){
-    if(cur_tb === ""){
+  Module.formatError = function formatError(e, cur_tb = "") {
+    if (cur_tb === "") {
       cur_tb += "Traceback (most recent call last):\n"
     }
     let split_stack = e.stack.split("\n");
-    split_stack = split_stack.slice(1).filter(e => e.indexOf("pyodide.asm") === -1);
+    split_stack =
+        split_stack.slice(1).filter(e => e.indexOf("pyodide.asm") === -1);
     split_stack.reverse();
     cur_tb += split_stack.join("\n") + "\n";
-    if(e.name === "PythonError"){
+    if (e.name === "PythonError") {
       cur_tb = pyodide._module.pyodide_py.format_error(e.pythonError, cur_tb);
     } else {
       cur_tb += (e.name || e.constructor.name || "<Unknown Error>");
-      if(e.message){
+      if (e.message) {
         cur_tb += ": " + e.message;
       }
       cur_tb += "\n";

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -85,7 +85,7 @@
         term.handlePythonError = function(result) {
           c.restore_stdstreams();
           term.resume();
-          term.error(result.toString());
+          term.error(pyodide.formatError(result));
         }
       });
     </script>


### PR DESCRIPTION
This PR adds support for traceback formatting of mixed Python / javascript stack tracebacks. I don't know what the ideal way to signal when we switch from js to python or from python to js is. Currently there is some inconsistency in presentation between the javascript frames and the Python ones.

@rth @dalcde I'm interested in feedback on how the mixed tracebacks should be formatted.

## Examples:

#### Raise `ValueError` into console

```python
raise ValueError("hi")
```
We see two layers of javascript stack trace (starting with `at`) and three layers of python stack trace (starting with `File`):
```python
Traceback (most recent call last):
    at Object.Module.runPythonAsync (http://172.27.140.60:8002/pyodide.js:387:19)
    at Object.Module.runPython (http://172.27.140.60:8002/pyodide.js:340:48)
  File "/lib/python3.8/site-packages/pyodide/_base.py", line 302, in eval_code
    return CodeRunner(
  File "/lib/python3.8/site-packages/pyodide/_base.py", line 225, in run
    exec(mod, self.globals, self.locals)
  File "<exec>", line 1, in <module>
ValueError: hi
```

#### `__context__` when an error is thrown in a javascript function in a catch block
```javascript
function f(){
    g();
}
function g(){
    pyodide.globals.h();
}
function m(){
    throw new Error("oops");
}
pyodide.runPython(`
    from js import f, m
    def h():
        k()

    def k():
        try:
            raise ValueError("hi")
        except Exception as e:
            m()
`);
try {
    f()
} catch(e) {
    pyodide.formatError(e);
}
```
currently results in the following traceback:
```python
Traceback (most recent call last):
  File "<exec>", line 8, in k
ValueError: hi

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
    at <anonymous>:22:5
    at f (<anonymous>:2:5)
    at g (<anonymous>:5:21)
  File "<exec>", line 4, in h
  File "<exec>", line 10, in k
    at m (<anonymous>:8:11)
Error: oops
```