### PR TITLE
Allow awaiting the same proxied promise multiple times

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -34,7 +34,6 @@ typedef struct
 {
   PyObject_HEAD
   JsRef js;
-  bool awaited; // for promises
 } JsProxy;
 // clang-format on
 
@@ -319,13 +318,6 @@ JsProxy_Bool(PyObject* o)
 static PyObject*
 JsProxy_Await(JsProxy* self)
 {
-  // Guards
-  if (self->awaited) {
-    PyErr_SetString(PyExc_RuntimeError,
-                    "cannot reuse already awaited coroutine");
-    return NULL;
-  }
-
   if (!hiwire_is_promise(self->js)) {
     PyObject* str = JsProxy_Repr((PyObject*)self);
     const char* str_utf8 = PyUnicode_AsUTF8(str);
@@ -432,7 +424,6 @@ JsProxy_cinit(PyObject* obj, JsRef idobj)
 {
   JsProxy* self = (JsProxy*)obj;
   self->js = hiwire_incref(idobj);
-  self->awaited = false;
 }
 
 static PyObject*


### PR DESCRIPTION
`JsProxy` has some extra code to raise an error the second time a promise is awaited to imitate the Python awaitable coroutines. This PR removes it.

A coroutine in python is initially not scheduled, awaiting it schedules the coroutine and then waits for the coroutine to complete. Since the coroutine cannot be scheduled twice it cannot be awaited twice.

On the other hand, a python future can be awaited as many times as one likes:
```python
async def test():
   return 2
async def await_twice(awaitable):
   fut = asyncio.ensure_future(awaitable)
   r1 = await fut
   r2 = await fut
   return [r1, r2]
import asyncio
result = asyncio.get_event_loop().run_until_complete(await_twice(test()))
print(result) # ==> [2, 2]
```
A promise is more like a future than like a coroutine since awaiting a promise doesn't schedule anything, so it should be fine to await it multiple times.