### PR TITLE
RFC pyodide governance and decision-making process

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,3 +1,5 @@
+(how_to_contribute)=
+
 # How to Contribute
 
 Thank you for your interest in contributing to PYODIDE! There are many ways to contribute, and we appreciate all of them. Here are some guidelines & pointers for diving into it.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ information about the project's organization.
 
    project/about.md
    project/code-of-conduct.md
+   project/governance.md
    project/changelog.md
 
 Indices and tables

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -53,10 +53,10 @@ have been nominated, there will be a vote by the current core developers.
 Voting on new core developers is one of the few activities that takes place on
 the project's private communication channels. While it is expected that most votes
 will be unanimous, a two-thirds majority of the cast votes is enough. The vote
-needs to be open for at least 1 week.
+needs to be open for at least one week.
 
 Core developers that have not contributed to the project (commits or GitHub
-comments) in the past 2 years will be asked if they want to become emeritus
+comments) in the past two years will be asked if they want to become emeritus
 core developers and recant their commit and voting rights until they become
 active again.
 
@@ -79,12 +79,12 @@ hereafter may refer to as “the decision making process”.
 Decisions (in addition to adding core developers as above)
 are made according to the following rules:
 
-* **Maintenance changes**, include for
-  instance improving the wording in the documentation, updating CI or
-  dependencies.  Core developers are expected to give “reasonable time” to
-  others to give their opinion on the pull request if they’re not confident
-  others would agree. If no review is received within this time, the Pull
-  Request can be merged.
+* **Maintenance changes**, include for instance improving the wording in the
+  documentation, updating CI or dependencies.  Core developers are expected to
+  give “reasonable time” to others to give their opinion on the Pull Request in
+  case they’re not confident that others would agree. If no further review on
+  the Pull Request is received within this time, it can be merged. If a review
+  is received, then the consensus rules from the following section apply.
 
 * **Code changes in general, and especially those impacting user facing APIs**,
   as well as more significant documentation changes, require review and

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -86,8 +86,8 @@ are made according to the following rules:
   Request can be merged.
 
 * **Code changes impacting user facing APIs, or having backward compatibility
-  implications** require a review and an approval (+1 vote) by a core
-  developer, no objections with -1 vote by a core developer (lazy consensus).
+  implications** require review and approval by a core
+  developer and no objections raised by any core developer (lazy consensus).
   This process happens on the pull-request page.
 
 * **Changes to the governance model** use the same decision process outlined

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -89,8 +89,9 @@ are made according to the following rules:
   Request can be merged.
 
 * **Code changes impacting user facing APIs, or having backward compatibility
-  implications** require +1 by a core developers, no -1 by a core developer
-  (lazy consensus), happens on the issue of pull-request page.
+  implications** require a review and an approval (+1 vote) by a core
+  developer, no objections with -1 vote by a core developer (lazy consensus).
+  This process happens on the pull-request page.
 
 * **Changes to the governance model** use the same decision process outlined
   above.

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -2,7 +2,7 @@
 
 The purpose of this document is to formalize the governance process used by the
 pyodide project, to clarify how decisions are made and how the various
-elements of our community interact.
+members of our community interact.
 This document establishes a decision-making structure that takes into account
 feedback from all members of the community and strives to find consensus, while
 avoiding any deadlocks.
@@ -10,8 +10,7 @@ avoiding any deadlocks.
 Anyone with an
 interest in the project can join the community, contribute to the project
 design and participate in the decision making process. This document describes
-how that participation takes place and how to set about earning merit within
-the project community.
+how to participate and earn merit in the pyodide community.
 
 ## Roles And Responsibilities
 
@@ -27,11 +26,9 @@ The community members team is composed of community members who have permission 
 Github to label and close issues. Their work is
 crucial to improve the communication in the project.
 
