### PR TITLE
Remove `pyodide_py.open_url`

### DIFF
--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -14,7 +14,6 @@ Backward compatibility of the API is not guaranteed at this point.
    pyodide.as_nested_list
    pyodide.eval_code
    pyodide.find_imports
-   pyodide.open_url
    pyodide.JsException
    pyodide.register_js_module
    pyodide.unregister_js_module

--- a/packages/pandas/test_pandas.py
+++ b/packages/pandas/test_pandas.py
@@ -62,11 +62,16 @@ def test_load_largish_file(selenium_standalone, request, httpserver):
 
     selenium.run(
         f"""
-        import pyodide
         import matplotlib.pyplot as plt
         import pandas as pd
+        def open_url(url):
+            from js import XMLHttpRequest
+            req = XMLHttpRequest.new()
+            req.open("GET", url, False)
+            req.send(None)
+            return StringIO(req.response)
 
-        df = pd.read_json(pyodide.open_url('{request_url}'))
+        df = pd.read_json(open_url('{request_url}'))
         assert df.shape == ({n_rows}, 8)
-    """
+        """
     )

--- a/packages/pandas/test_pandas.py
+++ b/packages/pandas/test_pandas.py
@@ -66,6 +66,7 @@ def test_load_largish_file(selenium_standalone, request, httpserver):
         import pandas as pd
         def open_url(url):
             from js import XMLHttpRequest
+            from io import StringIO
             req = XMLHttpRequest.new()
             req.open("GET", url, False)
             req.send(None)

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,4 +1,4 @@
-from ._base import open_url, eval_code, find_imports, as_nested_list
+from ._base import eval_code, find_imports, as_nested_list
 from ._core import JsException  # type: ignore
 from ._importhooks import JsFinder
 from .webloop import WebLoopPolicy
@@ -18,7 +18,6 @@ if platform.system() == "Emscripten":
 __version__ = "0.16.1"
 
 __all__ = [
-    "open_url",
     "eval_code",
     "find_imports",
     "as_nested_list",

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -1,8 +1,6 @@
 """
 A library of helper utilities for connecting Python to the browser environment.
 """
-# Added by C:
-# JsException (from jsproxy.c)
 
 import ast
 from asyncio import iscoroutine
@@ -10,28 +8,6 @@ from io import StringIO
 from textwrap import dedent
 from typing import Dict, List, Any, Tuple, Optional
 import tokenize
-
-
-def open_url(url: str) -> StringIO:
-    """
-    Fetches a given URL
-
-    Parameters
-    ----------
-    url
-       URL to fetch
-
-    Returns
-    -------
-    a io.StringIO object with the contents of the URL.
-    """
-    from js import XMLHttpRequest
-
-    req = XMLHttpRequest.new()
-    req.open("GET", url, False)
-    req.send(None)
-    return StringIO(req.response)
-
 
 class CodeRunner:
     """

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 from typing import Dict, List, Any, Tuple, Optional
 import tokenize
 
+
 class CodeRunner:
     """
     A code runner to serve eval_code and eval_code_async.

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -64,6 +64,7 @@ def test_open_url(selenium, httpserver):
             f"""
             def open_url(url):
                 from js import XMLHttpRequest
+                from io import StringIO
                 req = XMLHttpRequest.new()
                 req.open("GET", url, False)
                 req.send(None)

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -62,9 +62,14 @@ def test_open_url(selenium, httpserver):
     assert (
         selenium.run(
             f"""
-        import pyodide
-        pyodide.open_url('{request_url}').read()
-        """
+            def open_url(url):
+                from js import XMLHttpRequest
+                req = XMLHttpRequest.new()
+                req.open("GET", url, False)
+                req.send(None)
+                return StringIO(req.response)
+            open_url('{request_url}').read()
+            """
         )
         == "HELLO"
     )


### PR DESCRIPTION
This function is pretty simple and really has nothing to do with core pyodide purposes. We aren't wrapping the entire javascript standard library, so why do we specifically need a wrapper for `XMLHttpRequest`? Also this makes a blocking request which is [deprecated on the main thread](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#synchronous_request).

I think we should add an faq entry like the following:

## How can I load a url?
Pretty much the same way as you would in javascript. Use `fetch` for simple cases. For more complicated uses, use `XMLHttpRequest`.
```javascript
await pyodide.eval_code_async(`
   from js import fetch
   text = await (await fetch("some_url")).text()
`);
```
### What if I don't want to use `async`?
You can make a blocking call to `XMLHttpRequest`, for instance:
```python
def open_url(url):
    from js import XMLHttpRequest
    from io import StringIO
    req = XMLHttpRequest.new()
    asynchronous = False # make the request synchronous
    req.open("GET", url, asynchronous)
    req.send(None)
    return StringIO(req.response)
```
Note that blocking `XMLHttpRequest` calls are [deprecated on the main browser thread](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests#synchronous_request), so if you are going to do this you should run pyodide on a webworker.