### PR TITLE
match host and target in case of multiple pythons

### DIFF
--- a/Makefile.envs
+++ b/Makefile.envs
@@ -9,8 +9,8 @@ SHELL := /bin/bash
 
 export PYVERSION=3.8.2
 export PYMINOR=$(basename $(PYVERSION))
-export HOSTPYTHONROOT=$(shell python -c "import sys; print(sys.prefix)")
-export HOSTPYTHON=$(HOSTPYTHONROOT)/bin/python3
+export HOSTPYTHONROOT=$(shell python3.8 -c "import sys; print(sys.prefix)")
+export HOSTPYTHON=$(HOSTPYTHONROOT)/bin/python3.8
 export TARGETPYTHONROOT=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)
 export PYTHONINCLUDE=$(PYODIDE_ROOT)/cpython/installs/python-$(PYVERSION)/include/python$(PYMINOR)
 


### PR DESCRIPTION
so cpython make install step can proceed in case of multiple python3.x in path
