### PR TITLE
Revert removal of xfailed scipy dependent tests

### DIFF
--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -22,7 +22,7 @@ source:
 
 build:
   cflags: -s USE_FREETYPE=1 -s USE_LIBPNG=1 -s USE_ZLIB=1
-  ldflags: ../../../../emsdk/emsdk/fastcomp/emscripten/cache/asmjs/libpng.bc
+  ldflags: -s USE_FREETYPE=1 -s USE_LIBPNG=1 -s USE_ZLIB=1
   replace-libs:
     - png16=png
   post: |

--- a/packages/matplotlib/meta.yaml
+++ b/packages/matplotlib/meta.yaml
@@ -22,7 +22,7 @@ source:
 
 build:
   cflags: -s USE_FREETYPE=1 -s USE_LIBPNG=1 -s USE_ZLIB=1
-  ldflags: -s USE_FREETYPE=1 -s USE_LIBPNG=1 -s USE_ZLIB=1
+  ldflags: ../../../../emsdk/emsdk/fastcomp/emscripten/cache/asmjs/libpng.bc
   replace-libs:
     - png16=png
   post: |

--- a/packages/pandas/test_pandas.py
+++ b/packages/pandas/test_pandas.py
@@ -35,11 +35,15 @@ def generate_largish_json(n_rows: int = 91746) -> Dict:
 
 
 def test_pandas(selenium, request):
+    if selenium.browser == "chrome":
+        request.applymarker(pytest.mark.xfail(run=False, reason="chrome not supported"))
     selenium.load_package("pandas")
     assert len(selenium.run("import pandas\ndir(pandas)")) == 142
 
 
 def test_extra_import(selenium, request):
+    if selenium.browser == "chrome":
+        request.applymarker(pytest.mark.xfail(run=False, reason="chrome not supported"))
 
     selenium.load_package("pandas")
     selenium.run("from pandas import Series, DataFrame, Panel")
@@ -47,6 +51,9 @@ def test_extra_import(selenium, request):
 
 def test_load_largish_file(selenium_standalone, request, httpserver):
     selenium = selenium_standalone
+
+    if selenium.browser == "chrome":
+        request.applymarker(pytest.mark.xfail(run=False, reason="chrome not supported"))
 
     selenium.load_package("pandas")
     selenium.load_package("matplotlib")

--- a/packages/scikit-learn/test_scikit-learn.py
+++ b/packages/scikit-learn/test_scikit-learn.py
@@ -3,6 +3,8 @@ import pytest
 
 def test_scikit_learn(selenium_standalone, request):
     selenium = selenium_standalone
+    if selenium.browser == "chrome":
+        request.applymarker(pytest.mark.xfail(run=False, reason="chrome not supported"))
     selenium.load_package("scikit-learn")
     assert (
         selenium.run(

--- a/packages/scipy/test_scipy.py
+++ b/packages/scipy/test_scipy.py
@@ -6,6 +6,9 @@ import pytest
 def test_scipy_linalg(selenium_standalone, request):
     selenium = selenium_standalone
 
+    if selenium.browser == "chrome":
+        request.applymarker(pytest.mark.xfail(run=False, reason="chrome not supported"))
+
     selenium.load_package("scipy")
     cmd = dedent(
         r"""

--- a/packages/test_common.py
+++ b/packages/test_common.py
@@ -26,7 +26,7 @@ def registered_packages_meta():
     }
 
 
-UNSUPPORTED_PACKAGES = {"chrome": [], "firefox": []}
+UNSUPPORTED_PACKAGES = {"chrome": ["pandas", "scipy", "scikit-learn"], "firefox": []}
 
 
 @pytest.mark.parametrize("name", registered_packages())
@@ -68,9 +68,34 @@ def test_import(name, selenium_standalone):
         ))
         """
     )
+
+    selenium_standalone.load_package(name)
+
+    # Make sure there are no additional .pyc file
+    assert (
+        selenium_standalone.run(
+            """
+        len(list(glob.glob(
+            '/lib/python3.8/site-packages/**/*.pyc',
+            recursive=True)
+        ))
+        """
+        )
+        == baseline_pyc
+    )
+
     loaded_packages = []
     for import_name in meta.get("test", {}).get("imports", []):
-        selenium_standalone.run_async("import %s" % import_name)
+
+        if name not in loaded_packages:
+            selenium_standalone.load_package(name)
+            loaded_packages.append(name)
+        try:
+            selenium_standalone.run("import %s" % import_name)
+        except Exception:
+            print(selenium_standalone.logs)
+            raise
+
         # Make sure that even after importing, there are no additional .pyc
         # files
         assert (


### PR DESCRIPTION
This reverts part of https://github.com/iodide-project/pyodide/pull/1102 related to,
 - the removal of xfailed tests using scipy. These tests actually work and used to work on master locally. However they have a tendency to fail in CI, possibly because they use too much memory. So maybe we should retry them after https://github.com/iodide-project/pyodide/issues/386 is resolved.
 - using separate calls `load_package` and `run` instead of `run_async`. Again the change made sense, but maybe this is what's increasing the frequency of timeouts.

So I'm merely reverting some of the non critical changes to the last known configuration hoping fix CI on master (https://github.com/iodide-project/pyodide/issues/1204). We can then later look into improving these points.