### PR TITLE
Filter integers out of dir(js_array)

### DIFF
--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -353,7 +353,7 @@ EM_JS_REF(JsRef, hiwire_dir, (JsRef idobj), {
     result.push(... Object.getOwnPropertyNames(jsobj).filter(
       s => {
         let c = s.charCodeAt(0);
-        return c < 49 || c > 57; /* Filter out integer array indices */
+        return c < 48 || c > 57; /* Filter out integer array indices */
       }
     ));
     // clang-format on

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -349,7 +349,14 @@ EM_JS_REF(JsRef, hiwire_dir, (JsRef idobj), {
   let jsobj = Module.hiwire.get_value(idobj);
   let result = [];
   do {
-    result.push(... Object.getOwnPropertyNames(jsobj));
+    // clang-format off
+    result.push(... Object.getOwnPropertyNames(jsobj).filter(
+      s => {
+        let c = s.charCodeAt(0);
+        return c < 49 || c > 57; /* Filter out integer array indices */
+      }
+    ));
+    // clang-format on
   } while (jsobj = Object.getPrototypeOf(jsobj));
   return Module.hiwire.new_value(result);
 });

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -41,15 +41,22 @@ def test_jsproxy_dir(selenium):
     selenium.run_js(
         """
         window.a = [0,1,2,3,4,5,6,7,8,9];
+        a[27] = 0;
         a[":"] = 0;
         a["/"] = 0;
+        a.abcd = 0;
+        a.α = 0;
+
         pyodide.runPython(`
             from js import a
             d = dir(a)
             assert '0' not in d
             assert '9' not in d
+            assert '27' not in d
             assert ':' in d
             assert '/' in d
+            assert 'abcd' in d
+            assert 'α' in d
         `);
         """
     )

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -38,6 +38,15 @@ def test_jsproxy_dir(selenium):
     assert set1.issuperset(jsproxy_items)
     assert set1.issuperset(callable_items)
     assert set1.isdisjoint(a_items)
+    selenium.run_js(
+        """
+        window.a = [0];
+        pyodide.runPython(`
+            from js import a
+            assert '0' not in dir(a)
+        `);
+        """
+    )
 
 
 def test_jsproxy_getattr(selenium):

--- a/src/tests/test_jsproxy.py
+++ b/src/tests/test_jsproxy.py
@@ -40,10 +40,16 @@ def test_jsproxy_dir(selenium):
     assert set1.isdisjoint(a_items)
     selenium.run_js(
         """
-        window.a = [0];
+        window.a = [0,1,2,3,4,5,6,7,8,9];
+        a[":"] = 0;
+        a["/"] = 0;
         pyodide.runPython(`
             from js import a
-            assert '0' not in dir(a)
+            d = dir(a)
+            assert '0' not in d
+            assert '9' not in d
+            assert ':' in d
+            assert '/' in d
         `);
         """
     )


### PR DESCRIPTION
Javascript arrays list a bunch of integers among their ownKeys. I think that including these in `dir(js_array)` is generally undesirable: the point of `dir` is supposed to be for finding out which methods are available, if you want to know what keys an array contains it's more common to inspect the `length` field. This strips them out.