### PR TITLE
Change error code on waitpid to ENOSYS

### DIFF
--- a/emsdk/patches/fix_waitpid.patch
+++ b/emsdk/patches/fix_waitpid.patch
@@ -1,6 +1,6 @@
 --- a/emsdk/upstream/emscripten/src/library_syscall.js
 +++ b/emsdk/upstream/emscripten/src/library_syscall.js
-@@ -755,7 +755,8 @@ var SyscallsLibrary = {
+@@ -755,7 +755,7 @@ var SyscallsLibrary = {
    },
    __sys_wait4__proxy: false,
    __sys_wait4: function(pid, wstart, options, rusage) {

--- a/emsdk/patches/fix_waitpid.patch
+++ b/emsdk/patches/fix_waitpid.patch
@@ -1,5 +1,3 @@
-diff --git a/srctemp/library_syscall.js b/emsdk/upstream/emscripten/src/library_syscall.js
-index 5a1c978..725459e 100644
 --- a/emsdk/upstream/emscripten/src/library_syscall.js
 +++ b/emsdk/upstream/emscripten/src/library_syscall.js
 @@ -755,7 +755,8 @@ var SyscallsLibrary = {
@@ -7,8 +5,7 @@ index 5a1c978..725459e 100644
    __sys_wait4__proxy: false,
    __sys_wait4: function(pid, wstart, options, rusage) {
 -    abort('cannot wait on child processes');
-+    // Makes no sense in a single-process environment.
-+    return -({{{ cDefine('ECHILD') }}});
++    return -({{{ cDefine('ENOSYS') }}});
    },
    __sys_setdomainname__nothrow: true,
    __sys_setdomainname__proxy: false,


### PR DESCRIPTION
I think this is more semantically correct:

> ENOSYS Function not implemented (POSIX.1-2001).

An upstream PR is submitted at https://github.com/emscripten-core/emscripten/pull/13487 .