### PR TITLE
Use EM_COMPILER_WRAPPER to enable ccache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ UGLIFYJS=$(PYODIDE_ROOT)/node_modules/.bin/uglifyjs
 CPYTHONROOT=cpython
 CPYTHONLIB=$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/python$(PYMINOR)
 
-PYODIDE_EMCC=$(PYODIDE_ROOT)/ccache/emcc
-PYODIDE_CXX=$(PYODIDE_ROOT)/ccache/em++
-
 CC=emcc
 CXX=em++
 OPTFLAGS=-O2
@@ -167,28 +164,6 @@ build/test.data: $(CPYTHONLIB) $(UGLIFYJS)
 $(UGLIFYJS): emsdk/emsdk/.complete
 	npm i --no-save uglify-js
 	touch -h $(UGLIFYJS)
-
-
-$(PYODIDE_EMCC):
-	mkdir -p $(PYODIDE_ROOT)/ccache ; \
-	if test ! -h $@; then \
-		if hash ccache &>/dev/null; then \
-			ln -s `which ccache` $@ ; \
-		else \
-			ln -s emsdk/emsdk/upstream/emscripten/emcc $@; \
-		fi; \
-	fi
-
-
-$(PYODIDE_CXX):
-	mkdir -p $(PYODIDE_ROOT)/ccache ; \
-	if test ! -h $@; then \
-		if hash ccache &>/dev/null; then \
-			ln -s `which ccache` $@ ; \
-		else \
-			ln -s emsdk/emsdk/upstream/emscripten/em++ $@; \
-		fi; \
-	fi
 
 
 $(CPYTHONLIB): emsdk/emsdk/.complete $(PYODIDE_EMCC) $(PYODIDE_CXX)

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -22,3 +22,4 @@ export PYODIDE_BASE_URL?=./
 export PYODIDE=1
 # This is the legacy environment variable used for the aforementioned purpose
 export PYODIDE_PACKAGE_ABI=1
+export EM_COMPILER_WRAPPER=ccache

--- a/pyodide_env.sh
+++ b/pyodide_env.sh
@@ -5,5 +5,5 @@ ROOT=`dirname ${BASH_SOURCE[0]}`
 # emsdk_env.sh is fairly noisy, and suppress error message if the file doesn't
 # exist yet (i.e. before building emsdk)
 source "$ROOT/emsdk/emsdk/emsdk_env.sh" 2> /dev/null || true
-export PATH=$ROOT/ccache:$ROOT/node_modules/.bin/:$PATH
+export PATH=$ROOT/node_modules/.bin/:$PATH
 export EM_DIR=$(dirname $(which emcc.py || echo "."))


### PR DESCRIPTION
Fixes #1007. As in #1214, this breaks build if ccache is not available.
