### PR TITLE
Use eval_code_async in runPythonAsync

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -87,6 +87,8 @@ substitutions:
   `pyodide.loadPackage`, `pyodide.runPythonAsync` and
   `pyodide.loadPackagesFromImport`, then the messages are no longer
   automatically logged to the console.
+- {{ Feature }} `runPythonAsync` now runs the code with `eval_code_async`. In
+  particular, it is possible to use top level `await` inside of `runPythonAsync`.
 - `eval_code` now accepts separate `globals` and `locals` parameters.
   [#1083](https://github.com/iodide-project/pyodide/pull/1083)
 - Added the `pyodide.setInterruptBuffer` API. This can be used to set a

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -210,10 +210,10 @@ EM_JS_REF(JsRef, hiwire_float64array, (f64 * ptr, int len), {
   return Module.hiwire.new_value(array);
 })
 
-EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef idmsg), {
-  let jsmsg = Module.hiwire.get_value(idmsg);
-  Module.hiwire.decref(idmsg);
-  throw new Error(jsmsg);
+EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
+  let jserr = Module.hiwire.get_value(iderr);
+  Module.hiwire.decref(iderr);
+  throw jserr;
 });
 
 EM_JS_REF(JsRef, hiwire_array, (), { return Module.hiwire.new_value([]); });

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -211,9 +211,7 @@ EM_JS_REF(JsRef, hiwire_float64array, (f64 * ptr, int len), {
 })
 
 EM_JS(void _Py_NO_RETURN, hiwire_throw_error, (JsRef iderr), {
-  let jserr = Module.hiwire.get_value(iderr);
-  Module.hiwire.decref(iderr);
-  throw jserr;
+  throw Module.hiwire.pop_value(iderr);
 });
 
 EM_JS_REF(JsRef, hiwire_array, (), { return Module.hiwire.new_value([]); });

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -276,6 +276,7 @@ hiwire_push_object_pair(JsRef idobj, JsRef idkey, JsRef idval);
 
 /**
  * Throw a javascript Error object.
+ * Steals a reference to the argument.
  */
 void _Py_NO_RETURN
 hiwire_throw_error(JsRef iderr);

--- a/src/core/hiwire.h
+++ b/src/core/hiwire.h
@@ -275,13 +275,10 @@ errcode
 hiwire_push_object_pair(JsRef idobj, JsRef idkey, JsRef idval);
 
 /**
- * Throws a new Error object with the given message.
- *
- * The message is conventionally a Javascript string, but that is not required.
- * TODO: should be hiwire_set_error.
+ * Throw a javascript Error object.
  */
 void _Py_NO_RETURN
