### PR TITLE
DOC fixes to quickstart >> "Accessing Python scope from Javascript"

### DIFF
--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -124,33 +124,39 @@ Create and save a test `index.html` page with the following contents:
 
 ## Accessing Python scope from Javascript
 
-You can also access from Javascript all functions and variables defined in Python using the {any}`pyodide.globals` object.
+You can access from Javascript all functions and variables defined in Python by using the {any}`pyodide.globals` object or {any}`pyodide.pyimport` .
 
-For example, if you initialize the variable `x = numpy.ones([3,3])` in Python, you can access it from Javascript in your browser's developer console as follows: `pyodide.globals.get("x")`. The same goes for functions and imports. See {ref}`type_conversions` for more details.
+For example, if you initialize the variable `x = numpy.ones([3,3])` in Python, you can access it from Javascript in your browser's developer console by using either `pyodide.globals.x` or `pyodide.pyimport('x')`. The same goes for functions and imports. See {ref}`type_conversions` for more details.
 
 You can try it yourself in the browser console:
 ```js
+pyodide.runPython(`import numpy`);
 pyodide.runPython(`x=numpy.ones([3, 3])`);
-pyodide.globals.get("x");
+pyodide.globals.x;
+pyodide.pyimport('x');
 // >>> [Float64Array(3), Float64Array(3), Float64Array(3)]
 
-// create the same 3x3 ndarray from js
-let x = pyodide.globals.get("numpy").ones(new Int32Array([3, 3]));
-// x >>> [Float64Array(3), Float64Array(3), Float64Array(3)]
+// update the ndarray from js
+x = pyodide.globals.numpy.ones(new Int32Array([4, 4]));
+// x >>> [ Float64Array(4), Float64Array(4), Float64Array(4), Float64Array(4) ]
 ```
 
 Since you have full scope access, you can also re-assign new values or even Javascript functions to variables, and create new ones from Javascript:
 
 ```js
 // re-assign a new value to an existing variable
-pyodide.globals.set("x", 'x will be now string');
+pyodide.globals.x = 'x will be now string';
 
 // create a new js function that will be available from Python
 // this will show a browser alert if the function is called from Python
-pyodide.globals.set("alert", alert);
+pyodide.globals.alert = alert;
 
 // this new function will also be available in Python and will return the squared value.
-pyodide.globals.set("square", x => x*x);
+pyodide.globals.square = x => x*x;
+
+// You can test your new Python function in the console by running
+pyodide.runPython(`square(3)`);
+
 ```
 
 Feel free to play around with the code using the browser console and the above example.


### PR DESCRIPTION
This PR fixes issues in the section **Accessing Python scope from Javascript** in the quickstart on [this link](https://pyodide.org/en/latest/usage/quickstart.html).

`pyodide.globals.get('x')` and `pyodide.globals.set()` do not seem to work. I figured that `pyodide.pyimport()` does... and I looked around the issues and saw that the correct syntax is `pyodide.globals.x`  (see screenshot at end).

So, this PR mentions both options, there seems to be no consensus on which is better ( see issue https://github.com/iodide-project/pyodide/issues/926 )

I also fixed things with the examples that uses numpy, so it all runs. For example, `let x` was creating a re-assignment issue, numpy needs to be imported and so on (also see screenshots)

## screenshot / before
<img width="745" alt="Screen Shot 2021-03-04 at 10 20 20 AM" src="https://user-images.githubusercontent.com/521705/110014339-eb2bce80-7cdf-11eb-81d4-6909c288b402.png">

<img width="727" alt="Screen Shot 2021-03-04 at 10 43 51 AM" src="https://user-images.githubusercontent.com/521705/110015600-47dbb900-7ce1-11eb-847c-09522801cd25.png">