-Similarly to what has been decided in the [CPython project](
-https://devguide.python.org/triaging/#becoming-a-member-of-the-python-triage-team),
-any contributor may become a member of this team, after
-showing some continuity in participating in pyodide
-development (with pull requests and reviews).
+After participating in pyodide development with pull requests and reviews for a period of time, any contributor may become a member of the team.
+The process for adding team members is modeled on the [CPython project](
+https://devguide.python.org/triaging/#becoming-a-member-of-the-python-triage-team).
 Any core developer is welcome to propose a pyodide contributor to join the
 community members team. Other core developers are then consulted: while it is expected
 that most acceptances will be unanimous, a two-thirds majority is enough.

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -7,18 +7,18 @@ This document establishes a decision-making structure that takes into account
 feedback from all members of the community and strives to find consensus, while
 avoiding any deadlocks.
 
-Anyone with an
-interest in the project can join the community, contribute to the project
-design and participate in the decision making process. This document describes
-how to participate and earn merit in the pyodide community.
+Anyone with an interest in the project can join the community, contribute to
+the project design and participate in the decision making process. This
+document describes how to participate and earn merit in the pyodide community.
 
 ## Roles And Responsibilities
 
 ### Contributors
 
 Contributors are community members who contribute in concrete ways to the
-project. Anyone can become a contributor, and contributions can take many forms
-– not only code – as detailed in the {ref}`how_to_contibute`.
+project. Anyone can become a contributor, and contributions can take many
+forms, for instance, answering user questions – not only code – as detailed in
+the {ref}`how_to_contibute`
 
 ### Community members team
 
@@ -26,7 +26,8 @@ The community members team is composed of community members who have permission 
 Github to label and close issues. Their work is
 crucial to improve the communication in the project.
 
-After participating in pyodide development with pull requests and reviews for a period of time, any contributor may become a member of the team.
+After participating in pyodide development with pull requests and reviews for a
+period of time, any contributor may become a member of the team.
 The process for adding team members is modeled on the [CPython project](
 https://devguide.python.org/triaging/#becoming-a-member-of-the-python-triage-team).
 Any core developer is welcome to propose a pyodide contributor to join the
@@ -44,8 +45,8 @@ project’s repository and is represented as being a member of the core team on 
 pyodide [GitHub organization](https://github.com/orgs/pyodide/teams/core/members).
 Core developers are expected to review code
 contributions, can merge approved pull requests, can cast votes for and against
-merging a pull-request, and can be involved in deciding major changes to the
-API.
+merging a pull-request, and can make decisions about major changes to the
+API (all contributors are welcome to participate in the discussion).
 
 New core developers can be nominated by any existing core developers. Once they
 have been nominated, there will be a vote by the current core developers.
@@ -78,17 +79,17 @@ hereafter may refer to as “the decision making process”.
 Decisions (in addition to adding core developers as above)
 are made according to the following rules:
 
-* **Minor Documentation changes and minor build setup changes**, include for
+* **Maintenance changes**, include for
   instance improving the wording in the documentation, updating CI or
   dependencies.  Core developers are expected to give “reasonable time” to
   others to give their opinion on the pull request if they’re not confident
   others would agree. If no review is received within this time, the Pull
   Request can be merged.
 
-* **Code changes impacting user facing APIs, or having backward compatibility
-  implications** require review and approval by a core
-  developer and no objections raised by any core developer (lazy consensus).
-  This process happens on the pull-request page.
+* **Code changes in general, and expecially those impacting user facing APIs**,
+  as well as more significant documentation changes, require review and
+  approval by a core developer and no objections raised by any core developer
+  (lazy consensus). This process happens on the pull-request page.
 
 * **Changes to the governance model** use the same decision process outlined
   above.

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -1,0 +1,96 @@
+# pyodide governance and decision-making
+
+The purpose of this document is to formalize the governance process used by the
+pyodide project, to clarify how decisions are made and how the various
+elements of our community interact.
+This document establishes a decision-making structure that takes into account
+feedback from all members of the community and strives to find consensus, while
+avoiding any deadlocks.
+
+Anyone with an
+interest in the project can join the community, contribute to the project
+design and participate in the decision making process. This document describes
+how that participation takes place and how to set about earning merit within
+the project community.
+
+## Roles And Responsibilities
+
+### Contributors
+
+Contributors are community members who contribute in concrete ways to the
+project. Anyone can become a contributor, and contributions can take many forms
+– not only code – as detailed in the {ref}`how_to_contibute`.
+
+### Community members team
+
+The community members team is composed of community members who have permission on
+Github to label and close issues. Their work is
+crucial to improve the communication in the project.
+
+Similarly to what has been decided in the [CPython project](
+https://devguide.python.org/triaging/#becoming-a-member-of-the-python-triage-team),
+any contributor may become a member of this team, after
+showing some continuity in participating in pyodide
+development (with pull requests and reviews).
+Any core developer is welcome to propose a pyodide contributor to join the
+community members team. Other core developers are then consulted: while it is expected
+that most acceptances will be unanimous, a two-thirds majority is enough.
+
+### Core developers
+
+Core developers are community members who have shown that they are dedicated to
+the continued development of the project through ongoing engagement with the
+community. They have shown they can be trusted to maintain pyodide with
+care. Being a core developer allows contributors to more easily carry on
+with their project related activities by giving them direct access to the
+project’s repository and is represented as being a member of the core team on the
+pyodide [GitHub organization](https://github.com/orgs/pyodide/teams/core/members).
+Core developers are expected to review code
+contributions, can merge approved pull requests, can cast votes for and against
+merging a pull-request, and can be involved in deciding major changes to the
+API.
+
+New core developers can be nominated by any existing core developers. Once they
+have been nominated, there will be a vote by the current core developers.
+Voting on new core developers is one of the few activities that takes place on
+the project's private communication channels. While it is expected that most votes
+will be unanimous, a two-thirds majority of the cast votes is enough. The vote
+needs to be open for at least 1 week.
+
+Core developers that have not contributed to the project (commits or GitHub
+comments) in the past 2 years will be asked if they want to become emeritus
+core developers and recant their commit and voting rights until they become
+active again.
+
+
+## Decision Making Process
+
+Decisions about the future of the project are made through discussion with all
+members of the community. All non-sensitive project management discussion takes
+place on the project contributors' [issue
+tracker](https://github.com/pyodide/pyodide/issues) and on [Github
+discussion](https://github.com/pyodide/pyodide/discussions).
+Occasionally, sensitive discussion occurs on a private communication channels.
+
+pyodide uses a "consensus seeking" process for making decisions. The group
+tries to find a resolution that has no open objections among core developers.
+At any point during the discussion, any core-developer can call for a vote,
+which will conclude two weeks from the call for the vote. This is what we
+hereafter may refer to as “the decision making process”.
+
+Decisions (in addition to adding core developers as above)
+are made according to the following rules:
+
+* **Minor Documentation changes and minor build setup changes**, include for
+  instance improving the wording in the documentation, updating CI or
+  dependencies.  Core developers are expected to give “reasonable time” to
+  others to give their opinion on the pull request if they’re not confident
+  others would agree. If no review is received within this time, the Pull
+  Request can be merged.
+
+* **Code changes impacting user facing APIs, or having backward compatibility
+  implications** require +1 by a core developers, no -1 by a core developer
+  (lazy consensus), happens on the issue of pull-request page.
+
+* **Changes to the governance model** use the same decision process outlined
+  above.

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -86,7 +86,7 @@ are made according to the following rules:
   others would agree. If no review is received within this time, the Pull
   Request can be merged.
 
-* **Code changes in general, and expecially those impacting user facing APIs**,
+* **Code changes in general, and especially those impacting user facing APIs**,
   as well as more significant documentation changes, require review and
   approval by a core developer and no objections raised by any core developer
   (lazy consensus). This process happens on the pull-request page.


### PR DESCRIPTION
This is an initial draft and request for comments for the governance document aiming to formalize the decision making process for pyodide, done as part of the migration to a separate org (https://github.com/iodide-project/pyodide/issues/1217) 

In practice this is useful to have a transparent process for approving new maintainers, accepting contributions and making other project related decisions. This draft is a close adaptation and simplification of the scikit-learn [governance document](https://scikit-learn.org/stable/governance.html). I think it's more or less how we and other scientific python projects function. I tried to keep it simple, but it's still somewhat detailed.

*TLDR*: the general approach is to try to reach consensus, and if a consensus cannot be reached call for a vote among core developers.

Alternatively, this document could also emphasize @mdboom's position as the creator of pyodide in some way. For instance with the possibility to veto  decisions, if you think this would be preferable?  

Please comment if you have other ideas or suggestions.

Rendered version: https://github.com/rth/pyodide/blob/governance/docs/project/governance.md

cc @mdboom @wlach @dalcde @phorward @bcolloran