### PR TITLE
Fix compile error from methnoargs-signatures branch

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -178,7 +178,7 @@ JsProxy_RichCompare(PyObject* a, PyObject* b, int op)
 }
 
 static PyObject*
-JsProxy_GetIter(PyObject* o, PyObject* _args)
+JsProxy_GetIter(PyObject* o)
 {
   JsProxy* self = (JsProxy*)o;
 
@@ -389,10 +389,6 @@ static PyNumberMethods JsProxy_NumberMethods = {
 };
 
 static PyMethodDef JsProxy_Methods[] = {
-  { "__iter__",
-    (PyCFunction)JsProxy_GetIter,
-    METH_NOARGS,
-    "Get an iterator over the object" },
   { "__await__", (PyCFunction)JsProxy_Await, METH_NOARGS, ""},
   { "__dir__",
     (PyCFunction)JsProxy_Dir,

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -317,7 +317,7 @@ JsProxy_Bool(PyObject* o)
 }
 
 static PyObject*
-JsProxy_Await(JsProxy* self, PyObject* _args)
+JsProxy_Await(JsProxy* self)
 {
   // Guards
   if (self->awaited) {
@@ -389,7 +389,6 @@ static PyNumberMethods JsProxy_NumberMethods = {
 };
 
 static PyMethodDef JsProxy_Methods[] = {
-  { "__await__", (PyCFunction)JsProxy_Await, METH_NOARGS, ""},
   { "__dir__",
     (PyCFunction)JsProxy_Dir,
     METH_NOARGS,

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -178,7 +178,7 @@ JsProxy_RichCompare(PyObject* a, PyObject* b, int op)
 }
 
 static PyObject*
-JsProxy_GetIter(PyObject* o)
+JsProxy_GetIter(PyObject* o, PyObject* _args)
 {
   JsProxy* self = (JsProxy*)o;
 
@@ -261,7 +261,7 @@ JsProxy_ass_subscript(PyObject* o, PyObject* pyidx, PyObject* pyvalue)
 #define GET_JSREF(x) (((JsProxy*)x)->js)
 
 static PyObject*
-JsProxy_Dir(PyObject* self)
+JsProxy_Dir(PyObject* self, PyObject* _args)
 {
   bool success = false;
   PyObject* object__dir__ = NULL;
@@ -317,7 +317,7 @@ JsProxy_Bool(PyObject* o)
 }
 
 static PyObject*
-JsProxy_Await(JsProxy* self)
+JsProxy_Await(JsProxy* self, PyObject* _args)
 {
   // Guards
   if (self->awaited) {


### PR DESCRIPTION
We were using `JsProxy_GetIter` as `.tp_iter` (signature is `unaryfunc` i.e., `PyObject* f(PyObject*)`) and to define a `METH_NOARGS`  `__iter__` method (signature should be `PyCFunction` i.e., `PyObject* f(PyObject*, PyObject*)`, second argument always `NULL`. In the standard library, iterables only define `tp_iter` and don't explicitly define an `__iter__` method so I just removed the `__iter__` method.

There is a similar issue with `.tp_as_async->am_await` which is a `unaryfunc` and `__await__` which is a `PyCFunction`. Again, it's nonstandard for builtin C types to define an `__await__` method so I removed it.