-hiwire_throw_error(JsRef idmsg);
+hiwire_throw_error(JsRef iderr);
 
 /**
  * Get a Javascript object from the global namespace, i.e. window.

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -308,7 +308,7 @@ FutureDoneCallback_call_reject(FutureDoneCallback* self)
   JsRef excval = NULL;
   JsRef result = NULL;
   // wrap_exception looks up the current exception and wraps it in a Js error.
-  excval = wrap_exception();
+  excval = wrap_exception(false);
   FAIL_IF_NULL(excval);
   result = hiwire_call_OneArg(self->reject_handle, excval);
 

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -129,10 +129,7 @@ pythonexc2js()
     jserror =
       new_error("Error occurred while formatting traceback", Js_undefined);
   }
-
-  // This throws an error making it pretty difficult to decref
-  // excval, so hiwire_throw_error will decref it for us (in other words
-  // hiwire_throw_error steals a reference to its argument).
+  // hiwire_throw_error steals jserror
   hiwire_throw_error(jserror);
 }
 

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -17,15 +17,19 @@ static JsRef
 _python2js_unicode(PyObject* x);
 
 EM_JS_REF(JsRef, new_error, (const char* msg, JsRef pyproxy), {
-  return Module.hiwire.new_value(
-    new Module.PythonError(UTF8ToString(msg), Module.hiwire.get_value(pyproxy)));
+  return Module.hiwire.new_value(new Module.PythonError(
+    UTF8ToString(msg), Module.hiwire.get_value(pyproxy)));
 });
 
 static int
-fetch_and_normalize_exception(PyObject** type, PyObject** value, PyObject** traceback){
+fetch_and_normalize_exception(PyObject** type,
+                              PyObject** value,
+                              PyObject** traceback)
+{
   PyErr_Fetch(type, value, traceback);
   PyErr_NormalizeException(type, value, traceback);
-  if (*type == NULL || *type == Py_None || *value == NULL || *value == Py_None) {
+  if (*type == NULL || *type == Py_None || *value == NULL ||
+      *value == Py_None) {
     Py_CLEAR(*type);
     Py_CLEAR(*value);
     PyErr_SetString(PyExc_TypeError, "No exception type or value");
@@ -44,7 +48,8 @@ finally:
 }
 
 static PyObject*
-format_exception_traceback(PyObject* type, PyObject* value, PyObject* traceback){
+format_exception_traceback(PyObject* type, PyObject* value, PyObject* traceback)
+{
   PyObject* pylines = NULL;
   PyObject* empty = NULL;
   PyObject* result = NULL;
@@ -63,7 +68,6 @@ finally:
   return result;
 }
 
-
 JsRef
 wrap_exception(bool attach_python_error)
 {
@@ -81,7 +85,7 @@ wrap_exception(bool attach_python_error)
   const char* pystr_utf8 = PyUnicode_AsUTF8(pystr);
   FAIL_IF_NULL(pystr_utf8);
 
-  if(attach_python_error){
+  if (attach_python_error) {
     pyexc_proxy = pyproxy_new(value);
   } else {
     pyexc_proxy = Js_undefined;
@@ -91,15 +95,17 @@ wrap_exception(bool attach_python_error)
   success = true;
 finally:
   // Log an appropriate warning.
-  if (success){
-    EM_ASM({
+  if (success) {
+    EM_ASM(
+      {
         let msg = Module.hiwire.get_value($0).message;
         console.warn("Python exception:\n" + msg + "\n");
-    }, jserror);
+      },
+      jserror);
   } else {
     PySys_WriteStderr("Error occurred while formatting traceback:\n");
     PyErr_Print();
-    if(type != NULL){
+    if (type != NULL) {
       PySys_WriteStderr("\nOriginal exception was:\n");
       PyErr_Display(type, value, traceback);
     }
@@ -119,8 +125,9 @@ void _Py_NO_RETURN
 pythonexc2js()
 {
   JsRef jserror = wrap_exception(false);
-  if(jserror == NULL) {
-    jserror = new_error("Error occurred while formatting traceback", Js_undefined);
+  if (jserror == NULL) {
+    jserror =
+      new_error("Error occurred while formatting traceback", Js_undefined);
   }
 
   // This throws an error making it pretty difficult to decref
@@ -441,8 +448,9 @@ python2js_init()
         this.pythonError = pythonError;
       }
 
-      clear(){
-        if(this.pythonError){
+      clear()
+      {
+        if (this.pythonError) {
           this.pythonError.destroy();
           delete this.pythonError;
         }

--- a/src/core/python2js.h
+++ b/src/core/python2js.h
@@ -10,7 +10,7 @@
 #include "hiwire.h"
 
 JsRef
-wrap_exception();
+wrap_exception(bool attach_python_error);
 
 /** Convert the active Python exception into a Javascript Error object
  *  and print it to the console.

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -496,7 +496,13 @@ globalThis.languagePluginLoader = (async () => {
    */
   Module.runPythonAsync = async function(code, messageCallback, errorCallback) {
     await Module.loadPackagesFromImports(code, messageCallback, errorCallback);
-    return Module.runPython(code);
+    let coroutine = Module.pyodide_py.eval_code_async(code, Module.globals);
+    try {
+      let result = await coroutine;
+      return result;
+    } finally {
+      coroutine.destroy();
+    }
   };
 
   // clang-format off

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -268,9 +268,9 @@ globalThis.languagePluginLoader = (async () => {
   /**
    * @type {object}
    *
-   * Use ``Object.keys(pyodide.loadedPackages)`` to get the list of names of
+   * Use ``Object.keys(pyodide.loadedPackages)`` to get the list of names of 
    * loaded packages, and ``pyodide.loadedPackages[package_name]`` to access
-   * install location for a particular ``package_name``.
+   * the install location for a particular ``package_name``.
    */
   Module.loadedPackages = {};
 
@@ -422,19 +422,21 @@ globalThis.languagePluginLoader = (async () => {
 
   // clang-format off
   /**
-   * Inspect a Python code chunk and use ``pyodide.loadPackage` to load any known 
-   * packages that the code chunk imports. Uses 
-   * :func:`pyodide_py.find_imports <pyodide.find\_imports>` to inspect the code.
-
-   * For example, given the following code chunk as input
-   * 
-   * .. code-block:: python
-   * 
-   *    import numpy as np
-   *    x = np.array([1, 2, 3])
-   * 
-   * :js:func:`loadPackagesFromImports` will call ``pyodide.loadPackage(['numpy'])``.
-   * See also :js:func:`runPythonAsync`.
+   * Inspect a Python code chunk with :any:`pyodide.find_imports` to determine
+   * which packages the code imports and use :any:`pyodide.loadPackage` to load
+   * any known packages that the code chunk imports.
+   *
+   * For example, given the following code:
+   *
+   * .. code-block:: pyodide
+   *    
+   *    pyodide.loadPackagesFromImports(`
+   *      import numpy as np 
+   *      x = np.array([1, 2, 3])
+   *    `);
+   *
+   * :js:func:`loadPackagesFromImports` will call
+   * ``pyodide.loadPackage(['numpy'])``. See also :js:func:`runPythonAsync`.
    *
    * @param {*} code 
    * @param {*} messageCallback 
@@ -470,23 +472,27 @@ globalThis.languagePluginLoader = (async () => {
   Module.pyimport = name => Module.globals[name];
 
   /**
-   * Runs Python code, possibly asynchronously loading any known packages that
-   * the code chunk imports. For example, given the following code chunk
+   * An `async` function. First it runs
+   * :any:`pyodide.loadPackagesFromImports(code)
+   * <pyodide.loadPackagesFromImports>` to asynchronously load any known
+   * packages that ``code`` imports. 
    *
-   * .. code-block:: python
-   *
-   *    import numpy as np
-   *    x = np.array([1, 2, 3])
-   *
-   * pyodide will first call `pyodide.loadPackage(['numpy'])`, and then run the
-   * code chunk, returning the result. Since package fetching must happen
-   * asynchronously, this function returns a `Promise` which resolves to the
-   * output. For example:
-   *
-   * .. code-block:: javascript
-   *
-   *    pyodide.runPythonAsync(code, messageCallback)
-   *           .then((output) => handleOutput(output))
+   * Then it will run ``code`` using :any:`pyodide.eval_code_async`. Examples:
+   * 
+   * .. code-block:: pyodide
+   *    
+   *    let packages_json = await pyodide.loadPackagesFromImports(`
+   *      from js import fetch
+   *      response = js.fetch("packages.json")
+   *      await response.json
+   *    `);
+   * 
+   * .. code-block:: pyodide
+   *    
+   *    let x = await pyodide.runPythonAsync(`
+   *      import numpy as np 
+   *      x = np.array([1, 2, 3])
+   *    `);
    *
    * @param {string} code Python code to evaluate
    * @param {Function} messageCallback A callback, called with progress

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -268,7 +268,7 @@ globalThis.languagePluginLoader = (async () => {
   /**
    * @type {object}
    *
-   * Use ``Object.keys(pyodide.loadedPackages)`` to get the list of names of 
+   * Use ``Object.keys(pyodide.loadedPackages)`` to get the list of names of
    * loaded packages, and ``pyodide.loadedPackages[package_name]`` to access
    * the install location for a particular ``package_name``.
    */
@@ -475,22 +475,22 @@ globalThis.languagePluginLoader = (async () => {
    * An `async` function. First it runs
    * :any:`pyodide.loadPackagesFromImports(code)
    * <pyodide.loadPackagesFromImports>` to asynchronously load any known
-   * packages that ``code`` imports. 
+   * packages that ``code`` imports.
    *
    * Then it will run ``code`` using :any:`pyodide.eval_code_async`. Examples:
-   * 
+   *
    * .. code-block:: pyodide
-   *    
+   *
    *    let packages_json = await pyodide.loadPackagesFromImports(`
    *      from js import fetch
    *      response = js.fetch("packages.json")
    *      await response.json
    *    `);
-   * 
+   *
    * .. code-block:: pyodide
-   *    
+   *
    *    let x = await pyodide.runPythonAsync(`
-   *      import numpy as np 
+   *      import numpy as np
    *      x = np.array([1, 2, 3])
    *    `);
    *

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -225,6 +225,7 @@ def test_keyboard_interrupt(selenium):
         """
     )
 
+
 def test_run_python_async_toplevel_await(selenium):
     selenium.run_js(
         """

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -224,3 +224,15 @@ def test_keyboard_interrupt(selenium):
         `)
         """
     )
+
+def test_run_python_async_toplevel_await(selenium):
+    selenium.run_js(
+        """
+        pyodide.runPythonAsync(`
+            from js import fetch
+            resp = await fetch("packages.json")
+            json = await resp.json()
+            assert hasattr(json, "dependencies")
+        `);
+        """
+    )


### PR DESCRIPTION
This updates `runPythonAsync` to use `pyodide_py.eval_code_async` internally. This has the effect that Python code run with `runPythonAsync` is executed with `PyCF_ALLOW_TOP_LEVEL_AWAIT`, which is what I and I think many other people expected `runPythonAsync` to do.

If this change to the code is approved, I'll add more appropriate updates to the docs.

It still makes the call to `pyodide.loadPackagesFromImports`. I think ideally we would remove the call to `loadPackagesFromImports` and have people do that separately if they want it. I believe that this would make `runPythonAsync` function more in the expected way.