### PR TITLE
Add PyProxy.type

### DIFF
--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -217,7 +217,8 @@ _pyproxy_iter_fetch_stopiteration()
 }
 
 JsRef
-_pyproxy_type(PyObject* ptrobj){
+_pyproxy_type(PyObject* ptrobj)
+{
   return hiwire_string_ascii(ptrobj->ob_type->tp_name);
 }
 

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -216,6 +216,11 @@ _pyproxy_iter_fetch_stopiteration()
   return result;
 }
 
+JsRef
+_pyproxy_type(PyObject* ptrobj){
+  return hiwire_string_ascii(ptrobj->ob_type->tp_name);
+}
+
 void
 _pyproxy_destroy(PyObject* ptrobj)
 { // See bug #1049
@@ -235,9 +240,8 @@ EM_JS_REF(JsRef, pyproxy_new, (PyObject * ptrobj), {
 
   _Py_IncRef(ptrobj);
 
-  let target = function(){};
+  let target = new Module.PyProxyClass();
   target['$$'] = { ptr : ptrobj, type : 'PyProxy' };
-  Object.assign(target, Module.PyProxyPublicMethods);
   let proxy = new Proxy(target, Module.PyProxyHandlers);
   let itertype = __pyproxy_iterator_type(ptrobj);
   // clang-format off
@@ -271,8 +275,12 @@ EM_JS(int, pyproxy_init, (), {
     },
   };
 
-  Module.PyProxyPublicMethods = {
-    toString : function() {
+  Module.PyProxyClass = class extends Function {
+    get type() {
+      let ptrobj = _getPtr(this);
+      return Module.hiwire.pop_value(__pyproxy_type(ptrobj));
+    }
+    toString() {
       let ptrobj = _getPtr(this);
       let jsref_repr;
       try {
@@ -284,13 +292,13 @@ EM_JS(int, pyproxy_init, (), {
         _pythonexc2js();
       }
       return Module.hiwire.pop_value(jsref_repr);
-    },
-    destroy : function() {
+    }
+    destroy() {
       let ptrobj = _getPtr(this);
       __pyproxy_destroy(ptrobj);
       this['$$']['ptr'] = null;
-    },
-    apply : function(jsthis, jsargs) {
+    }
+    apply(jsthis, jsargs) {
       let ptrobj = _getPtr(this);
       let idargs = Module.hiwire.new_value(jsargs);
       let idresult;
@@ -305,13 +313,13 @@ EM_JS(int, pyproxy_init, (), {
         _pythonexc2js();
       }
       return Module.hiwire.pop_value(idresult);
-    },
-    toJs : function(depth = -1){
+    }
+    toJs(depth = -1){
       let idresult = _python2js_with_depth(_getPtr(this), depth);
       let result = Module.hiwire.get_value(idresult);
       Module.hiwire.decref(idresult);
       return result;
-    },
+    }
   };
 
   // See: 

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -12,7 +12,7 @@ def test_pyproxy(selenium):
         f = Foo()
         """
     )
-    selenium.run_js("f = pyodide.pyimport('f')")
+    selenium.run_js("window.f = pyodide.pyimport('f')")
     assert selenium.run_js("return f.type") == "Foo"
     assert selenium.run_js("return f.get_value(2)") == 128
     assert selenium.run_js("return f.bar") == 42

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -12,13 +12,15 @@ def test_pyproxy(selenium):
         f = Foo()
         """
     )
-    assert selenium.run_js("return pyodide.pyimport('f').get_value(2)") == 128
-    assert selenium.run_js("return pyodide.pyimport('f').bar") == 42
-    assert selenium.run_js("return ('bar' in pyodide.pyimport('f'))")
-    selenium.run_js("f = pyodide.pyimport('f'); f.baz = 32")
+    selenium.run_js("f = pyodide.pyimport('f')");
+    assert selenium.run_js("return f.type") == "Foo"
+    assert selenium.run_js("return f.get_value(2)") == 128
+    assert selenium.run_js("return f.bar") == 42
+    assert selenium.run_js("return ('bar' in f)")
+    selenium.run_js("f.baz = 32")
     assert selenium.run("f.baz") == 32
     assert set(
-        selenium.run_js("return Object.getOwnPropertyNames(pyodide.pyimport('f'))")
+        selenium.run_js("return Object.getOwnPropertyNames(f)")
     ) == set(
         [
             "__class__",
@@ -136,35 +138,31 @@ def test_pyproxy_destroy(selenium):
 
 
 def test_pyproxy_iter(selenium):
-    assert (
-        selenium.run_js(
-            """
+    [ty, l] = selenium.run_js(
+        """
         let c = pyodide.runPython(`
             def test():
                 for i in range(10):
                     yield i
             test()
         `);
-        return [...c];
+        return [c.type, [...c]];
         """
-        )
-        == list(range(10))
-    )
+    )    
+    assert ty == "generator" 
+    assert l == list(range(10))
 
-    assert (
-        set(
-            selenium.run_js(
-                """
+    [ty, l] = selenium.run_js(
+        """
         c = pyodide.runPython(`
             from collections import ChainMap
             ChainMap({"a" : 2, "b" : 3})
         `);
-        return [...c];
+        return [c.type, [...c]];
         """
-            )
-        )
-        == set(["a", "b"])
     )
+    assert ty == "ChainMap" 
+    assert set(l) == set(["a", "b"])
 
     [result, result2] = selenium.run_js(
         """

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -19,7 +19,7 @@ def test_pyproxy(selenium):
     assert selenium.run_js("return ('bar' in f)")
     selenium.run_js("f.baz = 32")
     assert selenium.run("f.baz") == 32
-    assert set(selenium.run_js("return Object.getOwnPropertyNames(f)")) == set(
+    assert set(selenium.run_js("return Object.getOwnPropertyNames(f)")) > set(
         [
             "__class__",
             "__delattr__",
@@ -50,12 +50,6 @@ def test_pyproxy(selenium):
             "bar",
             "baz",
             "get_value",
-            "toString",
-            "prototype",
-            "apply",
-            "destroy",
-            "$$",
-            "toJs",
         ]
     )
     assert selenium.run("hasattr(f, 'baz')")

--- a/src/tests/test_pyproxy.py
+++ b/src/tests/test_pyproxy.py
@@ -12,16 +12,14 @@ def test_pyproxy(selenium):
         f = Foo()
         """
     )
-    selenium.run_js("f = pyodide.pyimport('f')");
+    selenium.run_js("f = pyodide.pyimport('f')")
     assert selenium.run_js("return f.type") == "Foo"
     assert selenium.run_js("return f.get_value(2)") == 128
     assert selenium.run_js("return f.bar") == 42
     assert selenium.run_js("return ('bar' in f)")
     selenium.run_js("f.baz = 32")
     assert selenium.run("f.baz") == 32
-    assert set(
-        selenium.run_js("return Object.getOwnPropertyNames(f)")
-    ) == set(
+    assert set(selenium.run_js("return Object.getOwnPropertyNames(f)")) == set(
         [
             "__class__",
             "__delattr__",
@@ -148,8 +146,8 @@ def test_pyproxy_iter(selenium):
         `);
         return [c.type, [...c]];
         """
-    )    
-    assert ty == "generator" 
+    )
+    assert ty == "generator"
     assert l == list(range(10))
 
     [ty, l] = selenium.run_js(
@@ -161,7 +159,7 @@ def test_pyproxy_iter(selenium):
         return [c.type, [...c]];
         """
     )
-    assert ty == "ChainMap" 
+    assert ty == "ChainMap"
     assert set(l) == set(["a", "b"])
 
     [result, result2] = selenium.run_js(

--- a/src/tests/test_typeconversions.py
+++ b/src/tests/test_typeconversions.py
@@ -22,15 +22,21 @@ def test_python2js(selenium):
     )
     assert selenium.run_js(
         """
-        let x = pyodide.runPython("[1, 2, 3]").toJs();
-        return ((x instanceof window.Array) && (x.length === 3) &&
-                (x[0] == 1) && (x[1] == 2) && (x[2] == 3))
+        let proxy = pyodide.runPython("[1, 2, 3]");
+        let typename = proxy.type;
+        let x = proxy.toJs();
+        proxy.destroy();
+        return ((typename === "list") && (x instanceof window.Array) && 
+                (x.length === 3) && (x[0] == 1) && (x[1] == 2) && (x[2] == 3));
         """
     )
     assert selenium.run_js(
         """
-        let x = pyodide.runPython("{42: 64}").toJs();
-        return (typeof x === "object") && (x[42] === 64)
+        let proxy = pyodide.runPython("{42: 64}");
+        let typename = proxy.type;
+        let x = proxy.toJs();
+        proxy.destroy();
+        return (typename === "dict") && (typeof x === "object") && (x[42] === 64)
         """
     )
     assert selenium.run_js(
@@ -112,7 +118,10 @@ def test_js2python(selenium):
         """
     )
     assert selenium.run(
-        "from js import jsobject\n" 'str(jsobject) == "[object XMLHttpRequest]"'
+        """
+        from js import jsobject
+        str(jsobject) == "[object XMLHttpRequest]"
+        """
     )
     assert selenium.run(
         """
@@ -331,10 +340,10 @@ def test_javascript_error_back_to_js(selenium):
     assert (
         selenium.run(
             """
-        from js import err
-        py_err = err
-        type(py_err).__name__
-        """
+            from js import err
+            py_err = err
+            type(py_err).__name__
+            """
         )
         == "JsException"
     )


### PR DESCRIPTION
I added a field `PyProxy.type` that returns the fully qualified name of the type. For example `list`, `dict`, `array.array`, `_io.StringIO`. If you say `repr(type(x))` the answer will be `"<class 'something'>"` and then `xproxy.type` is `"something"`. (This is usually equal to `type(x).__module__ + "." + type(x).__name__` except for builtins when it is equal to `type(x).__name__`.)

This is the partner to the `JsProxy.typeof` api.

I also added tests (and did some minor formatting on some of the existing type conversions tests).