### PR TITLE
Fix support for brackets in error messages

### DIFF
--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -71,7 +71,7 @@
         );
 
         pyconsole.stdout_callback = (s) => term.echo(s, {newline : false});
-        pyconsole.stderr_callback = (s) => term.echo(`[[;red;]${s}\u200B]`, {newline : false});
+        pyconsole.stderr_callback = (s) => term.echo(`[[;red;]${$.terminal.escape_brackets(s)}\u200B]`, {newline : false});
       });
     </script>
   </body>


### PR DESCRIPTION
Another quick fix for the following bug:

![image](https://user-images.githubusercontent.com/8739626/109182855-3bd08400-7742-11eb-9dc7-c6d563b04593.png)

