### PR TITLE
Fix REPL completion

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -64,7 +64,8 @@
             prompt: ps1,
             completionEscape: false,
             completion: function(command, callback) {
-              callback(pyconsole.complete(command)[0]);
+              const completions = pyconsole.complete(command)[0];
+              callback(completions.deepCopyToJavascript());
             }
           }
         );


### PR DESCRIPTION
REPL completion in `console.html` has been accidentally broken by #1167 as reported by #1190.

This should resolves #1190.