### PR TITLE
Fix top level await in runPythonAsync

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -519,7 +519,13 @@ globalThis.languagePluginLoader = (async () => {
    */
   Module.runPythonAsync = async function(code, messageCallback, errorCallback) {
     await Module.loadPackagesFromImports(code, messageCallback, errorCallback);
-    return Module.runPython(code);
+    let coroutine = Module.pyodide_py.eval_code_async(code, Module.globals);
+    try {
+      let result = await coroutine;
+      return result;
+    } finally {
+      coroutine.destroy();
+    }
   };
 
   // clang-format off

--- a/src/tests/test_pyodide.py
+++ b/src/tests/test_pyodide.py
@@ -229,7 +229,7 @@ def test_keyboard_interrupt(selenium):
 def test_run_python_async_toplevel_await(selenium):
     selenium.run_js(
         """
-        pyodide.runPythonAsync(`
+        await pyodide.runPythonAsync(`
             from js import fetch
             resp = await fetch("packages.json")
             json = await resp.json()


### PR DESCRIPTION
I forgot an "await" in the top level await test added in #1269 which left the test useless (an error occurs inside of a promise that we didn't await or attach a handler to, so the error just gets swallowed and the test passes anyways). I also accidentally reverted the change to `runPythonAsync` in the PR breaking the feature. This fixes the test and puts back in the change to `runPythonAsync` needed to make it work.