### PR TITLE
Fix broken links in documentation homepage

### DIFF
--- a/docs/development/new-packages.md
+++ b/docs/development/new-packages.md
@@ -1,3 +1,4 @@
+(new-packages)=
 # Creating a Pyodide package
 
 Pyodide includes a toolchain to make it easier to add new third-party Python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Python with the scientific stack, compiled to WebAssembly.
    many other libraries in the Python scientific stack.
 
    To use additional packages from PyPI, see
-   `Installing packages from PyPI <pypi.html>`_ .
+   :ref:`micropip` .
 
    To create a Pyodide package to support and share libraries for new
    applications, try `Creating a Pyodide package <new-packages.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Python with the scientific stack, compiled to WebAssembly.
    :ref:`micropip` .
 
    To create a Pyodide package to support and share libraries for new
-   applications, try `Creating a Pyodide package <new-packages.html>`_.
+   applications, try :ref:`new-packages` .
 
 Using Pyodide
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,8 @@ Python with the scientific stack, compiled to WebAssembly.
    To use additional packages from PyPI, see
    :ref:`micropip` .
 
-   To create a Pyodide package to support and share libraries for new
-   applications, try :ref:`new-packages` .
+   You can also :ref:`create a Pyodide package <new-packages>` to support and share libraries for new
+   applications.
 
 Using Pyodide
 =============


### PR DESCRIPTION
I attempted to fix #1257 by using "linking via sphinx", like so: 
```
:ref:`micropip`
```
I apologize if I made any errors in this change; this is my first time dealing with Pyodide's codebase and I don't generally work with Sphinx.