### PR TITLE
Change isPromise to accept nonstandard javascript awaitables

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -113,7 +113,7 @@ EM_JS(int, hiwire_init, (), {
   Module.hiwire.isPromise = function(obj)
   {
     // clang-format off
-    return Object.prototype.toString.call(obj) === "[object Promise]";
+    return (!!obj) && typeof obj.then === 'function';
     // clang-format on
   };
   return 0;


### PR DESCRIPTION
Any object that implements a `then` method is considered awaitable by the javascript language. For instance, #1170 makes certain `PyProxy` into nonstandard javascript awaitables. We should implement `__await__` on a `JsProxy` of any object with a `then` method.