### PR TITLE
Revert "Don't automatically copy python objects into javascript"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -95,30 +95,10 @@ class SeleniumWrapper:
         self.driver.execute_script("window.logs = []")
 
     def run(self, code):
-        return self.run_js(
-            f"""
-            let result = pyodide.runPython({code!r});
-            if(result && result.deepCopyToJavascript){{
-                let converted_result = result.deepCopyToJavascript();
-                result.destroy();
-                return converted_result;
-            }}
-            return result;
-            """
-        )
+        return self.run_js("return pyodide.runPython({!r})".format(code))
 
     def run_async(self, code):
-        return self.run_js(
-            f"""
-            let result = await pyodide.runPythonAsync({code!r});
-            if(result && result.deepCopyToJavascript){{
-                let converted_result = result.deepCopyToJavascript();
-                result.destroy();
-                return converted_result;
-            }}
-            return result;
-            """
-        )
+        return self.run_js("return pyodide.runPythonAsync({!r})".format(code))
 
     def run_js(self, code):
         if isinstance(code, str) and code.startswith("\n"):

--- a/packages/matplotlib/src/wasm_backend.py
+++ b/packages/matplotlib/src/wasm_backend.py
@@ -190,7 +190,7 @@ class FigureCanvasWasm(backend_agg.FigureCanvasAgg):
         rubberband.addEventListener("keydown", self.onkeydown)
         context = rubberband.getContext("2d")
         context.strokeStyle = "#000000"
-        # context.setLineDash([2, 2])
+        context.setLineDash([2, 2])
         canvas_div.appendChild(rubberband)
 
         div.appendChild(canvas_div)

--- a/packages/matplotlib/test_matplotlib.py
+++ b/packages/matplotlib/test_matplotlib.py
@@ -2,15 +2,15 @@ def test_matplotlib(selenium_standalone):
     selenium = selenium_standalone
     selenium.load_package("matplotlib")
     selenium.run("from matplotlib import pyplot as plt")
-    selenium.run("plt.figure(); pass")
-    selenium.run("x = plt.plot([1,2,3])")
+    selenium.run("plt.figure()")
+    selenium.run("plt.plot([1,2,3])")
     selenium.run("plt.show()")
 
 
 def test_svg(selenium):
     selenium.load_package("matplotlib")
     selenium.run("from matplotlib import pyplot as plt")
-    selenium.run("plt.figure(); pass")
+    selenium.run("plt.figure()")
     selenium.run("x = plt.plot([1,2,3])")
     selenium.run("import io")
     selenium.run("fd = io.BytesIO()")
@@ -23,7 +23,7 @@ def test_svg(selenium):
 def test_pdf(selenium):
     selenium.load_package("matplotlib")
     selenium.run("from matplotlib import pyplot as plt")
-    selenium.run("plt.figure(); pass")
+    selenium.run("plt.figure()")
     selenium.run("x = plt.plot([1,2,3])")
     selenium.run("import io")
     selenium.run("fd = io.BytesIO()")

--- a/packages/numpy/test_numpy.py
+++ b/packages/numpy/test_numpy.py
@@ -2,17 +2,11 @@ def test_numpy(selenium):
     selenium.load_package("numpy")
     selenium.run("import numpy")
     selenium.run("x = numpy.ones((32, 64))")
-    assert selenium.run_js(
-        "return pyodide.pyimport('x').deepCopyToJavascript().length == 32"
-    )
+    assert selenium.run_js("return pyodide.pyimport('x').length == 32")
     for i in range(32):
-        assert selenium.run_js(
-            f"return pyodide.pyimport('x').deepCopyToJavascript()[{i}].length == 64"
-        )
+        assert selenium.run_js(f"return pyodide.pyimport('x')[{i}].length == 64")
         for j in range(64):
-            assert selenium.run_js(
-                f"return pyodide.pyimport('x').deepCopyToJavascript()[{i}][{j}] == 1"
-            )
+            assert selenium.run_js(f"return pyodide.pyimport('x')[{i}][{j}] == 1")
 
 
 def test_typed_arrays(selenium):
@@ -54,9 +48,7 @@ def test_python2js_numpy_dtype(selenium_standalone):
             for j in range(2):
                 for k in range(2):
                     assert (
-                        selenium.run_js(
-                            f"return pyodide.pyimport('x').deepCopyToJavascript()[{i}][{j}][{k}]"
-                        )
+                        selenium.run_js(f"return pyodide.pyimport('x')[{i}][{j}][{k}]")
                         == expected_result[i][j][k]
                     )
 
