### PR TITLE
Add setInterruptBuffer to public API, update changelog and docs

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -85,7 +85,8 @@ some completion issues (see
 [#821](https://github.com/iodide-project/pyodide/issues/821) and
 [#1160](https://github.com/iodide-project/pyodide/issues/821)
 
-## Version 0.16.1 *December 25, 2020*
+## Version 0.16.1 
+*December 25, 2020*
 
 Note: due to a CI deployment issue the 0.16.0 release was skipped and replaced
 by 0.16.1 with identical contents.
@@ -198,7 +199,8 @@ Meyer, Jay Harris, jcaesar, Joseph D. Long, Matthew Turk, Michael Greminger,
 Michael Panchenko, mojighahar, Nicolas Ollinger, Ram Rachum, Roman Yurchak,
 Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
-## Version 0.15.0 *May 19, 2020*
+## Version 0.15.0 
+*May 19, 2020*
 
 - Upgrades pyodide to CPython 3.7.4.
 - micropip no longer uses a CORS proxy to install pure Python packages from
@@ -219,7 +221,8 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
   documentation <partial-builds>` for more details.
 - New packages: future, autograd
 
-## Version 0.14.3 *Dec 11, 2019*
+## Version 0.14.3 
+*Dec 11, 2019*
 
 - Convert JavaScript numbers containing integers, e.g. `3.0`, to a real Python
   long (e.g. `3`).
@@ -227,16 +230,19 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 - Adds a Javascript-side auto completion function for Iodide that uses jedi.
 - New packages: nltk, jeudi, statsmodels, regex, cytoolz, xlrd, uncertainties
 
-## Version 0.14.0 *Aug 14, 2019*
+## Version 0.14.0 
+*Aug 14, 2019*
 
 - The built-in `sqlite` and `bz2` modules of Python are now enabled.
 - Adds support for auto-completion based on jedi when used in iodide
 
-## Version 0.13.0 *May 31, 2019*
+## Version 0.13.0 
+*May 31, 2019*
 
 - Tagged versions of Pyodide are now deployed to Netlify.
 
-## Version 0.12.0 *May 3, 2019*
+## Version 0.12.0 
+*May 3, 2019*
 
 **User improvements:**
 
@@ -275,7 +281,8 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
 - New packages: `jinja2`, `MarkupSafe`
 
-## Version 0.10.0 *Mar 21, 2019*
+## Version 0.10.0 
+*Mar 21, 2019*
 
 **User improvements:**
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -45,45 +45,46 @@
   [#1155](https://github.com/iodide-project/pyodide/pull/1155)
 - Flexible jsimports: it now possible to add custom Python "packages" backed by
   Javascript code, like the js package.  The js package is now implemented
-using this system. [#1146](https://github.com/iodide-project/pyodide/pull/1146)
+  using this system. 
+  [#1146](https://github.com/iodide-project/pyodide/pull/1146)
 - Added the `pyodide.setInterruptBuffer` API. This can be used to set a
   `SharedArrayBuffer` to be the keyboard interupt buffer. If Pyodide is running
-on a webworker, the main thread can signal to the webworker that it should
-raise a `KeyboardInterrupt` by writing to the interrupt buffer.
-[#1148](https://github.com/iodide-project/pyodide/pull/1148) and
-[#1173](https://github.com/iodide-project/pyodide/pull/1173)
+  on a webworker, the main thread can signal to the webworker that it should
+  raise a `KeyboardInterrupt` by writing to the interrupt buffer.
+  [#1148](https://github.com/iodide-project/pyodide/pull/1148) and
+  [#1173](https://github.com/iodide-project/pyodide/pull/1173)
 
 ### Fixed
 - getattr and dir on JsProxy now report consistent results and include all
   names defined on the Python dictionary backing JsProxy.
-[#1017](https://github.com/iodide-project/pyodide/pull/1017)
+  [#1017](https://github.com/iodide-project/pyodide/pull/1017)
 - `JsProxy.__bool__` now produces more consistent results: both `bool(window)`
   and `bool(zero-arg-callback)` were `False` but now are `True`. Conversely,
-`bool(empty_js_set)` and `bool(empty_js_map)` were `True` but now are `False`.
-[#1061](https://github.com/iodide-project/pyodide/pull/1061)
+  `bool(empty_js_set)` and `bool(empty_js_map)` were `True` but now are `False`.
+  [#1061](https://github.com/iodide-project/pyodide/pull/1061)
 - When calling a javascript function from Python without keyword arguments,
   Pyodide no longer passes a `PyProxy`-wrapped `NULL` pointer as the last
-argument.  [#1033](https://github.com/iodide-project/pyodide/pull/1033)
+  argument.  [#1033](https://github.com/iodide-project/pyodide/pull/1033)
 - JsBoundMethod is now a subclass of JsProxy, which fixes nested attribute
   access and various other strange bugs.
-[#1124](https://github.com/iodide-project/pyodide/pull/1124)
+  [#1124](https://github.com/iodide-project/pyodide/pull/1124)
 - In console.html: sync behavior, full stdout/stderr support, clean namespace,
   bigger font, correct result representation, clean traceback
-[#1125](https://github.com/iodide-project/pyodide/pull/1125) and
-[#1141](https://github.com/iodide-project/pyodide/pull/1141)
+  [#1125](https://github.com/iodide-project/pyodide/pull/1125) and
+  [#1141](https://github.com/iodide-project/pyodide/pull/1141)
 - Javascript functions imported like `from js import fetch` no longer trigger
   "invalid invocation" errors (issue
-[#461](https://github.com/iodide-project/pyodide/issues/461)) and
-`js.fetch("some_url")` also works now (issue
-[#768](https://github.com/iodide-project/pyodide/issues/461)).
-[#1126](https://github.com/iodide-project/pyodide/pull/1126)
+  [#461](https://github.com/iodide-project/pyodide/issues/461)) and
+  `js.fetch("some_url")` also works now (issue
+  [#768](https://github.com/iodide-project/pyodide/issues/461)).
+  [#1126](https://github.com/iodide-project/pyodide/pull/1126)
 - Javascript bound method calls now work correctly with keyword arguments.
   [#1138](https://github.com/iodide-project/pyodide/pull/1138)
 - Switched from ̀Jedi` to `rlcompleter` for completion in
   `pyodide.console.InteractiveConsole` and so in `console.html`. This fixes
-some completion issues (see
-[#821](https://github.com/iodide-project/pyodide/issues/821) and
-[#1160](https://github.com/iodide-project/pyodide/issues/821)
+  some completion issues (see
+  [#821](https://github.com/iodide-project/pyodide/issues/821) and
+  [#1160](https://github.com/iodide-project/pyodide/issues/821)
 
 ## Version 0.16.1 
 *December 25, 2020*
@@ -119,7 +120,7 @@ by 0.16.1 with identical contents.
   [#708](https://github.com/iodide-project/pyodide/pull/708)
 - Javascript exceptions can now be raised and caught in Python. They are
   wrapped in pyodide.JsException.
-[#891](https://github.com/iodide-project/pyodide/pull/891)
+  [#891](https://github.com/iodide-project/pyodide/pull/891)
 
 ### pyodide-py package and micropip
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -157,10 +157,10 @@ by 0.16.1 with identical contents.
   [#851](https://github.com/iodide-project/pyodide/pull/851)
 - Pyodide deployment URL can now be specified with the `PYODIDE_BASE_URL`
   environment variable during build. The `pyodide_dev.js` is no longer
-  distributed.  To get an equivalent behavior with `pyodide.js`, set, 
+  distributed.  To get an equivalent behavior with `pyodide.js`, set
   ```javascript
-  window.languagePluginUrl = './'; 
-  ``` 
+  window.languagePluginUrl = './';
+  ```
   before loading it.
   [#855](https://github.com/iodide-project/pyodide/pull/855)
 - Build runtime C libraries (e.g. libxml) via package build system with correct
@@ -213,9 +213,10 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 - Adds support for installing pure Python wheels from arbitrary URLs with
   micropip.
 - The CDN URL for pyodide changed to
-  https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js It now supports
-  versioning and should provide faster downloads. The latest release can be
-  accessed via `https://pyodide-cdn2.iodide.io/latest/full/`
+  https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js 
+  It now supports versioning and should provide faster downloads. 
+  The latest release can be accessed via 
+  https://pyodide-cdn2.iodide.io/latest/full/
 - Adds `messageCallback` and `errorCallback` to {ref}`pyodide.loadPackage
   <js_api_pyodide_loadPackage>`.
 - Reduces the initial memory footprint (`TOTAL_MEMORY`) from 1 GiB to 5 MiB.

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -42,6 +42,7 @@
   of Pyodide REPL in webpages (used in console.html) [#1125](https://github.com/iodide-project/pyodide/pull/1125) and [#1155](https://github.com/iodide-project/pyodide/pull/1155)
 - Flexible jsimports: it now possible to add custom Python "packages" backed by Javascript code, like the js package.
   The js package is now implemented using this system. [#1146](https://github.com/iodide-project/pyodide/pull/1146)
+- Added the `pyodide.setInterruptBuffer` API. This can be used to set a `SharedArrayBuffer` to be the keyboard interupt buffer. If Pyodide is running on a webworker, the main thread can signal to the webworker that it should raise a `KeyboardInterrupt` by writing to the interrupt buffer.
 
 ### Fixed
 - getattr and dir on JsProxy now report consistent results and include all names defined on the Python dictionary backing JsProxy. [#1017](https://github.com/iodide-project/pyodide/pull/1017)

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -86,7 +86,7 @@
   [#821](https://github.com/iodide-project/pyodide/issues/821) and
   [#1160](https://github.com/iodide-project/pyodide/issues/821)
 
-## Version 0.16.1 
+## Version 0.16.1
 *December 25, 2020*
 
 Note: due to a CI deployment issue the 0.16.0 release was skipped and replaced

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -64,7 +64,7 @@
   [#1061](https://github.com/iodide-project/pyodide/pull/1061)
 - When calling a javascript function from Python without keyword arguments,
   Pyodide no longer passes a `PyProxy`-wrapped `NULL` pointer as the last
-  argument.  [#1033](https://github.com/iodide-project/pyodide/pull/1033)
+  argument. [#1033](https://github.com/iodide-project/pyodide/pull/1033)
 - JsBoundMethod is now a subclass of JsProxy, which fixes nested attribute
   access and various other strange bugs.
   [#1124](https://github.com/iodide-project/pyodide/pull/1124)
@@ -103,7 +103,7 @@ by 0.16.1 with identical contents.
 
 - Pyodide includes CPython 3.8.2
   [#712](https://github.com/iodide-project/pyodide/pull/712)
-- ENH Patches for the threading module were removed in all packages.  Importing
+- ENH Patches for the threading module were removed in all packages. Importing
   the module, and a subset of functionality (e.g. locks) works, while starting
   a new thread will produce an exception, as expected.
   [#796](https://github.com/iodide-project/pyodide/pull/796). 
@@ -223,7 +223,7 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 - Reduces the initial memory footprint (`TOTAL_MEMORY`) from 1 GiB to 5 MiB.
   More memory will be allocated as needed.
 - When building from source, only a subset of packages can be built by setting
-  the `PYODIDE_PACKAGES` environment variable. See 
+  the `PYODIDE_PACKAGES` environment variable. See
   {ref}`partial builds documentation <partial-builds>` for more details.
 - New packages: future, autograd
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -1,5 +1,4 @@
-(changelog)=
-# Release notes
+(changelog)= # Release notes
 
 ## Version [Unreleased]
 ### Breaking changes
@@ -43,6 +42,7 @@
 - Flexible jsimports: it now possible to add custom Python "packages" backed by Javascript code, like the js package.
   The js package is now implemented using this system. [#1146](https://github.com/iodide-project/pyodide/pull/1146)
 - Added the `pyodide.setInterruptBuffer` API. This can be used to set a `SharedArrayBuffer` to be the keyboard interupt buffer. If Pyodide is running on a webworker, the main thread can signal to the webworker that it should raise a `KeyboardInterrupt` by writing to the interrupt buffer.
+[#1148](https://github.com/iodide-project/pyodide/pull/1148) and [#1173](https://github.com/iodide-project/pyodide/pull/1173)
 
 ### Fixed
 - getattr and dir on JsProxy now report consistent results and include all names defined on the Python dictionary backing JsProxy. [#1017](https://github.com/iodide-project/pyodide/pull/1017)
@@ -54,37 +54,40 @@
 - In console.html: sync behavior, full stdout/stderr support, clean namespace, bigger font, correct result representation, clean traceback [#1125](https://github.com/iodide-project/pyodide/pull/1125) and [#1141](https://github.com/iodide-project/pyodide/pull/1141)
 - Javascript functions imported like `from js import fetch` no longer trigger "invalid invocation" errors (issue [#461](https://github.com/iodide-project/pyodide/issues/461)) and `js.fetch("some_url")` also works now (issue [#768](https://github.com/iodide-project/pyodide/issues/461)).
 [#1126](https://github.com/iodide-project/pyodide/pull/1126)
-- Javascript bound method calls now work correctly with keyword arguments. [#1138](https://github.com/iodide-project/pyodide/pull/1138)
-- Switched from ̀Jedi` to `rlcompleter` for completion in `pyodide.console.InteractiveConsole` and so in `console.html`. This fixes some completion issues (see [#821](https://github.com/iodide-project/pyodide/issues/821) and [#1160](https://github.com/iodide-project/pyodide/issues/821)
+- Javascript bound method calls now work correctly with keyword arguments.
+  [#1138](https://github.com/iodide-project/pyodide/pull/1138)
+- Switched from ̀Jedi` to `rlcompleter` for completion in
+  `pyodide.console.InteractiveConsole` and so in `console.html`. This fixes
+some completion issues (see
+[#821](https://github.com/iodide-project/pyodide/issues/821) and
+[#1160](https://github.com/iodide-project/pyodide/issues/821)
 
-## Version 0.16.1
-*December 25, 2020*
+## Version 0.16.1 *December 25, 2020*
 
 Note: due to a CI deployment issue the 0.16.0 release was skipped and replaced
 by 0.16.1 with identical contents.
 
 - Pyodide files are distributed by [JsDelivr](https://www.jsdelivr.com/),
-  `https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js`
-  The previous CDN `pyodide-cdn2.iodide.io` still works and there
-  are no plans for deprecating it. However please use
-  JsDelivr as a more sustainable solution, including for earlier pyodide
-  versions.
+  `https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js` The previous CDN
+`pyodide-cdn2.iodide.io` still works and there are no plans for deprecating it.
+However please use JsDelivr as a more sustainable solution, including for
+earlier pyodide versions.
 
 ### Python and the standard library
 
 - Pyodide includes CPython 3.8.2
   [#712](https://github.com/iodide-project/pyodide/pull/712)
-- ENH Patches for the threading module were removed in all packages.
-  Importing the module, and a subset of functionality (e.g. locks) works,
-  while starting a new thread will produce an exception, as expected.
-  [#796](https://github.com/iodide-project/pyodide/pull/796). See
-  [#237](https://github.com/iodide-project/pyodide/pull/237) for the current
-  status of the threading support.
+- ENH Patches for the threading module were removed in all packages.  Importing
+  the module, and a subset of functionality (e.g. locks) works, while starting
+a new thread will produce an exception, as expected.
+[#796](https://github.com/iodide-project/pyodide/pull/796). See
+[#237](https://github.com/iodide-project/pyodide/pull/237) for the current
+status of the threading support.
 - ENH The multiprocessing module is now included, and will not fail at import,
-  thus avoiding the necessity to patch included packages. Starting a new process
-  will produce an exception due to the limitation of the WebAssembly VM  with
-  the following message: `Resource temporarily unavailable`
-  [#796](https://github.com/iodide-project/pyodide/pull/796).
+  thus avoiding the necessity to patch included packages. Starting a new
+process will produce an exception due to the limitation of the WebAssembly VM
+with the following message: `Resource temporarily unavailable`
+[#796](https://github.com/iodide-project/pyodide/pull/796).
 
 ### Python / JS type conversions
 
@@ -92,20 +95,20 @@ by 0.16.1 with identical contents.
   [#708](https://github.com/iodide-project/pyodide/pull/708)
 - Javascript exceptions can now be raised and caught in Python. They are
   wrapped in pyodide.JsException.
-  [#891](https://github.com/iodide-project/pyodide/pull/891)
+[#891](https://github.com/iodide-project/pyodide/pull/891)
 
 ### pyodide-py package and micropip
 
 - The `pyodide.py` file was transformed to a pyodide-py package. The imports
   remain the same so this change is transparent to the users
-  [#909](https://github.com/iodide-project/pyodide/pull/909).
+[#909](https://github.com/iodide-project/pyodide/pull/909).
 - FIX Get last version from PyPi when installing a module via micropip
   [#846](https://github.com/iodide-project/pyodide/pull/846).
 - Suppress REPL results returned by `pyodide.eval_code` by adding a semicolon
   [#876](https://github.com/iodide-project/pyodide/pull/876).
-- Enable monkey patching of `eval_code` and `find_imports` to customize behavior
-  of `runPython` and `runPythonAsync`
-  [#941](https://github.com/iodide-project/pyodide/pull/941).
+- Enable monkey patching of `eval_code` and `find_imports` to customize
+  behavior of `runPython` and `runPythonAsync`
+[#941](https://github.com/iodide-project/pyodide/pull/941).
 
 ### Build system
 
@@ -113,28 +116,25 @@ by 0.16.1 with identical contents.
   [#815](https://github.com/iodide-project/pyodide/pull/815)
 - Pre-built docker images are now available as
   [`iodide-project/pyodide`](https://hub.docker.com/r/iodide/pyodide)
-  [#787](https://github.com/iodide-project/pyodide/pull/787)
+[#787](https://github.com/iodide-project/pyodide/pull/787)
 - Host python is no longer compiled, reducing compilation time. This also
   implies that python 3.8 is now required to build pyodide. It can for instance
-  be installed with conda.
-  [#830](https://github.com/iodide-project/pyodide/pull/830)
+be installed with conda.
+[#830](https://github.com/iodide-project/pyodide/pull/830)
 - FIX Infer package tarball directory from source url
   [#687](https://github.com/iodide-project/pyodide/pull/687)
-- Updated to emscripten 1.38.44 and binaryen v86
-  (see related [commits](https://github.com/iodide-project/pyodide/search?q=emscripten&type=commits))
+- Updated to emscripten 1.38.44 and binaryen v86 (see related
+  [commits](https://github.com/iodide-project/pyodide/search?q=emscripten&type=commits))
 - Updated default `--ldflags` argument to `pyodide_build` scripts to equal what
   pyodide actually uses.
-  [#817](https://github.com/iodide-project/pyodide/pull/480)
+[#817](https://github.com/iodide-project/pyodide/pull/480)
 - Replace C lz4 implementation with the (upstream) Javascript implementation.
   [#851](https://github.com/iodide-project/pyodide/pull/851)
 - Pyodide deployment URL can now be specified with the `PYODIDE_BASE_URL`
-  environment variable during build. The `pyodide_dev.js` is no longer distributed.
-  To get an equivalent behavior with `pyodide.js`, set,
-  ```
-  window.languagePluginUrl = './';
-  ```
-  before loading it.
-  [#855](https://github.com/iodide-project/pyodide/pull/855)
+  environment variable during build. The `pyodide_dev.js` is no longer
+distributed.  To get an equivalent behavior with `pyodide.js`, set, ```
+window.languagePluginUrl = './'; ``` before loading it.
+[#855](https://github.com/iodide-project/pyodide/pull/855)
 - Build runtime C libraries (e.g. libxml) via package build system with correct
   dependency resolution
   [#927](https://github.com/iodide-project/pyodide/pull/927)

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -80,7 +80,7 @@
   [#1126](https://github.com/iodide-project/pyodide/pull/1126)
 - Javascript bound method calls now work correctly with keyword arguments.
   [#1138](https://github.com/iodide-project/pyodide/pull/1138)
-- Switched from ̀Jedi` to `rlcompleter` for completion in
+- Switched from ̀Jedi to rlcompleter for completion in
   `pyodide.console.InteractiveConsole` and so in `console.html`. This fixes
   some completion issues (see
   [#821](https://github.com/iodide-project/pyodide/issues/821) and
@@ -93,10 +93,11 @@ Note: due to a CI deployment issue the 0.16.0 release was skipped and replaced
 by 0.16.1 with identical contents.
 
 - Pyodide files are distributed by [JsDelivr](https://www.jsdelivr.com/),
-  `https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js` The previous CDN
-  `pyodide-cdn2.iodide.io` still works and there are no plans for deprecating it.
-  However please use JsDelivr as a more sustainable solution, including for
-  earlier pyodide versions.
+  `https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js`
+  The previous CDN `pyodide-cdn2.iodide.io` still works and there
+  are no plans for deprecating it. However please use
+  JsDelivr as a more sustainable solution, including for earlier pyodide
+  versions.
 
 ### Python and the standard library
 
@@ -157,7 +158,7 @@ by 0.16.1 with identical contents.
   [#851](https://github.com/iodide-project/pyodide/pull/851)
 - Pyodide deployment URL can now be specified with the `PYODIDE_BASE_URL`
   environment variable during build. The `pyodide_dev.js` is no longer
-  distributed.  To get an equivalent behavior with `pyodide.js`, set
+  distributed. To get an equivalent behavior with `pyodide.js`, set
   ```javascript
   window.languagePluginUrl = './';
   ```
@@ -217,13 +218,13 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
   It now supports versioning and should provide faster downloads. 
   The latest release can be accessed via 
   https://pyodide-cdn2.iodide.io/latest/full/
-- Adds `messageCallback` and `errorCallback` to {ref}`pyodide.loadPackage
-  <js_api_pyodide_loadPackage>`.
+- Adds `messageCallback` and `errorCallback` to 
+  {ref}`pyodide.loadPackage <js_api_pyodide_loadPackage>`.
 - Reduces the initial memory footprint (`TOTAL_MEMORY`) from 1 GiB to 5 MiB.
   More memory will be allocated as needed.
 - When building from source, only a subset of packages can be built by setting
-  the `PYODIDE_PACKAGES` environment variable. See {ref}`partial builds
-  documentation <partial-builds>` for more details.
+  the `PYODIDE_PACKAGES` environment variable. See 
+  {ref}`partial builds documentation <partial-builds>` for more details.
 - New packages: future, autograd
 
 ## Version 0.14.3

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -1,4 +1,5 @@
-(changelog)= # Release notes
+(changelog)= 
+# Release notes
 
 ## Version [Unreleased]
 ### Breaking changes
@@ -29,7 +30,8 @@
   automatically logged to the console.
 
 ### Added
-- `micropip` now supports installing wheels from relative urls. [#872](https://github.com/iodide-project/pyodide/pull/872)
+- `micropip` now supports installing wheels from relative urls. 
+  [#872](https://github.com/iodide-project/pyodide/pull/872)
 - uglifyjs and lessc no longer need to be installed in the system during build
   [#878](https://github.com/iodide-project/pyodide/pull/878).
 - Reduce the size of the core pyodide package
@@ -38,21 +40,42 @@
 - `eval_code` now accepts separate `globals` and `locals` parameters.
   [#1083](https://github.com/iodide-project/pyodide/pull/1083)
 - An InteractiveConsole with completion support to ease the integration
-  of Pyodide REPL in webpages (used in console.html) [#1125](https://github.com/iodide-project/pyodide/pull/1125) and [#1155](https://github.com/iodide-project/pyodide/pull/1155)
-- Flexible jsimports: it now possible to add custom Python "packages" backed by Javascript code, like the js package.
-  The js package is now implemented using this system. [#1146](https://github.com/iodide-project/pyodide/pull/1146)
-- Added the `pyodide.setInterruptBuffer` API. This can be used to set a `SharedArrayBuffer` to be the keyboard interupt buffer. If Pyodide is running on a webworker, the main thread can signal to the webworker that it should raise a `KeyboardInterrupt` by writing to the interrupt buffer.
-[#1148](https://github.com/iodide-project/pyodide/pull/1148) and [#1173](https://github.com/iodide-project/pyodide/pull/1173)
+  of Pyodide REPL in webpages (used in console.html) 
+  [#1125](https://github.com/iodide-project/pyodide/pull/1125) and 
+  [#1155](https://github.com/iodide-project/pyodide/pull/1155)
+- Flexible jsimports: it now possible to add custom Python "packages" backed by
+  Javascript code, like the js package.  The js package is now implemented
+using this system. [#1146](https://github.com/iodide-project/pyodide/pull/1146)
+- Added the `pyodide.setInterruptBuffer` API. This can be used to set a
+  `SharedArrayBuffer` to be the keyboard interupt buffer. If Pyodide is running
+on a webworker, the main thread can signal to the webworker that it should
+raise a `KeyboardInterrupt` by writing to the interrupt buffer.
+[#1148](https://github.com/iodide-project/pyodide/pull/1148) and
+[#1173](https://github.com/iodide-project/pyodide/pull/1173)
 
 ### Fixed
-- getattr and dir on JsProxy now report consistent results and include all names defined on the Python dictionary backing JsProxy. [#1017](https://github.com/iodide-project/pyodide/pull/1017)
-- `JsProxy.__bool__` now produces more consistent results: both `bool(window)` and `bool(zero-arg-callback)` were `False` but now are `True`. Conversely, `bool(empty_js_set)` and `bool(empty_js_map)` were `True` but now are `False`. [#1061](https://github.com/iodide-project/pyodide/pull/1061)
-- When calling a javascript function from Python without keyword arguments, Pyodide no longer passes a `PyProxy`-wrapped `NULL` pointer as the last argument.
-[#1033](https://github.com/iodide-project/pyodide/pull/1033)
-- JsBoundMethod is now a subclass of JsProxy, which fixes nested attribute access and various other strange bugs.
-  [#1124](https://github.com/iodide-project/pyodide/pull/1124)
-- In console.html: sync behavior, full stdout/stderr support, clean namespace, bigger font, correct result representation, clean traceback [#1125](https://github.com/iodide-project/pyodide/pull/1125) and [#1141](https://github.com/iodide-project/pyodide/pull/1141)
-- Javascript functions imported like `from js import fetch` no longer trigger "invalid invocation" errors (issue [#461](https://github.com/iodide-project/pyodide/issues/461)) and `js.fetch("some_url")` also works now (issue [#768](https://github.com/iodide-project/pyodide/issues/461)).
+- getattr and dir on JsProxy now report consistent results and include all
+  names defined on the Python dictionary backing JsProxy.
+[#1017](https://github.com/iodide-project/pyodide/pull/1017)
+- `JsProxy.__bool__` now produces more consistent results: both `bool(window)`
+  and `bool(zero-arg-callback)` were `False` but now are `True`. Conversely,
+`bool(empty_js_set)` and `bool(empty_js_map)` were `True` but now are `False`.
+[#1061](https://github.com/iodide-project/pyodide/pull/1061)
+- When calling a javascript function from Python without keyword arguments,
+  Pyodide no longer passes a `PyProxy`-wrapped `NULL` pointer as the last
+argument.  [#1033](https://github.com/iodide-project/pyodide/pull/1033)
+- JsBoundMethod is now a subclass of JsProxy, which fixes nested attribute
+  access and various other strange bugs.
+[#1124](https://github.com/iodide-project/pyodide/pull/1124)
+- In console.html: sync behavior, full stdout/stderr support, clean namespace,
+  bigger font, correct result representation, clean traceback
+[#1125](https://github.com/iodide-project/pyodide/pull/1125) and
+[#1141](https://github.com/iodide-project/pyodide/pull/1141)
+- Javascript functions imported like `from js import fetch` no longer trigger
+  "invalid invocation" errors (issue
+[#461](https://github.com/iodide-project/pyodide/issues/461)) and
+`js.fetch("some_url")` also works now (issue
+[#768](https://github.com/iodide-project/pyodide/issues/461)).
 [#1126](https://github.com/iodide-project/pyodide/pull/1126)
 - Javascript bound method calls now work correctly with keyword arguments.
   [#1138](https://github.com/iodide-project/pyodide/pull/1138)
@@ -79,10 +102,10 @@ earlier pyodide versions.
   [#712](https://github.com/iodide-project/pyodide/pull/712)
 - ENH Patches for the threading module were removed in all packages.  Importing
   the module, and a subset of functionality (e.g. locks) works, while starting
-a new thread will produce an exception, as expected.
-[#796](https://github.com/iodide-project/pyodide/pull/796). See
-[#237](https://github.com/iodide-project/pyodide/pull/237) for the current
-status of the threading support.
+  a new thread will produce an exception, as expected.
+  [#796](https://github.com/iodide-project/pyodide/pull/796). 
+  See [#237](https://github.com/iodide-project/pyodide/pull/237) for the current
+  status of the threading support.
 - ENH The multiprocessing module is now included, and will not fail at import,
   thus avoiding the necessity to patch included packages. Starting a new
 process will produce an exception due to the limitation of the WebAssembly VM
@@ -101,14 +124,14 @@ with the following message: `Resource temporarily unavailable`
 
 - The `pyodide.py` file was transformed to a pyodide-py package. The imports
   remain the same so this change is transparent to the users
-[#909](https://github.com/iodide-project/pyodide/pull/909).
+  [#909](https://github.com/iodide-project/pyodide/pull/909).
 - FIX Get last version from PyPi when installing a module via micropip
   [#846](https://github.com/iodide-project/pyodide/pull/846).
 - Suppress REPL results returned by `pyodide.eval_code` by adding a semicolon
   [#876](https://github.com/iodide-project/pyodide/pull/876).
 - Enable monkey patching of `eval_code` and `find_imports` to customize
   behavior of `runPython` and `runPythonAsync`
-[#941](https://github.com/iodide-project/pyodide/pull/941).
+  [#941](https://github.com/iodide-project/pyodide/pull/941).
 
 ### Build system
 
@@ -116,25 +139,25 @@ with the following message: `Resource temporarily unavailable`
   [#815](https://github.com/iodide-project/pyodide/pull/815)
 - Pre-built docker images are now available as
   [`iodide-project/pyodide`](https://hub.docker.com/r/iodide/pyodide)
-[#787](https://github.com/iodide-project/pyodide/pull/787)
+  [#787](https://github.com/iodide-project/pyodide/pull/787)
 - Host python is no longer compiled, reducing compilation time. This also
   implies that python 3.8 is now required to build pyodide. It can for instance
-be installed with conda.
-[#830](https://github.com/iodide-project/pyodide/pull/830)
+  be installed with conda.
+  [#830](https://github.com/iodide-project/pyodide/pull/830)
 - FIX Infer package tarball directory from source url
   [#687](https://github.com/iodide-project/pyodide/pull/687)
 - Updated to emscripten 1.38.44 and binaryen v86 (see related
   [commits](https://github.com/iodide-project/pyodide/search?q=emscripten&type=commits))
 - Updated default `--ldflags` argument to `pyodide_build` scripts to equal what
   pyodide actually uses.
-[#817](https://github.com/iodide-project/pyodide/pull/480)
+  [#817](https://github.com/iodide-project/pyodide/pull/480)
 - Replace C lz4 implementation with the (upstream) Javascript implementation.
   [#851](https://github.com/iodide-project/pyodide/pull/851)
 - Pyodide deployment URL can now be specified with the `PYODIDE_BASE_URL`
   environment variable during build. The `pyodide_dev.js` is no longer
-distributed.  To get an equivalent behavior with `pyodide.js`, set, ```
-window.languagePluginUrl = './'; ``` before loading it.
-[#855](https://github.com/iodide-project/pyodide/pull/855)
+  distributed.  To get an equivalent behavior with `pyodide.js`, set, ```
+  window.languagePluginUrl = './'; ``` before loading it.
+  [#855](https://github.com/iodide-project/pyodide/pull/855)
 - Build runtime C libraries (e.g. libxml) via package build system with correct
   dependency resolution
   [#927](https://github.com/iodide-project/pyodide/pull/927)
@@ -143,9 +166,9 @@ window.languagePluginUrl = './'; ``` before loading it.
 
 ### Other improvements
 
-- Modifiy MEMFS timestamp handling to support better caching. This in particular allows to
-  import newly created python modules without invalidating import caches
-  [#893](https://github.com/iodide-project/pyodide/pull/893)
+- Modifiy MEMFS timestamp handling to support better caching. This in
+  particular allows to import newly created python modules without invalidating
+  import caches [#893](https://github.com/iodide-project/pyodide/pull/893)
 
 ### Packages
 - New packages: freesasa, lxml, python-sat, traits, astropy, pillow,
@@ -175,29 +198,28 @@ Meyer, Jay Harris, jcaesar, Joseph D. Long, Matthew Turk, Michael Greminger,
 Michael Panchenko, mojighahar, Nicolas Ollinger, Ram Rachum, Roman Yurchak,
 Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
-## Version 0.15.0
-*May 19, 2020*
+## Version 0.15.0 *May 19, 2020*
 
 - Upgrades pyodide to CPython 3.7.4.
 - micropip no longer uses a CORS proxy to install pure Python packages from
   PyPi. Packages are now installed from PyPi directly.
 - micropip can now be used from web workers.
-- Adds support for installing pure Python wheels from arbitrary URLs with micropip.
+- Adds support for installing pure Python wheels from arbitrary URLs with
+  micropip.
 - The CDN URL for pyodide changed to
-  https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js
-  It now supports versioning and should provide faster downloads. The latest release
-  can be accessed via `https://pyodide-cdn2.iodide.io/latest/full/`
-- Adds `messageCallback` and `errorCallback` to
-  {ref}`pyodide.loadPackage <js_api_pyodide_loadPackage>`.
-- Reduces the initial memory footprint (`TOTAL_MEMORY`) from 1 GiB to 5 MiB. More
-  memory will be allocated as needed.
+  https://pyodide-cdn2.iodide.io/v0.15.0/full/pyodide.js It now supports
+  versioning and should provide faster downloads. The latest release can be
+  accessed via `https://pyodide-cdn2.iodide.io/latest/full/`
+- Adds `messageCallback` and `errorCallback` to {ref}`pyodide.loadPackage
+  <js_api_pyodide_loadPackage>`.
+- Reduces the initial memory footprint (`TOTAL_MEMORY`) from 1 GiB to 5 MiB.
+  More memory will be allocated as needed.
 - When building from source, only a subset of packages can be built by setting
-  the `PYODIDE_PACKAGES` environment variable. See
-  {ref}`partial builds documentation <partial-builds>` for more details.
+  the `PYODIDE_PACKAGES` environment variable. See {ref}`partial builds
+  documentation <partial-builds>` for more details.
 - New packages: future, autograd
 
-## Version 0.14.3
-*Dec 11, 2019*
+## Version 0.14.3 *Dec 11, 2019*
 
 - Convert JavaScript numbers containing integers, e.g. `3.0`, to a real Python
   long (e.g. `3`).
@@ -205,19 +227,16 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 - Adds a Javascript-side auto completion function for Iodide that uses jedi.
 - New packages: nltk, jeudi, statsmodels, regex, cytoolz, xlrd, uncertainties
 
-## Version 0.14.0
-*Aug 14, 2019*
+## Version 0.14.0 *Aug 14, 2019*
 
 - The built-in `sqlite` and `bz2` modules of Python are now enabled.
 - Adds support for auto-completion based on jedi when used in iodide
 
-## Version 0.13.0
-*May 31, 2019*
+## Version 0.13.0 *May 31, 2019*
 
 - Tagged versions of Pyodide are now deployed to Netlify.
 
-## Version 0.12.0
-*May 3, 2019*
+## Version 0.12.0 *May 3, 2019*
 
 **User improvements:**
 
@@ -232,13 +251,12 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
 - Calling `dir()` in Python on a JavaScript proxy now works.
 
-- Passing an `ArrayBuffer` from Javascript to Python now correctly creates
-  a `memoryview` object.
+- Passing an `ArrayBuffer` from Javascript to Python now correctly creates a
+  `memoryview` object.
 
 - Pyodide now works on Safari.
 
-## Version 0.11.0
-*Apr 12, 2019*
+## Version 0.11.0 *Apr 12, 2019*
 
 **User improvements:**
 
@@ -249,16 +267,15 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
 **Developer improvements:**
 
-- The `mkpkg` command will now select an appropriate archive to use, rather than
-  just using the first.
+- The `mkpkg` command will now select an appropriate archive to use, rather
+  than just using the first.
 
 - The included version of emscripten has been upgraded to 1.38.30 (plus a
   bugfix).
 
 - New packages: `jinja2`, `MarkupSafe`
 
-## Version 0.10.0
-*Mar 21, 2019*
+## Version 0.10.0 *Mar 21, 2019*
 
 **User improvements:**
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -1,4 +1,4 @@
-(changelog)= 
+(changelog)=
 # Release notes
 
 ## Version [Unreleased]
@@ -93,9 +93,9 @@ by 0.16.1 with identical contents.
 
 - Pyodide files are distributed by [JsDelivr](https://www.jsdelivr.com/),
   `https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js` The previous CDN
-`pyodide-cdn2.iodide.io` still works and there are no plans for deprecating it.
-However please use JsDelivr as a more sustainable solution, including for
-earlier pyodide versions.
+  `pyodide-cdn2.iodide.io` still works and there are no plans for deprecating it.
+  However please use JsDelivr as a more sustainable solution, including for
+  earlier pyodide versions.
 
 ### Python and the standard library
 
@@ -109,9 +109,9 @@ earlier pyodide versions.
   status of the threading support.
 - ENH The multiprocessing module is now included, and will not fail at import,
   thus avoiding the necessity to patch included packages. Starting a new
-process will produce an exception due to the limitation of the WebAssembly VM
-with the following message: `Resource temporarily unavailable`
-[#796](https://github.com/iodide-project/pyodide/pull/796).
+  process will produce an exception due to the limitation of the WebAssembly VM
+  with the following message: `Resource temporarily unavailable`
+  [#796](https://github.com/iodide-project/pyodide/pull/796).
 
 ### Python / JS type conversions
 
@@ -156,8 +156,11 @@ with the following message: `Resource temporarily unavailable`
   [#851](https://github.com/iodide-project/pyodide/pull/851)
 - Pyodide deployment URL can now be specified with the `PYODIDE_BASE_URL`
   environment variable during build. The `pyodide_dev.js` is no longer
-  distributed.  To get an equivalent behavior with `pyodide.js`, set, ```
-  window.languagePluginUrl = './'; ``` before loading it.
+  distributed.  To get an equivalent behavior with `pyodide.js`, set, 
+  ```javascript
+  window.languagePluginUrl = './'; 
+  ``` 
+  before loading it.
   [#855](https://github.com/iodide-project/pyodide/pull/855)
 - Build runtime C libraries (e.g. libxml) via package build system with correct
   dependency resolution
@@ -199,7 +202,7 @@ Meyer, Jay Harris, jcaesar, Joseph D. Long, Matthew Turk, Michael Greminger,
 Michael Panchenko, mojighahar, Nicolas Ollinger, Ram Rachum, Roman Yurchak,
 Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
-## Version 0.15.0 
+## Version 0.15.0
 *May 19, 2020*
 
 - Upgrades pyodide to CPython 3.7.4.
@@ -221,7 +224,7 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
   documentation <partial-builds>` for more details.
 - New packages: future, autograd
 
-## Version 0.14.3 
+## Version 0.14.3
 *Dec 11, 2019*
 
 - Convert JavaScript numbers containing integers, e.g. `3.0`, to a real Python
@@ -230,18 +233,18 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 - Adds a Javascript-side auto completion function for Iodide that uses jedi.
 - New packages: nltk, jeudi, statsmodels, regex, cytoolz, xlrd, uncertainties
 
-## Version 0.14.0 
+## Version 0.14.0
 *Aug 14, 2019*
 
 - The built-in `sqlite` and `bz2` modules of Python are now enabled.
 - Adds support for auto-completion based on jedi when used in iodide
 
-## Version 0.13.0 
+## Version 0.13.0
 *May 31, 2019*
 
 - Tagged versions of Pyodide are now deployed to Netlify.
 
-## Version 0.12.0 
+## Version 0.12.0
 *May 3, 2019*
 
 **User improvements:**
@@ -262,7 +265,8 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
 - Pyodide now works on Safari.
 
-## Version 0.11.0 *Apr 12, 2019*
+## Version 0.11.0
+*Apr 12, 2019*
 
 **User improvements:**
 
@@ -281,7 +285,7 @@ Sergio, Seungmin Kim, Shyam Saladi, smkm, Wei Ouyang
 
 - New packages: `jinja2`, `MarkupSafe`
 
-## Version 0.10.0 
+## Version 0.10.0
 *Mar 21, 2019*
 
 **User improvements:**

--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -41,6 +41,7 @@ Backward compatibility of the API is not guaranteed at this point.
 | **{ref}`js_api_pyodide_runPython`**      | Runs Python code from Javascript.                              |
 | **{ref}`pyodide.runPythonAsync(code, ...) <js_api_pyodide_runPythonAsync>`** | Runs Python code with automatic preloading of imports.         |
 | **{ref}`js_api_pyodide_version`**        | The pyodide version string.                                    |
+| **{ref}`pyodide.setInterruptBuffer(interruptBuffer) <js_api_pyodide_setInterruptBuffer>`** | Set the keyboard interrupt buffer                |
 
 
 ```{eval-rst}

--- a/docs/usage/js-api/pyodide.setInterruptBuffer.md
+++ b/docs/usage/js-api/pyodide.setInterruptBuffer.md
@@ -1,0 +1,12 @@
+(js_api_pyodide_setInterruptBuffer)=
+# pyodide.setInterruptBuffer(interruptBuffer)
+This is a low level API for handling keyboard interrupts.
+Sets the pyodide interrupt buffer to be `interruptBuffer`. If thereafter one sets `interruptBuffer[0] = 2;` (2 stands for SIGINT) this will cause Pyodide to raise a `KeyboardInterupt`. The value of `interruptBuffer[0]` will regularly be set back to zero.
+This is intended for use when Pyodide is running on a webworker. In this case, one should make `interruptBuffer` a `SharedArrayBuffer` shared with the main thread. If the user requests a keyboard interrupt from the main thread, then the main thread can set `interruptBuffer[0] = 2;` and this will signal the webworker to raise a KeyboardInterupt exception.
+
+
+**Parameters**
+
+| name               | type       | description                                          |
+|--------------------|------------|------------------------------------------------------|
+| *interruptBuffer*  | TypedArray | The SharedArrayBuffer to use as the interrupt buffer |

--- a/docs/usage/js-api/pyodide.setInterruptBuffer.md
+++ b/docs/usage/js-api/pyodide.setInterruptBuffer.md
@@ -1,12 +1,19 @@
-(js_api_pyodide_setInterruptBuffer)=
-# pyodide.setInterruptBuffer(interruptBuffer)
-This is a low level API for handling keyboard interrupts.
-Sets the pyodide interrupt buffer to be `interruptBuffer`. If thereafter one sets `interruptBuffer[0] = 2;` (2 stands for SIGINT) this will cause Pyodide to raise a `KeyboardInterupt`. The value of `interruptBuffer[0]` will regularly be set back to zero.
-This is intended for use when Pyodide is running on a webworker. In this case, one should make `interruptBuffer` a `SharedArrayBuffer` shared with the main thread. If the user requests a keyboard interrupt from the main thread, then the main thread can set `interruptBuffer[0] = 2;` and this will signal the webworker to raise a KeyboardInterupt exception.
+(js_api_pyodide_setInterruptBuffer)= #
+pyodide.setInterruptBuffer(interruptBuffer) This is a low level API for
+handling keyboard interrupts.  Sets the pyodide interrupt buffer to be
+`interruptBuffer`. If thereafter one sets `interruptBuffer[0] = 2;` (2 stands
+for SIGINT) this will cause Pyodide to raise a `KeyboardInterupt`. The value of
+`interruptBuffer[0]` will regularly be set back to zero.  This is intended for
+use when Pyodide is running on a webworker. In this case, one should make
+`interruptBuffer` a `SharedArrayBuffer` shared with the main thread. If the
+user requests a keyboard interrupt from the main thread, then the main thread
+can set `interruptBuffer[0] = 2;` and this will signal the webworker to raise a
+KeyboardInterupt exception.
 
 
 **Parameters**
 
-| name               | type       | description                                          |
+| name               | type       | description
+|
 |--------------------|------------|------------------------------------------------------|
 | *interruptBuffer*  | TypedArray | The SharedArrayBuffer to use as the interrupt buffer |

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -315,6 +315,7 @@ globalThis.languagePluginLoader = new Promise((resolve, reject) => {
     'version',
     'registerJsModule',
     'unregisterJsModule',
+    'setInterruptBuffer',
   ];
 
   function makePublicAPI(module, public_api) {


### PR DESCRIPTION
This minimally solves issue #676, though we may wish to wait to close it until we offer a more convenient webworker API.