### PR TITLE
Deploy even with a failure of "tests packages" CI on chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,6 @@ workflows:
             - test-core-firefox
             - test-packages-firefox
             - test-core-chrome
-            - test-packages-chrome
             - test-emsdk
             - build-docs
           filters:
@@ -331,7 +330,6 @@ workflows:
             - test-core-firefox
             - test-packages-firefox
             - test-core-chrome
-            - test-packages-chrome
             - test-emsdk
             - build-docs
           filters:


### PR DESCRIPTION
The CI job that tests packages on chrome still frequently experiences timeouts https://github.com/iodide-project/pyodide/issues/1204 . This allows to deploy the dev version even if that CI job failed, so we have the latest version in the dev console.

Partially reverts https://github.com/iodide-project/pyodide/pull/946  We can revert back once the CI issue is fixed.