@@ -82,7 +74,7 @@ def test_python2js_numpy_dtype(selenium_standalone):
             )
             assert_equal()
             classname = selenium.run_js(
-                "return pyodide.pyimport('x').deepCopyToJavascript()[0][0].constructor.name"
+                "return pyodide.pyimport('x')[0][0].constructor.name"
             )
             if order == "C" and dtype not in ("uint64", "int64"):
                 # Here we expect a TypedArray subclass, such as Uint8Array, but
@@ -98,7 +90,7 @@ def test_python2js_numpy_dtype(selenium_standalone):
             )
             assert_equal()
             classname = selenium.run_js(
-                "return pyodide.pyimport('x').deepCopyToJavascript()[0][0].constructor.name"
+                "return pyodide.pyimport('x')[0][0].constructor.name"
             )
             if order == "C" and dtype in ("int8", "uint8"):
                 # Here we expect a TypedArray subclass, such as Uint8Array, but
@@ -112,18 +104,9 @@ def test_python2js_numpy_dtype(selenium_standalone):
     assert selenium.run("np.array([True, False])") == [True, False]
 
     selenium.run("x = np.array([['string1', 'string2'], ['string3', 'string4']])")
-    assert (
-        selenium.run_js("return pyodide.pyimport('x').deepCopyToJavascript().length")
-        == 2
-    )
-    assert (
-        selenium.run_js("return pyodide.pyimport('x').deepCopyToJavascript()[0][0]")
-        == "string1"
-    )
-    assert (
-        selenium.run_js("return pyodide.pyimport('x').deepCopyToJavascript()[1][1]")
-        == "string4"
-    )
+    assert selenium.run_js("return pyodide.pyimport('x').length") == 2
+    assert selenium.run_js("return pyodide.pyimport('x')[0][0]") == "string1"
+    assert selenium.run_js("return pyodide.pyimport('x')[1][1]") == "string4"
 
 
 def test_py2js_buffer_clear_error_flag(selenium):
@@ -193,9 +176,7 @@ def test_runpythonasync_numpy(selenium_standalone):
         """
     )
     for i in range(5):
-        assert selenium_standalone.run_js(
-            f"return pyodide.pyimport('x').deepCopyToJavascript()[{i}] == 0"
-        )
+        assert selenium_standalone.run_js(f"return pyodide.pyimport('x')[{i}] == 0")
 
 
 def test_runwebworker_numpy(selenium_standalone):

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -223,18 +223,6 @@ EM_JS(int, pyproxy_init, (), {
       Module.hiwire.decref(idresult);
       return jsresult;
     },
-    shallowCopyToJavascript : function(){
-      let idresult = _python2js_with_depth(_getPtr(this), depth);
-      let result = Module.hiwire.get_value(idresult);
-      Module.hiwire.decref(idresult);
-      return result;
-    },
-    deepCopyToJavascript : function(depth = -1){
-      let idresult = _python2js_with_depth(_getPtr(this), depth);
-      let result = Module.hiwire.get_value(idresult);
-      Module.hiwire.decref(idresult);
-      return result;
-    },
   };
 
   let ignoredTargetFields = ["name", "length"];

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -342,7 +342,7 @@ JsRef
 python2js(PyObject* x)
 {
   PyObject* map = PyDict_New();
-  JsRef result = _python2js_cache(x, map, 0);
+  JsRef result = _python2js_cache(x, map, -1);
   Py_DECREF(map);
 
   if (result == NULL) {

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -16,20 +16,12 @@ void
 pythonexc2js();
 
 /** Convert a Python object to a Javascript object.
- *  \param x The Python object
+ *  \param The Python object
  *  \return The Javascript object -- might be an Error object in the case of an
  *     exception.
  */
 JsRef
 python2js(PyObject* x);
-
-/** Convert a Python object to a Javascript object, copying standard collections
- * into javascript down to specified depth \param x The Python object \param
- * depth The maximum depth to copy \return The Javascript object -- might be an
- * Error object in the case of an exception.
- */
-JsRef
-python2js_with_depth(PyObject* x, int depth);
 
 /** Set up the global state for this module.
  */

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -362,7 +362,7 @@ globalThis.languagePluginLoader = new Promise((resolve, reject) => {
 
   // clang-format off
   Module.loadPackagesFromImports  = async function(code, messageCallback, errorCallback) {
-    let imports = Module.pyodide_py.find_imports(code).deepCopyToJavascript();
+    let imports = Module.pyodide_py.find_imports(code);
     if (imports.length === 0) {
       return;
     }

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -12,7 +12,7 @@ def test_jsproxy_dir(selenium):
             from js import a
             from js import b
             [dir(a), dir(b)]
-        `).deepCopyToJavascript();
+        `);
         """
     )
     jsproxy_items = set(
@@ -49,7 +49,7 @@ def test_jsproxy_getattr(selenium):
         return pyodide.runPython(`
             from js import a
             [ a.x, a.y, a.typeof ]
-        `).deepCopyToJavascript();
+        `);
         """
         )
         == [2, "9", "object"]
@@ -195,7 +195,7 @@ def test_jsproxy_call(selenium):
             from js import f
             [f(*range(n)) for n in range(10)]
             `
-        ).deepCopyToJavascript();
+        );
         """
         )
         == list(range(10))
@@ -379,7 +379,7 @@ def test_mount_object(selenium):
             import b
             result += [a.s, dir(a), dir(b)]
             result
-        `).deepCopyToJavascript()
+        `)
         """
     )
     assert result[:3] == ["x1", "x2", 3]

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -55,8 +55,6 @@ def test_pyproxy(selenium):
             "apply",
             "destroy",
             "$$",
