### PR TITLE
Allow changing emscripten version with env var

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -1,5 +1,5 @@
-export EMSCRIPTEN_VERSION = 2.0.13
-export BINARYEN_VERSION = ed20954 # version_99. The git tag tags the wrong commit
+export PYODIDE_EMSCRIPTEN_VERSION ?= 2.0.13
+export PYODIDE_BINARYEN_VERSION ?= ed20954 # version_99. The git tag tags the wrong commit
 
 # BASH_ENV tells bash to run pyodide_env.sh on startup, whcih sets various
 # environment variables. The next line instructs make to use bash to run each

--- a/emsdk/Makefile
+++ b/emsdk/Makefile
@@ -6,11 +6,11 @@ all: emsdk/.complete
 emsdk/.complete: ../Makefile.envs $(wildcard patches/*.patch)
 	if [ -d emsdk ]; then rm -rf emsdk; fi
 	git clone --depth 1 https://github.com/emscripten-core/emsdk.git
-	cd emsdk && ./emsdk install --build=Release $(EMSCRIPTEN_VERSION)
+	cd emsdk && ./emsdk install --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	git clone https://github.com/WebAssembly/binaryen.git emsdk/binaryen
-	cd emsdk/binaryen && git checkout $(BINARYEN_VERSION)
+	cd emsdk/binaryen && git checkout $(PYODIDE_BINARYEN_VERSION)
 	cat patches/*.patch | patch -p1
-	cd emsdk && ./emsdk activate --embedded --build=Release $(EMSCRIPTEN_VERSION)
+	cd emsdk && ./emsdk activate --embedded --build=Release $(PYODIDE_EMSCRIPTEN_VERSION)
 	cmake -S emsdk/binaryen -B emsdk/binaryen -DBUILD_STATIC_LIB=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 	make -C emsdk/binaryen -j5 wasm-opt
 	cp emsdk/binaryen/bin/wasm-opt emsdk/upstream/bin/


### PR DESCRIPTION
This makes it easier to test against different emscripten versions on the same tree (e.g. tot a la #1223).
