### PR TITLE
Rewrite JsProxy_IterNext

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -453,14 +453,13 @@ MAKE_OPERATOR(not_equal, !==);
 MAKE_OPERATOR(greater_than, >);
 MAKE_OPERATOR(greater_than_equal, >=);
 
-EM_JS_REF(JsRef, hiwire_next, (JsRef idobj), {
+EM_JS_REF(int, hiwire_next, (JsRef idobj, JsRef* result_ptr), {
   // clang-format off
-  if (idobj === Module.hiwire.UNDEFINED) {
-    return Module.hiwire.ERROR;
-  }
-
   let jsobj = Module.hiwire.get_value(idobj);
-  return Module.hiwire.new_value(jsobj.next());
+  let { done, value } = jsobj.next();
+  let result_id = Module.hiwire.new_value(value);
+  setValue(result_ptr, result_id, "i32");
+  return done;
   // clang-format on
 });
 
@@ -481,12 +480,6 @@ EM_JS_REF(JsRef, hiwire_get_iterator, (JsRef idobj), {
   return Module.hiwire.ERROR;
   // clang-format on
 })
-
-EM_JS_NUM(bool, hiwire_nonzero, (JsRef idobj), {
-  let jsobj = Module.hiwire.get_value(idobj);
-  // TODO: should this be !== 0?
-  return (jsobj != 0) ? 1 : 0;
-});
 
 EM_JS_NUM(bool, hiwire_is_typedarray, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -538,23 +538,17 @@ hiwire_greater_than_equal(JsRef ida, JsRef idb);
 /**
  * Calls the `next` function on an iterator.
  *
- * Returns: Js_ERROR if `next` function is undefined.
+ * Returns -1 if an error occurs.
+ * Stores "value" into argument "result", returns "done".
  */
-JsRef
-hiwire_next(JsRef idobj);
+int
+hiwire_next(JsRef idobj, JsRef* result);
 
 /**
  * Returns the iterator associated with the given object, if any.
  */
 JsRef
 hiwire_get_iterator(JsRef idobj);
-
-/**
- * Returns 1 if the value is non-zero.
- *
- */
-bool
-hiwire_nonzero(JsRef idobj);
 
 /**
  * Returns 1 if the value is a typedarray.

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -38,22 +38,19 @@ _js2python_number(double val)
 PyObject*
 _js2python_none()
 {
-  Py_INCREF(Py_None);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 PyObject*
 _js2python_true()
 {
-  Py_INCREF(Py_True);
-  return Py_True;
+  Py_RETURN_TRUE;
 }
 
 PyObject*
 _js2python_false()
 {
-  Py_INCREF(Py_False);
-  return Py_False;
+  Py_RETURN_FALSE;
 }
 
 PyObject*


### PR DESCRIPTION
I fixed a couple of minor things in the implementation of `JsProxy_IterNext`:
1. When `done` is true, we are supposed to raise `StopIteration` with the value given by the iterator. This is optional, but it is the correct way to handle generator functions that use both `yield` and `return`.
2. To test the boolean value `done`, it used a function called `hiwire_nonzero` which does the check using `x != 0`. This is weird: `false != 0` is `false`, but `false !== 0` is `true`. It's generally bad to use `!=`. 
3. Unnecessary allocations and conversions.