### PR TITLE
Set sys.last_type, sys.last_value, sys.last_traceback on exception

### DIFF
--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -12,6 +12,9 @@
 static PyObject* tbmod = NULL;
 
 _Py_IDENTIFIER(format_exception);
+_Py_IDENTIFIER(last_type);
+_Py_IDENTIFIER(last_value);
+_Py_IDENTIFIER(last_traceback);
 
 static JsRef
 _python2js_unicode(PyObject* x);
@@ -109,6 +112,12 @@ finally:
       PySys_WriteStderr("\nOriginal exception was:\n");
       PyErr_Display(type, value, traceback);
     }
+  }
+
+  if(success){
+    _PySys_SetObjectId(&PyId_last_type, type);
+    _PySys_SetObjectId(&PyId_last_value, value);
+    _PySys_SetObjectId(&PyId_last_traceback, traceback);
   }
   Py_CLEAR(type);
   Py_CLEAR(value);

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -114,7 +114,7 @@ finally:
     }
   }
 
-  if(success){
+  if (success) {
     _PySys_SetObjectId(&PyId_last_type, type);
     _PySys_SetObjectId(&PyId_last_value, value);
     _PySys_SetObjectId(&PyId_last_traceback, traceback);

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -237,3 +237,19 @@ def test_run_python_async_toplevel_await(selenium):
         `);
         """
     )
+
+
+def test_run_python_last_exc(selenium):
+    selenium.run_js(
+        """
+        try {
+            pyodide.runPython("x = ValueError(77); raise x");
+        } catch(e){}
+        pyodide.runPython(`
+            import sys
+            assert sys.last_value is x
+            assert sys.last_type is type(x)
+            assert sys.last_traceback is x.__traceback__
+        `);
+        """
+    )


### PR DESCRIPTION
Normally repls store the most recent unhandled exception in `sys.last_value`, etc. This PR updates pyodide to do this too.