### PR TITLE
Print fatal error message when the fatal error occurs

### DIFF
--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -385,6 +385,10 @@ globalThis.languagePluginLoader = (async () => {
   Module.preloadedWasm = {};
   let isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
+  let fatal_error_msg =
+      "Pyodide has suffered a fatal error, refresh the page. " +
+      "Please report this to the Pyodide maintainers.";
+
   Module.fatal_error = function(e) {
     for (let [key, value] of Object.entries(Module.public_api)) {
       if (key.startsWith("_")) {
@@ -397,12 +401,10 @@ globalThis.languagePluginLoader = (async () => {
         continue;
       }
       if (typeof (value) === "function") {
-        Module.public_api[key] = function() {
-          throw Error("Pyodide has suffered a fatal error, refresh the page. " +
-                      "Please report this to the Pyodide maintainers.");
-        }
+        Module.public_api[key] = function() { throw Error(fatal_error_msg); }
       }
     }
+    console.error(fatal_error_msg);
     throw e;
   };
 

--- a/src/pyodide.js
+++ b/src/pyodide.js
@@ -383,12 +383,10 @@ globalThis.languagePluginLoader = (async () => {
   Module.noWasmDecoding =
       false; // we preload wasm using the built in plugin now
   Module.preloadedWasm = {};
-  let isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
   let fatal_error_msg =
       "Pyodide has suffered a fatal error, refresh the page. " +
       "Please report this to the Pyodide maintainers.";
-
   Module.fatal_error = function(e) {
     for (let [key, value] of Object.entries(Module.public_api)) {
       if (key.startsWith("_")) {
@@ -405,6 +403,7 @@ globalThis.languagePluginLoader = (async () => {
       }
     }
     console.error(fatal_error_msg);
+    console.error("The cause of the fatal error was:\n", e);
     throw e;
   };
 


### PR DESCRIPTION
Currently when there's a fatal error, it updates the various pyodide apis to throw an error saying that pyodide has fatally failed, and then it reraises the original error. However, it's a bit confusing because it first says there's been a fatal error the _next_ time a pyodide API is used. This adds a `console.error` to print the fatal error message before rethrowing the original error which should make it easier to locate where the problem actually occurred.