### PR TITLE
Fix METH_NOARGS function signatures

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -178,7 +178,7 @@ JsProxy_RichCompare(PyObject* a, PyObject* b, int op)
 }
 
 static PyObject*
-JsProxy_GetIter(PyObject* o)
+JsProxy_GetIter(PyObject* o, PyObject* _args)
 {
   JsProxy* self = (JsProxy*)o;
 
@@ -261,7 +261,7 @@ JsProxy_ass_subscript(PyObject* o, PyObject* pyidx, PyObject* pyvalue)
 #define GET_JSREF(x) (((JsProxy*)x)->js)
 
 static PyObject*
-JsProxy_Dir(PyObject* self)
+JsProxy_Dir(PyObject* self, PyObject* _args)
 {
   bool success = false;
   PyObject* object__dir__ = NULL;
@@ -317,7 +317,7 @@ JsProxy_Bool(PyObject* o)
 }
 
 static PyObject*
-JsProxy_Await(JsProxy* self)
+JsProxy_Await(JsProxy* self, PyObject* _args)
 {
   // Guards
   if (self->awaited) {


### PR DESCRIPTION
According to the python documentation [METH_NOARGS](https://docs.python.org/3/c-api/structures.html#METH_NOARGS) functions should be of type [PyCFunction](https://docs.python.org/3/c-api/structures.html#c.PyCFunction). This means they should have function signature:
```C
PyObject *PyCFunction(PyObject *self, PyObject *args);
```
The second argument `args` will always be `NULL`. I think the gcc calling convention makes it okay to cast a one argument function to a two argument function and then call it as if it had two arguments and I assume that we are using the gcc calling convention, but I think it's in any case preferable not to do that.