### PR TITLE
[docs] rename files and fix broken links in quickstart 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ may be installed from PyPI to be used with Pyodide.
 
    usage/quickstart.md
    usage/webworker.md
-   usage/serving-pyodide-packages.md
+   usage/serving-pyodide-files.md
    usage/loading-packages.md
    usage/type-conversions.md
    usage/api-reference.md

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -6,15 +6,17 @@ This document describes using Pyodide directly from Javascript.
 
 ## Startup
 
-To include Pyodide in your project you can use the following CDN URL,
+To include Pyodide in your project you can use the following CDN URL:
 
+```html 
   https://cdn.jsdelivr.net/pyodide/v0.16.1/full/pyodide.js
+```
 
 You can also download a release from
 [Github releases](https://github.com/iodide-project/pyodide/releases)
 (or build it yourself), include its contents in your distribution, and import
-the `pyodide.js` file there from a `<script>` tag. See the following section on
-[serving pyodide files](#serving-pyodide-files) for more details.
+the `pyodide.js` file there from a `<script>` tag. Check
+{ref}`serving_pyodide_files` for more details.
 
 The `pyodide.js` file has a single `Promise` object which bootstraps the Python
 environment: `languagePluginLoader`. Since this must happen asynchronously, it
@@ -167,4 +169,4 @@ div.innerHTML = "<h1>This element was created from Python</h1>"
 js.document.body.prepend(div)
 ```
 
-See {ref}`serving_pyodide_packages` to distribute pyodide files locally.
+See {ref}`serving_pyodide_files` to distribute pyodide files locally.

--- a/docs/usage/serving-pyodide-files.md
+++ b/docs/usage/serving-pyodide-files.md
@@ -1,5 +1,5 @@
-(serving_pyodide_packages)=
-# Serving pyodide packages
+(serving_pyodide_files)=
+# Serving pyodide files
 
 
 If you built your pyodide distribution or downloaded the release tarball

--- a/docs/usage/serving-pyodide-files.md
+++ b/docs/usage/serving-pyodide-files.md
@@ -1,5 +1,5 @@
 (serving_pyodide_files)=
-# Serving pyodide files
+# Serving Pyodide files
 
 
 If you built your pyodide distribution or downloaded the release tarball


### PR DESCRIPTION
I was reading the quickstart on https://pyodide.readthedocs.io/en/latest/usage/quickstart.html 

It says:
> See the following section on [serving pyodide files](https://pyodide.readthedocs.io/en/latest/usage/quickstart.html#serving-pyodide-files) for more details.

That link goes nowhere. So I looked around the document and it seems that [Serving pyodide packages](https://pyodide.readthedocs.io/en/latest/usage/serving-pyodide-packages.html) is actually about "Serving pyodide files"

This PR:
- renames the file from `serving-pyodide-packages.md` to `serving-pyodide-files.md` and updates the title/reference.
- fixes the broken link. 
- updates the index.

I figured that this is the more "honest" way to fix the docs, but if renaming the files is a hassle or might cause some breaking changes for people with existing PRs... then you can reject this and I can just fix the broken link without file changes.