### PR TITLE
Fix test_asyncio by removing DumbLoop

### DIFF
--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -8,6 +8,7 @@ import time
 from pyodide._base import eval_code_async
 import asyncio
 
+
 def test_await_jsproxy(selenium):
     selenium.run(
         """

--- a/src/tests/test_asyncio.py
+++ b/src/tests/test_asyncio.py
@@ -5,38 +5,10 @@ sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
 import pytest  # type: ignore
 import time
-
-
-def test_eval_async():
-    pass
-
-
-ASYNCIO_EVENT_LOOP_STARTUP = """
+from pyodide._base import eval_code_async
 import asyncio
-class DumbLoop(asyncio.AbstractEventLoop):
-    def create_future(self):
-        fut = asyncio.Future(loop=self)
-        old_set_result = fut.set_result
-        old_set_exception = fut.set_exception
-        def set_result(a):
-            print("set_result:", a)
-            old_set_result(a)
-        fut.set_result = set_result
-        def set_exception(a):
-            print("set_exception:", a)
-            old_set_exception(a)
-        fut.set_exception = set_exception
-        return fut
-
-    def get_debug(self):
-        return False
-
-asyncio.set_event_loop(DumbLoop())
-"""
-
 
 def test_await_jsproxy(selenium):
-    selenium.run(ASYNCIO_EVENT_LOOP_STARTUP)
     selenium.run(
         """
         def prom(res,rej):
@@ -63,7 +35,6 @@ def test_await_jsproxy(selenium):
 
 
 def test_await_fetch(selenium):
-    selenium.run(ASYNCIO_EVENT_LOOP_STARTUP)
     selenium.run(
         """
         from js import fetch, window
@@ -108,7 +79,6 @@ def test_await_error(selenium):
         window.js_raises = js_raises;
         """
     )
-    selenium.run(ASYNCIO_EVENT_LOOP_STARTUP)
     selenium.run(
         """
         from js import async_js_raises, js_raises
@@ -129,16 +99,10 @@ def test_await_error(selenium):
         )
 
 
-from pyodide._base import eval_code_async
-
-
 def test_eval_code_async_simple():
     c = eval_code_async("1+92")
     with pytest.raises(StopIteration, match="93"):
         c.send(None)
-
-
-import asyncio
 
 
 def test_eval_code_async_loop():
@@ -162,7 +126,6 @@ def test_eval_code_async_loop():
 
 
 def test_eval_code_await_jsproxy(selenium):
-    selenium.run(ASYNCIO_EVENT_LOOP_STARTUP)
     selenium.run(
         """
         def prom(res,rej):
@@ -193,7 +156,6 @@ def test_eval_code_await_jsproxy(selenium):
 
 
 def test_eval_code_await_fetch(selenium):
-    selenium.run(ASYNCIO_EVENT_LOOP_STARTUP)
     selenium.run(
         """
         from js import fetch, window
@@ -239,7 +201,6 @@ def test_eval_code_await_error(selenium):
         window.js_raises = js_raises;
         """
     )
-    selenium.run(ASYNCIO_EVENT_LOOP_STARTUP)
     selenium.run(
         """
         from js import async_js_raises, js_raises
@@ -267,9 +228,9 @@ def test_await_pyproxy_eval_async(selenium):
     assert (
         selenium.run_js(
             """
-        let c = pyodide._module.pyodide_py._base.eval_code_async("1+1");
-        return await c;
-        """
+            let c = pyodide._module.pyodide_py._base.eval_code_async("1+1");
+            return await c;
+            """
         )
         == 2
     )

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -26,8 +26,10 @@ def test_stream_redirection():
 @pytest.fixture
 def safe_sys_redirections():
     redirected = sys.stdout, sys.stderr, sys.displayhook
-    yield
-    sys.stdout, sys.stderr, sys.displayhook = redirected
+    try:
+        yield
+    finally:
+        sys.stdout, sys.stderr, sys.displayhook = redirected
 
 
 def test_interactive_console_streams(safe_sys_redirections):
@@ -130,8 +132,10 @@ def test_repr(safe_sys_redirections):
 def safe_selenium_sys_redirections(selenium):
     selenium.run("import sys")
     selenium.run("_redirected = sys.stdout, sys.stderr, sys.displayhook")
-    yield
-    selenium.run("sys.stdout, sys.stderr, sys.displayhook = _redirected")
+    try:
+        yield
+    finally:
+        selenium.run("sys.stdout, sys.stderr, sys.displayhook = _redirected")
 
 
 def test_interactive_console(selenium, safe_selenium_sys_redirections):


### PR DESCRIPTION
This fixes many of the test failures reported by @albertas in #1258. The problem was that the older tests in `test_asyncio` globally set up a `DumbLoop` which is a very feature poor event loop meant for low level asyncio testing, but they didn't restore the event loop when they were finished.

The newer tests are more integration tests of the asyncio testing features (they test the code added in all 3-4 of the major asyncio PRs mixed together) and they expect to use the typical `WebLoop`, not the `DumbLoop`.

~Anyways I switched to using a `dumb_loop` fixture that restores the normal event loop on exit.~ 
Edit: I removed `DumbLoop` entirely.
I also adjusted the fixtures in `test_console` to use the standard
```python
try:
   yield
finally:
   # cleanup
```
setup.