### PR TITLE
Fix uninitialized variables in PyProxy

### DIFF
--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -74,9 +74,9 @@ JsProxy_GetAttr(PyObject* self, PyObject* attr)
   PyErr_Clear();
 
   bool success = false;
-  JsRef idresult=0;
+  JsRef idresult = 0;
   // result:
-  PyObject* pyresult=NULL;
+  PyObject* pyresult = NULL;
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -74,9 +74,9 @@ JsProxy_GetAttr(PyObject* self, PyObject* attr)
   PyErr_Clear();
 
   bool success = false;
-  JsRef idresult;
+  JsRef idresult=0;
   // result:
-  PyObject* pyresult;
+  PyObject* pyresult=NULL;
 
   const char* key = PyUnicode_AsUTF8(attr);
   FAIL_IF_NULL(key);


### PR DESCRIPTION
A fix taken from https://github.com/iodide-project/pyodide/pull/1102