### PR TITLE
Remove debug statements from fix_emulate_pointers

### DIFF
--- a/emsdk/patches/fix_emscripten_dylink.patch
+++ b/emsdk/patches/fix_emscripten_dylink.patch
@@ -61,9 +61,6 @@ index c8af59d..7084ff7 100644
 +    // only ever called from javascript
 +    var dyncallInvokeMap=new Map();
 +#endif
-diff --git a/emsdk/upstream/emscripten/tools/__pycache__/shared.cpython-38.pyc b/emsdk/upstream/emscripten/tools/__pycache__/shared.cpython-38.pyc
-index 087e7fd..872c6f0 100644
-Binary files a/emsdk/upstream/emscripten/tools/__pycache__/shared.cpython-38.pyc and b/emsdk/upstream/emscripten/tools/__pycache__/shared.cpython-38.pyc differ
 diff --git a/emsdk/upstream/emscripten/tools/shared.py b/emsdk/upstream/emscripten/tools/shared.py
 index 74666ee..3d5657b 100644
 --- a/emsdk/upstream/emscripten/tools/shared.py

--- a/emsdk/patches/fix_emulate_pointers_dlsym.patch
+++ b/emsdk/patches/fix_emulate_pointers_dlsym.patch
@@ -74,11 +74,9 @@ index 9d232c9..60d3990 100644
 +                auto* export2_ = new Export;
 +                export2_->name = buffer;
 +                export2_->value = orig_name;
-+                printf("Orig_name %s\n",orig_name.str);
 +                export2_->kind = ExternalKind::Function;
 +                module->addExport(export2_);
 +                name = thunk;
-+                printf("Orig_name2 %s,%d\n",orig_name.str,exportCount);
 +            } else {
 +              name = iter->second;
 +            }

--- a/emsdk/patches/fix_emulate_pointers_dlsym.patch
+++ b/emsdk/patches/fix_emulate_pointers_dlsym.patch
@@ -2,7 +2,7 @@ diff --git a/emsdk/binary/src/passes/FuncCastEmulation.cpp b/src/passes/FuncCast
 index 9d232c9..60d3990 100644
 --- a/emsdk/binaryen/src/passes/FuncCastEmulation.cpp
 +++ b/emsdk/binaryen/src/passes/FuncCastEmulation.cpp
-@@ -170,20 +170,88 @@ struct FuncCastEmulation : public Pass {
+@@ -170,20 +170,86 @@ struct FuncCastEmulation : public Pass {
        std::stoul(runner->options.getArgumentOrDefault("max-func-params", "16"));
      // we just need the one ABI function type for all indirect calls
      Signature ABIType(Type(std::vector<Type>(numParams, Type::i64)), Type::i64);

--- a/emsdk/patches/fix_time.patch
+++ b/emsdk/patches/fix_time.patch
@@ -1,4 +1,4 @@
-diff --git a/upstream/emscripten/src/library.js b/upstream/emscripten/src/library.js.new
+diff --git a/upstream/emscripten/src/library.js b/upstream/emscripten/src/library.js
 index ea4cf27..6a692bd 100644
 --- a/emsdk/upstream/emscripten/src/library.js
 +++ b/emsdk/upstream/emscripten/src/library.js


### PR DESCRIPTION
Two `printf` statements in `fix_emulate_pointers_dlsym.patch` print a lot of junk to the console during compilation. I suspect they were added for debugging purposes. This PR removes them.