### PR TITLE
Fix console.html completions

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -64,8 +64,7 @@
             prompt: ps1,
             completionEscape: false,
             completion: function(command, callback) {
-              const completions = pyconsole.complete(command)[0];
-              callback(completions.toJs());
+              callback(pyconsole.complete(command).toJs()[0]);
             }
           }
         );


### PR DESCRIPTION
I think #1167 broke `console.html` completions, this fixes it. I tried to figure out how to add a test against this, but it seemed annoying. Maybe we should make a `test_console` that actually runs in `console.html`?