### PR TITLE
Don't implicitly convert tuple and bytes objects into Javascript

### DIFF
--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -230,7 +230,7 @@ _python2js_dict(PyObject* x, PyObject* map, int depth)
   } while (0)
 
 static JsRef
-_python2js_immutable(PyObject* x, PyObject* map, int depth)
+_python2js_immutable(PyObject* x)
 {
   if (x == Py_None) {
     return Js_undefined;
@@ -244,14 +244,10 @@ _python2js_immutable(PyObject* x, PyObject* map, int depth)
     return _python2js_float(x);
   } else if (PyUnicode_Check(x)) {
     return _python2js_unicode(x);
-  } else if (PyBytes_Check(x)) {
-    return _python2js_bytes(x);
   } else if (JsProxy_Check(x)) {
     return JsProxy_AsJs(x);
   } else if (JsException_Check(x)) {
     return JsException_AsJs(x);
-  } else if (PyTuple_Check(x)) {
-    return _python2js_sequence(x, map, depth);
   }
   return NULL;
 }
@@ -259,8 +255,8 @@ _python2js_immutable(PyObject* x, PyObject* map, int depth)
 static JsRef
 _python2js_deep(PyObject* x, PyObject* map, int depth)
 {
-  RETURN_IF_SUCCEEDS(_python2js_immutable(x, map, depth));
-  if (PyList_Check(x)) {
+  RETURN_IF_SUCCEEDS(_python2js_immutable(x));
+  if (PyList_Check(x) || PyTuple_Check(x)) {
     return _python2js_sequence(x, map, depth);
   }
   if (PyDict_Check(x)) {
@@ -278,11 +274,10 @@ static JsRef
 _python2js(PyObject* x, PyObject* map, int depth)
 {
   if (depth == 0) {
-    RETURN_IF_SUCCEEDS(_python2js_immutable(x, map, 0));
+    RETURN_IF_SUCCEEDS(_python2js_immutable(x));
     return pyproxy_new(x);
-  } else {
-    return _python2js_deep(x, map, depth - 1);
   }
+  return _python2js_deep(x, map, depth - 1);
 }
 
 /* During conversion of collection types (lists and dicts) from Python to
@@ -341,15 +336,9 @@ _python2js_cache(PyObject* x, PyObject* map, int depth)
 JsRef
 python2js(PyObject* x)
 {
-  PyObject* map = PyDict_New();
-  JsRef result = _python2js_cache(x, map, 0);
-  Py_DECREF(map);
-
-  if (result == NULL) {
-    pythonexc2js();
-  }
-
-  return result;
+  RETURN_IF_SUCCEEDS(_python2js_immutable(x));
+  RETURN_IF_SUCCEEDS(pyproxy_new(x));
+  pythonexc2js();
 }
 
 JsRef

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -14,12 +14,14 @@ def test_python2js(selenium):
     assert selenium.run_js('return pyodide.runPython("\'ιωδιούχο\'") === "ιωδιούχο"')
     assert selenium.run_js('return pyodide.runPython("\'碘化物\'") === "碘化物"')
     assert selenium.run_js('return pyodide.runPython("\'🐍\'") === "🐍"')
-    assert selenium.run_js(
-        "let x = pyodide.runPython(\"b'bytes'\");\n"
-        "return (x instanceof window.Uint8ClampedArray) && "
-        "(x.length === 5) && "
-        "(x[0] === 98)"
-    )
+    # TODO: replace with suitable test for the behavior of bytes objects once we
+    # get the new behavior specified.
+    # assert selenium.run_js(
+    #     "let x = pyodide.runPython(\"b'bytes'\");\n"
+    #     "return (x instanceof window.Uint8ClampedArray) && "
+    #     "(x.length === 5) && "
+    #     "(x[0] === 98)"
+    # )
     assert selenium.run_js(
         """
         let x = pyodide.runPython("[1, 2, 3]").deepCopyToJavascript();
@@ -428,10 +430,9 @@ def test_python2js_with_depth(selenium):
                 throw new Error(`Assertion failed: ${msg}`);
             }
         }
-        let depths = [0, 3, 3, 3, 6, 6, 6]
         for(let i=0; i < 7; i++){
             let x = pyodide._module.test_python2js_with_depth("a", i);
-            for(let j=0; j < depths[i]; j++){
+            for(let j=0; j < i; j++){
                 assert(Array.isArray(x), `i: ${i}, j: ${j}`);
                 x = x[1];
             }


### PR DESCRIPTION
`tuple` and `bytes` objects are immutable Python objects with no corresponding immutable type in Javascript. For this reason, it is impossible to do a round trip conversion of `tuple` and `bytes` through Javascript and have it come out as an equivalent Python object. I think it's better to preserve as much as possible the invariant that a round trip translation gives back the original object. People who want the idiomatic Javascript object can then use the `toJs` API.

The current implicit conversions for buffers has various limitations (#1221, #1202). I'm hoping to replace it with a new explicit `PyBufferView` API see #1215. 

