### PR TITLE
DOC Update project subtitle to be more general

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 [![Build Status](https://circleci.com/gh/iodide-project/pyodide.png)](https://circleci.com/gh/iodide-project/pyodide)
 [![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=latest)](https://pyodide.readthedocs.io/?badge=latest)
 
-The Python scientific stack, compiled to WebAssembly.
+Python and the scientific stack, compiled to WebAssembly.
 
 ## What is Pyodide?
 
-**Pyodide** brings the Python 3.8 runtime to the browser via WebAssembly, along with the Python scientific stack including NumPy, Pandas, Matplotlib, parts of SciPy, and NetworkX. The [`packages` directory](https://github.com/iodide-project/pyodide/tree/master/packages) lists over 35 packages which are currently available.
+**Pyodide** brings the Python 3.8 runtime to the browser via WebAssembly, along with the Python scientific stack including NumPy, Pandas, Matplotlib, SciPy, and scikit-learn. The [`packages` directory](https://github.com/iodide-project/pyodide/tree/master/packages) lists over 75 packages which are currently available. In addition it's possible to install pure Python wheels from PyPi.
 
 **Pyodide** provides transparent conversion of objects between Javascript and Python.
 When used inside a browser, Python has full access to the Web APIs.
@@ -23,8 +23,7 @@ browser**.
 
 ## Try Pyodide (no installation needed)
 
-Try the [iodide demo notebook](https://alpha.iodide.io/notebooks/300/) or fire
-up a [Python REPL](https://pyodide-cdn2.iodide.io/v0.16.1/full/console.html) directly in your
+Try pyodide in [Python REPL](https://pyodide-cdn2.iodide.io/v0.16.1/full/console.html) directly in your
 browser.
 
 For further information, look through the [documentation](https://pyodide.readthedocs.io/).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build Status](https://circleci.com/gh/iodide-project/pyodide.png)](https://circleci.com/gh/iodide-project/pyodide)
 [![Documentation Status](https://readthedocs.org/projects/pyodide/badge/?version=latest)](https://pyodide.readthedocs.io/?badge=latest)
 
-Python and the scientific stack, compiled to WebAssembly.
+Python with the scientific stack, compiled to WebAssembly.
 
 ## What is Pyodide?
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,16 +6,15 @@
 Pyodide
 =======
 
-The Python scientific stack, compiled to WebAssembly.
+Python and the scientific stack, compiled to WebAssembly.
 
 .. note::
 
    Pyodide bundles support for the following packages: numpy, scipy, and
    many other libraries in the Python scientific stack.
 
-   To use additional packages from PyPI, try the experimental feature,
-   `Installing packages from PyPI <pypi.html>`_ and try to `pip install` the
-   package.
+   To use additional packages from PyPI, see
+   `Installing packages from PyPI <pypi.html>`_ .
 
    To create a Pyodide package to support and share libraries for new
    applications, try `Creating a Pyodide package <new-packages.html>`_.
@@ -24,8 +23,8 @@ Using Pyodide
 =============
 
 Pyodide may be used in several ways: directly from JavaScript, or to execute
-Python scripts asynchronously in a web worker. Although still experimental,
-additional packages may be installed from PyPI to be used with Pyodide.
+Python scripts asynchronously in a web worker. Additional packages may be
+installed from PyPI to be used with Pyodide.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Pyodide
 =======
 
-Python and the scientific stack, compiled to WebAssembly.
+Python with the scientific stack, compiled to WebAssembly.
 
 .. note::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ Using Pyodide
 =============
 
 Pyodide may be used in several ways: directly from JavaScript, or to execute
-Python scripts asynchronously in a web worker. Additional packages may be
-installed from PyPI to be used with Pyodide.
+Python scripts asynchronously in a web worker. Additional Pure python packages
+may be installed from PyPI to be used with Pyodide.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/553

Changes the project subtitle to be more general.

From 
> The Python scientific stack, compiled to WebAssembly.

to

> Python and the scientific stack, compiled to WebAssembly.

Or maybe 

> Python, and the scientific Python stack, compiled to WebAssembly.


(not sure if we need a comma after Python).

The vast majority of users don't use the scientific stack and just use Python with Pyodide (e.g. for teaching). Also a number of included packages are not scientific packages, so maybe we should go with a more general

> Python, compiled to WebAssembly

as suggested in https://github.com/iodide-project/pyodide/issues/553

WDYT?