### PR TITLE
Skip -ffixed-form flag

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -299,6 +299,9 @@ def handle_command(line, args, dryrun=False):
         # threading is disabled for now
         if arg == "-pthread":
             continue
+        # this only applies to compiling fortran code, but we already f2c'd
+        if arg == "-ffixed-form":
+            continue
         # On Mac, we need to omit some darwin-specific arguments
         if arg in ["-bundle", "-undefined", "dynamic_lookup"]:
             continue


### PR DESCRIPTION
This is only effective when compiling fortran code, which is not what we are doing since we have applied f2c. Future versions of clang forbid specifying the flag when not compiling fortran.
