### PR TITLE
Simplify hiwire constants

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -6,6 +6,11 @@
 
 #include "hiwire.h"
 
+const JsRef Js_undefined = ((JsRef)(2));
+const JsRef Js_true = ((JsRef)(4));
+const JsRef Js_false = ((JsRef)(6));
+const JsRef Js_null = ((JsRef)(8));
+
 JsRef
 hiwire_bool(bool boolean)
 {

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -6,34 +6,15 @@
 
 #include "hiwire.h"
 
-JsRef
-hiwire_undefined()
-{
-  return Js_UNDEFINED;
-}
-
-JsRef
-hiwire_null()
-{
-  return Js_NULL;
-}
-
-JsRef
-hiwire_true()
-{
-  return Js_TRUE;
-}
-
-JsRef
-hiwire_false()
-{
-  return Js_FALSE;
-}
+JsRef Js_undefined = Js_UNDEFINED;
+JsRef Js_null = Js_NULL;
+JsRef Js_true = Js_TRUE;
+JsRef Js_false = Js_FALSE;
 
 JsRef
 hiwire_bool(bool boolean)
 {
-  return boolean ? hiwire_true() : hiwire_false();
+  return boolean ? Js_true : Js_false;
 }
 
 EM_JS(int, hiwire_init, (), {
@@ -52,10 +33,10 @@ EM_JS(int, hiwire_init, (), {
     counter : new Uint32Array([1])
   };
   Module.hiwire = {};
-  Module.hiwire.UNDEFINED = _hiwire_undefined();
-  Module.hiwire.JSNULL = _hiwire_null();
-  Module.hiwire.TRUE = _hiwire_true();
-  Module.hiwire.FALSE = _hiwire_false();
+  Module.hiwire.UNDEFINED = HEAP8[_Js_undefined];
+  Module.hiwire.JSNULL = HEAP8[_Js_null];
+  Module.hiwire.TRUE = HEAP8[_Js_true];
+  Module.hiwire.FALSE = HEAP8[_Js_false];
 
   _hiwire.objects.set(Module.hiwire.UNDEFINED, undefined);
   _hiwire.objects.set(Module.hiwire.JSNULL, null);

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -6,11 +6,6 @@
 
 #include "hiwire.h"
 
-JsRef Js_undefined = Js_UNDEFINED;
-JsRef Js_null = Js_NULL;
-JsRef Js_true = Js_TRUE;
-JsRef Js_false = Js_FALSE;
-
 JsRef
 hiwire_bool(bool boolean)
 {

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -232,38 +232,6 @@ JsRef
 hiwire_float64array(f64* ptr, int len);
 
 /**
- * Create a new Javascript undefined value.
- *
- * Returns: "New" reference
- */
-JsRef
-hiwire_undefined();
-
-/**
- * Create a new Javascript null value.
- *
- * Returns: "New" reference
- */
-JsRef
-hiwire_null();
-
-/**
- * Create a new Javascript true value.
- *
- * Returns: "New" reference
- */
-JsRef
-hiwire_true();
-
-/**
- * Create a new Javascript false value.
- *
- * Returns: "New" reference
- */
-JsRef
-hiwire_false();
-
-/**
  * Create a new Javascript boolean value.
  * Return value is true if boolean != 0, false if boolean == 0.
  *

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -39,10 +39,10 @@ typedef struct _JsRefStruct* JsRef;
 // Special JsRefs for singleton constants.
 // (These must be even because the least significance bit is set to 0 for
 // singleton constants.)
-#define Js_UNDEFINED ((JsRef)(2))
-#define Js_TRUE ((JsRef)(4))
-#define Js_FALSE ((JsRef)(6))
-#define Js_NULL ((JsRef)(8))
+const JsRef Js_undefined = ((JsRef)(2));
+const JsRef Js_true = ((JsRef)(4));
+const JsRef Js_false = ((JsRef)(6));
+const JsRef Js_null = ((JsRef)(8));
 
 #define hiwire_CLEAR(x)                                                        \
   do {                                                                         \

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -39,10 +39,10 @@ typedef struct _JsRefStruct* JsRef;
 // Special JsRefs for singleton constants.
 // (These must be even because the least significance bit is set to 0 for
 // singleton constants.)
-const JsRef Js_undefined = ((JsRef)(2));
-const JsRef Js_true = ((JsRef)(4));
-const JsRef Js_false = ((JsRef)(6));
-const JsRef Js_null = ((JsRef)(8));
+extern const JsRef Js_undefined;
+extern const JsRef Js_true;
+extern const JsRef Js_false;
+extern const JsRef Js_null;
 
 #define hiwire_CLEAR(x)                                                        \
   do {                                                                         \

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -825,7 +825,7 @@ JsProxy_create(JsRef object)
   if (hiwire_is_error(object)) {
     return JsProxy_new_error(object);
   } else if (hiwire_is_function(object)) {
-    return JsMethod_cnew(object, Js_NULL);
+    return JsMethod_cnew(object, Js_null);
   } else if (hiwire_is_typedarray(object)) {
     return JsBuffer_cnew(object);
   } else {

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -825,7 +825,7 @@ JsProxy_create(JsRef object)
   if (hiwire_is_error(object)) {
     return JsProxy_new_error(object);
   } else if (hiwire_is_function(object)) {
-    return JsMethod_cnew(object, hiwire_null());
+    return JsMethod_cnew(object, Js_NULL);
   } else if (hiwire_is_typedarray(object)) {
     return JsBuffer_cnew(object);
   } else {

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -45,7 +45,7 @@ _pyproxy_get(PyObject* pyobj, JsRef idkey)
   Py_DECREF(pykey);
   if (pyattr == NULL) {
     PyErr_Clear();
-    return hiwire_undefined();
+    return Js_UNDEFINED;
   }
 
   JsRef idattr = python2js(pyattr);
@@ -91,7 +91,7 @@ _pyproxy_deleteProperty(PyObject* pyobj, JsRef idkey)
     return NULL;
   }
 
-  return hiwire_undefined();
+  return Js_UNDEFINED;
 }
 
 JsRef

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -45,7 +45,7 @@ _pyproxy_get(PyObject* pyobj, JsRef idkey)
   Py_DECREF(pykey);
   if (pyattr == NULL) {
     PyErr_Clear();
-    return Js_UNDEFINED;
+    return Js_undefined;
   }
 
   JsRef idattr = python2js(pyattr);
@@ -91,7 +91,7 @@ _pyproxy_deleteProperty(PyObject* pyobj, JsRef idkey)
     return NULL;
   }
 
-  return Js_UNDEFINED;
+  return Js_undefined;
 }
 
 JsRef

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -233,11 +233,11 @@ static JsRef
 _python2js_immutable(PyObject* x, PyObject* map, int depth)
 {
   if (x == Py_None) {
-    return hiwire_undefined();
+    return Js_UNDEFINED;
   } else if (x == Py_True) {
-    return hiwire_true();
+    return Js_TRUE;
   } else if (x == Py_False) {
-    return hiwire_false();
+    return Js_FALSE;
   } else if (PyLong_Check(x)) {
     return _python2js_long(x);
   } else if (PyFloat_Check(x)) {

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -233,11 +233,11 @@ static JsRef
 _python2js_immutable(PyObject* x, PyObject* map, int depth)
 {
   if (x == Py_None) {
-    return Js_UNDEFINED;
+    return Js_undefined;
   } else if (x == Py_True) {
-    return Js_TRUE;
+    return Js_true;
   } else if (x == Py_False) {
-    return Js_FALSE;
+    return Js_false;
   } else if (PyLong_Check(x)) {
     return _python2js_long(x);
   } else if (PyFloat_Check(x)) {

--- a/src/core/runpython.c
+++ b/src/core/runpython.c
@@ -21,7 +21,7 @@ _runPythonDebug(char* code)
   if (py_code == NULL) {
     fprintf(stderr, "runPythonDebug -- error occurred converting argument:\n");
     PyErr_Print();
-    return Js_UNDEFINED;
+    return Js_undefined;
   }
 
   PyObject* result = _PyObject_CallMethodIdObjArgs(
@@ -30,7 +30,7 @@ _runPythonDebug(char* code)
   if (result == NULL) {
     fprintf(stderr, "runPythonDebug -- error occurred\n");
     PyErr_Print();
-    return Js_UNDEFINED;
+    return Js_undefined;
   }
 
   printf("runPythonDebug -- eval_code succeeded, it returned:\n");


### PR DESCRIPTION
We have macros e.g., `Js_UNDEFINED` that represent the constant hiwire keys for interpreter constants. We had functions like `hiwire_undefined` that just return `Js_UNDEFINED`. I removed the functions `hiwire_undefined` and replaced their uses with `Js_UNDEFINED`. In order to get the values into javascript, instead of defining functions that just return constants, I define global variables e.g., `Js_undefined`.