### PR TITLE
Use jquery v3.5.1 instead of v1.11.1

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -70,7 +70,7 @@
           }
         );
 
-        pyconsole.stdout_callback = (s) => term.error(s, {newline : false});
+        pyconsole.stdout_callback = (s) => term.echo(s, {newline : false});
         pyconsole.stderr_callback = (s) => term.error(s, {newline : false});
       });
     </script>

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/echo_newline.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" rel="stylesheet"/>
     <script type="text/javascript">
         // set the pyodide files URL (packages.json, pyodide.asm.data etc)
@@ -69,28 +70,8 @@
           }
         );
 
-        // JQuery.terminal adds a trailing newline that is not easy
-        // to remove with the current API. Doing our best here.
-        term.echo_no_newline = (function (message) {
-          // prompt can be polluted with previous echo
-          // _prompt_tail is the line part just before the prompt
-          this._prompt_tail = this._prompt_tail || '';
-          let prompt = this.get_prompt();
-          if( prompt.startsWith(this._prompt_tail) )
-            prompt = prompt.slice(this._prompt_tail.length);
-          else
-            this._prompt_tail = '';
-          // here, prompt and _prompt_tail should be correctly isolated
-          const lines = message.split('\n');
-          lines[0] = this._prompt_tail + lines[0];
-          this._prompt_tail = lines.pop();
-          this.set_prompt(this._prompt_tail + prompt);
-          if( lines.length )
-            this.echo(lines.join('\n'));
-        }).bind(term);
-
-        pyconsole.stdout_callback = term.echo_no_newline;
-        pyconsole.stderr_callback = (s) => term.error(s.replace(/\n+$/, ""));
+        pyconsole.stdout_callback = (s) => term.error(s, {newline : false});
+        pyconsole.stderr_callback = (s) => term.error(s, {newline : false});
       });
     </script>
   </body>

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <script src="https://code.jquery.com/jquery-latest.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" rel="stylesheet"/>
     <script type="text/javascript">


### PR DESCRIPTION
Oddly enough `https://code.jquery.com/jquery-latest.js` does not point to the latest version of jquery, it points to version 1.11.1 (released in 2014). The jsdelivr link `https://cdn.jsdelivr.net/npm/jquery` points to 3.5.1. The terminal seems to work better with the up to date version of jquery, despite the fact that terminal docs suggested using the jquery-latest link.

Closes https://github.com/iodide-project/pyodide/issues/1276