### PR TITLE
BLD Fix overwriting package optflags via clfags etc in meta.yaml

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -264,12 +264,26 @@ def handle_command(line, args, dryrun=False):
     elif new_args[0] == "em++":
         new_args.extend(args.cflags.split() + args.cxxflags.split())
 
+    optflags_valid = [f"-O{tok}" for tok in "01234sz"]
+    optflag = None
+    # Identify the optflag (e.g. -O3) in cflags/cxxflags/ldflags. Last one has
+    # priority.
+    for arg in new_args[::-1]:
+        if arg in optflags_valid:
+            optflag = arg
+            break
+
     lapack_dir = None
 
     used_libs = set()
 
     # Go through and adjust arguments
     for arg in line[1:]:
+        if arg in optflags_valid and optflag is not None and arg != optflag:
+            # There are multiple contradictory optflags provided, use the one
+            # from cflags/cxxflags/ldflags
+            continue
+
         if arg.startswith("-I"):
             if (
                 str(Path(arg[2:]).resolve()).startswith(sys.prefix + "/include/python")

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -14,7 +14,7 @@ from pyodide_build.pywasmcross import make_parser
 
 @dataclass
 class BuildArgs:
-    """A simple ArgumentParser like object for tests"""
+    """An object to hold build arguments"""
 
     cflags: str = ""
     cxxflags: str = ""

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -13,7 +13,7 @@ from pyodide_build.pywasmcross import make_parser
 
 
 @dataclass
-class CompileArgs:
+class BuildArgs:
     """A simple ArgumentParser like object for tests"""
 
     cflags: str = ""
@@ -47,7 +47,7 @@ f2c_wrap = _args_wrapper(f2c)
 
 
 def test_handle_command():
-    args = CompileArgs()
+    args = BuildArgs()
     assert handle_command_wrap("gcc -print-multiarch", args) is None
     assert handle_command_wrap("gcc test.c", args) == "emcc test.c"
     assert (
@@ -56,7 +56,7 @@ def test_handle_command():
     )
 
     # check cxxflags injection and cpp detection
-    args = CompileArgs(
+    args = BuildArgs(
         cflags="-I./lib2",
         cxxflags="-std=c++11",
         ldflags="-lm",
@@ -67,7 +67,7 @@ def test_handle_command():
     )
 
     # check ldflags injection
-    args = CompileArgs(
+    args = BuildArgs(
         cflags="", cxxflags="", ldflags="-lm", host="", replace_libs="", install_dir=""
     )
     assert (
@@ -76,7 +76,7 @@ def test_handle_command():
     )
 
     # check library replacement and removal of double libraries
-    args = CompileArgs(
+    args = BuildArgs(
         replace_libs="bob=fred",
     )
     assert (
@@ -100,7 +100,7 @@ def test_handle_command_optflags(in_ext, out_ext, executable, flag_name):
     # Make sure that when multiple optflags are present those in cflags,
     # cxxflags, or ldflags has priority
 
-    args = CompileArgs(**{flag_name: "-Oz"})
+    args = BuildArgs(**{flag_name: "-Oz"})
     assert (
         handle_command_wrap(f"gcc -O3 test.{in_ext} -o test.{out_ext}", args)
         == f"{executable} -Oz test.{in_ext} -o test.{out_ext}"
@@ -118,7 +118,7 @@ def test_f2c():
 
 
 def test_conda_compiler_compat():
-    args = CompileArgs()
+    args = BuildArgs()
     assert handle_command_wrap(
         "gcc -shared -c test.o -B /compiler_compat -o test.so", args
     ) == ("emcc -c test.o -o test.so")

--- a/pyodide_build/tests/test_pywasmcross.py
+++ b/pyodide_build/tests/test_pywasmcross.py
@@ -1,7 +1,7 @@
-from collections import namedtuple
 from pathlib import Path
 import sys
 import argparse
+from dataclasses import dataclass
 
 import pytest
 
@@ -11,7 +11,17 @@ from pyodide_build.pywasmcross import handle_command  # noqa: E402
 from pyodide_build.pywasmcross import f2c  # noqa: E402
 from pyodide_build.pywasmcross import make_parser
 
-ARG_FIELDS = ["cflags", "cxxflags", "ldflags", "host", "replace_libs", "install_dir"]
+
+@dataclass
+class CompileArgs:
+    """A simple ArgumentParser like object for tests"""
+
+    cflags: str = ""
+    cxxflags: str = ""
+    ldflags: str = ""
+    host: str = ""
+    replace_libs: str = ""
+    install_dir: str = ""
 
 
 def _args_wrapper(func):
@@ -37,8 +47,7 @@ f2c_wrap = _args_wrapper(f2c)
 
 
 def test_handle_command():
-    Args = namedtuple("args", ARG_FIELDS, defaults=("",) * len(ARG_FIELDS))
-    args = Args()
+    args = CompileArgs()
     assert handle_command_wrap("gcc -print-multiarch", args) is None
     assert handle_command_wrap("gcc test.c", args) == "emcc test.c"
     assert (
@@ -47,7 +56,7 @@ def test_handle_command():
     )
 
     # check cxxflags injection and cpp detection
-    args = Args(
+    args = CompileArgs(
         cflags="-I./lib2",
         cxxflags="-std=c++11",
         ldflags="-lm",
@@ -58,7 +67,7 @@ def test_handle_command():
     )
 
     # check ldflags injection
-    args = Args(
+    args = CompileArgs(
         cflags="", cxxflags="", ldflags="-lm", host="", replace_libs="", install_dir=""
     )
     assert (
@@ -67,7 +76,7 @@ def test_handle_command():
     )
 
     # check library replacement and removal of double libraries
-    args = Args(
+    args = CompileArgs(
         replace_libs="bob=fred",
     )
     assert (
@@ -91,8 +100,7 @@ def test_handle_command_optflags(in_ext, out_ext, executable, flag_name):
     # Make sure that when multiple optflags are present those in cflags,
     # cxxflags, or ldflags has priority
 
-    Args = namedtuple("args", ARG_FIELDS, defaults=("",) * len(ARG_FIELDS))
-    args = Args(**{flag_name: "-Oz"})
+    args = CompileArgs(**{flag_name: "-Oz"})
     assert (
         handle_command_wrap(f"gcc -O3 test.{in_ext} -o test.{out_ext}", args)
         == f"{executable} -Oz test.{in_ext} -o test.{out_ext}"
@@ -110,12 +118,7 @@ def test_f2c():
 
 
 def test_conda_compiler_compat():
-    Args = namedtuple(
-        "args", ["cflags", "cxxflags", "ldflags", "host", "replace_libs", "install_dir"]
-    )
-    args = Args(
-        cflags="", cxxflags="", ldflags="", host="", replace_libs="", install_dir=""
-    )
+    args = CompileArgs()
     assert handle_command_wrap(
         "gcc -shared -c test.o -B /compiler_compat -o test.so", args
     ) == ("emcc -c test.o -o test.so")


### PR DESCRIPTION
Previously if a Python package was compiled with some optflags, for instance,
```
  gcc -O3 test.c -o test.o
```
and some cflags were provided in `meta.yaml` with a different optimization level such as `cflags='-Oz'`, then they would be injected by `handle_command` at the beginning of the command as,
```
  emcc -Oz -O3 test.c -o test.o
```
Then because when multiple optimization options are passed, clang [would take the last one](https://stackoverflow.com/a/61831017/1791279) thus ignoring the optimization option from cflags.

This fixes this issue by only taking the optflag from cflags/cxxflags/ldflags when they are conflicting with earlier optflags present in the initial command.

A simpler way of solving this could have been to append clfags, etc instead of prepending them. However I feel this would result in harder to read logs with potentially conflicting information and it doesn't take that much work to fix it, as done in this PR