-            "deepCopyToJavascript",
-            "shallowCopyToJavascript",
         ]
     )
     assert selenium.run("hasattr(f, 'baz')")

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -172,5 +172,5 @@ def test_unknown_attribute(selenium):
 def test_run_python_debug(selenium):
     assert selenium.run_js("return pyodide._module.runPythonDebug('1+1');") == 2
     assert selenium.run_js(
-        "return pyodide._module.runPythonDebug('[x*x + 1 for x in range(4)]').deepCopyToJavascript();"
+        "return pyodide._module.runPythonDebug('[x*x + 1 for x in range(4)]');"
     ) == [1, 2, 5, 10]

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -22,14 +22,14 @@ def test_python2js(selenium):
     )
     assert selenium.run_js(
         """
-        let x = pyodide.runPython("[1, 2, 3]").deepCopyToJavascript();
+        let x = pyodide.runPython("[1, 2, 3]");
         return ((x instanceof window.Array) && (x.length === 3) &&
                 (x[0] == 1) && (x[1] == 2) && (x[2] == 3))
         """
     )
     assert selenium.run_js(
         """
-        let x = pyodide.runPython("{42: 64}").deepCopyToJavascript();
+        let x = pyodide.runPython("{42: 64}");
         return (typeof x === "object") && (x[42] === 64)
         """
     )
@@ -230,7 +230,7 @@ def test_recursive_list_to_js(selenium_standalone):
         x.append(x)
         """
     )
-    selenium_standalone.run_js("x = pyodide.pyimport('x').deepCopyToJavascript();")
+    selenium_standalone.run_js("x = pyodide.pyimport('x');")
 
 
 def test_recursive_dict_to_js(selenium_standalone):
@@ -240,7 +240,7 @@ def test_recursive_dict_to_js(selenium_standalone):
         x[0] = x
         """
     )
-    selenium_standalone.run_js("x = pyodide.pyimport('x').deepCopyToJavascript();")
+    selenium_standalone.run_js("x = pyodide.pyimport('x');")
 
 
 def test_list_from_js(selenium):


### PR DESCRIPTION
Reverts iodide-project/pyodide#1152

It seems that we now have a regression with test_console.py #1152, which first must be examined.
```
___________________________ test_completion[firefox] ___________________________
[gw2] linux -- Python 3.8.2 /usr/local/bin/python

selenium = <conftest.FirefoxWrapper object at 0x7f6529803a00>
safe_selenium_sys_redirections = None

    def test_completion(selenium, safe_selenium_sys_redirections):
        selenium.run(
            """
        from pyodide import console
    
        shell = console.InteractiveConsole()
        """
        )
    
>       assert selenium.run("shell.complete('a')") == [
            [
                "and ",
                "as ",
                "assert ",
                "async ",
                "await ",
                "abs(",
                "all(",
                "any(",
                "ascii(",
            ],
            0,
        ]
E       AssertionError: assert [None, 0] == [['and ', 'as...bs(', ...], 0]
E         At index 0 diff: None != ['and ', 'as ', 'assert ', 'async ', 'await ', 'abs(', 'all(', 'any(', 'ascii(']
E         Full diff:
E           [
E         +  None,
E         -  ['and ',
E         -   'as ',
E         -   'assert ',
E         -   'async ',
E         -   'await ',
E         -   'abs(',
E         -   'all(',
E         -   'any(',
E         -   'ascii('],
E            0,
E           ]

src/tests/test_console.py:201: AssertionError
```
Next time it would be better to first merge master into this branch, and re-test it first.