### PR TITLE
BLD handle gcc-arg-symbolic-functions

### DIFF
--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -310,6 +310,11 @@ def handle_command(line, args, dryrun=False):
             if arg in used_libs:
                 continue
             used_libs.add(arg)
+        # some gcc flags that clang does not support actually
+        if arg == "-Bsymbolic-functions":
+            continue
+        if arg == "-Wl,-Bsymbolic-functions":
+            continue            
         # threading is disabled for now
         if arg == "-pthread":
             continue

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -314,7 +314,7 @@ def handle_command(line, args, dryrun=False):
         if arg == "-Bsymbolic-functions":
             continue
         if arg == "-Wl,-Bsymbolic-functions":
-            continue            
+            continue
         # threading is disabled for now
         if arg == "-pthread":
             continue


### PR DESCRIPTION
this parameter is not supported by clang wasmcross replay and can be found on ubuntu/py3.8.5

cf https://github.com/iodide-project/pyodide/issues/884#issuecomment-796624765