### PR TITLE
micropip improvements: fetch instead of XMLHttpRequest, async functions, remove memory leaks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -100,6 +100,9 @@ class SeleniumWrapper:
             let result = pyodide.runPython({code!r});
             if(result && result.toJs){{
                 let converted_result = result.toJs();
+                if(pyodide._module.PyProxy.isPyProxy(converted_result)){{
+                    converted_result = undefined;
+                }}
                 result.destroy();
                 return converted_result;
             }}
@@ -113,6 +116,9 @@ class SeleniumWrapper:
             let result = await pyodide.runPythonAsync({code!r});
             if(result && result.toJs){{
                 let converted_result = result.toJs();
+                if(pyodide._module.PyProxy.isPyProxy(converted_result)){{
+                    converted_result = undefined;
+                }}
                 result.destroy();
                 return converted_result;
             }}

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -113,6 +113,7 @@ substitutions:
 
 - {{ Feature }} `micropip` now supports installing wheels from relative urls.
   [#872](https://github.com/iodide-project/pyodide/pull/872)
+- {{ Change }} `micropip.install` now returns a Python `Future` instead of a Javascript `Promise`.
 
 ### Build system
 

--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -113,7 +113,7 @@ substitutions:
 
 - {{ Feature }} `micropip` now supports installing wheels from relative urls.
   [#872](https://github.com/iodide-project/pyodide/pull/872)
-- {{ Change }} `micropip.install` now returns a Python `Future` instead of a Javascript `Promise`.
+- {{ API }} `micropip.install` now returns a Python `Future` instead of a Javascript `Promise`.
 
 ### Build system
 

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -11,6 +11,7 @@ from distlib import markers, util, version
 
 import sys
 
+# Provide stubs for testing in native python
 IN_BROWSER = "js" in sys.modules
 
 if IN_BROWSER:
@@ -19,7 +20,6 @@ if IN_BROWSER:
 else:
     WHEEL_BASE = Path(".") / "wheels"
 
-# Implementations of HTTP fetching for in-browser and out-of-browser
 if IN_BROWSER:
     from js import fetch
 

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -9,18 +9,37 @@ from typing import Dict, Any, Union, List, Tuple
 
 from distlib import markers, util, version
 
+import sys
+IN_BROWSER = "js" in sys.modules
 
-try:
-    from js import XMLHttpRequest
+if IN_BROWSER:
+    # In practice, this is the `site-packages` directory.
+    WHEEL_BASE = Path(__file__).parent
+else:
+    WHEEL_BASE = Path(".") / "wheels"
+
+# Implementations of HTTP fetching for in-browser and out-of-browser
+if IN_BROWSER:
+    from js import fetch
+    async def _get_url(url):
+        resp = await fetch(url)
+        if not resp.ok:
+            raise OSError(f"Request for {url} failed with status {resp.status}: {resp.statusText}")
+        return io.BytesIO(await resp.arrayBuffer())
+else:
+    from urllib.request import urlopen
+    async def _get_url(url):
+        with urlopen(url) as fd:
+            content = fd.read()
+        return io.BytesIO(content)
+
+if IN_BROWSER:
     from js import pyodide as js_pyodide
-except ImportError:
-    XMLHttpRequest = None
-
+else:
     class js_pyodide:  # type: ignore
         """A mock object to allow import of this package outside pyodide
         Report that all dependencies are empty.
         """
-
         class _module:
             class packages:
                 class dependencies:
@@ -28,60 +47,22 @@ except ImportError:
                     def object_entries():
                         return []
 
-
-# Provide implementations of HTTP fetching for in-browser and out-of-browser to
-# make testing easier
-if XMLHttpRequest is not None:
-
-    async def _get_url(url):
-        req = XMLHttpRequest.new()
-        req.open("GET", url, True)
-        req.responseType = "arraybuffer"
-
-        fut = Future()
-
-        def callback(e):
-            if e.target.readyState == 4:
-                fut.set_result()
-
-        # TODO: this leaks the callback pyproxy, figure out how to reclaim it
-        req.onreadystatechange = callback
-        req.send(None)
-        await fut
-        # Not good enough to reclaim callback...
-        req.onreadystatechange = None
-        return io.BytesIO(req.response)
-
-    gather = asyncio.gather
-
-    # In practice, this is the `site-packages` directory.
-    WHEEL_BASE = Path(__file__).parent
+if IN_BROWSER:
+    from asyncio import gather
 else:
-    # Outside the browser
-    from urllib.request import urlopen
-
-    async def _get_url(url):
-        with urlopen(url) as fd:
-            content = fd.read()
-        return io.BytesIO(content)
-
-    WHEEL_BASE = Path(".") / "wheels"
-
-    # asyncio.gather will schedule any coroutines to run on the event loop which
-    # isn't running, so it will stall the program. In reality, everything is
-    # sync in this case anyways so just do everything in order.
+    # asyncio.gather will schedule any coroutines to run on the event loop but
+    # we want to avoid using the event loop at all. Instead just run the
+    # coroutines in sequence.
     async def gather(*coroutines):
         result = []
         for coroutine in coroutines:
             result.append(await coroutine)
         return result
 
-
 async def _get_pypi_json(pkgname):
     url = f"https://pypi.org/pypi/{pkgname}/json"
     fd = await _get_url(url)
     return json.load(fd)
-
 
 def _parse_wheel_url(url: str) -> Tuple[str, Dict[str, Any], str]:
     """Parse wheels url and extract available metadata

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -8,26 +8,24 @@ sys.path.append(str(Path(__file__).resolve().parent / "micropip"))
 
 
 def test_install_simple(selenium_standalone):
-    selenium_standalone.run("import os")
-    selenium_standalone.load_package("micropip")
-    selenium_standalone.run("import micropip")
-    selenium_standalone.run("micropip.install('pyodide-micropip-test')")
-    # Package 'pyodide-micropip-test' has dependency on 'snowballstemmer'
-    # It is used to test markers support
-
-    for i in range(10):
-        if selenium_standalone.run(
-            "os.path.exists" "('/lib/python3.8/site-packages/snowballstemmer')"
-        ):
-            break
-        else:
-            time.sleep(1)
-
-    selenium_standalone.run("import snowballstemmer")
-    selenium_standalone.run("stemmer = snowballstemmer.stemmer('english')")
-    assert selenium_standalone.run(
-        "stemmer.stemWords('go going goes gone'.split())"
-    ) == ["go", "go", "goe", "gone"]
+    assert (
+        selenium_standalone.run_js(
+            """
+        let result = await pyodide.runPythonAsync(`
+            import os
+            import micropip
+            # Package 'pyodide-micropip-test' has dependency on 'snowballstemmer'
+            # It is used to test markers support
+            await micropip.install('pyodide-micropip-test')
+            import snowballstemmer
+            stemmer = snowballstemmer.stemmer('english')
+            stemmer.stemWords('go going goes gone'.split())
+        `);
+        return result.toJs();
+        """
+        )
+        == ["go", "go", "goe", "gone"]
+    )
 
 
 def test_parse_wheel_url():
@@ -61,14 +59,17 @@ def test_parse_wheel_url():
 
 def test_install_custom_url(selenium_standalone, web_server_tst_data):
     server_hostname, server_port, server_log = web_server_tst_data
-    selenium_standalone.load_package("micropip")
-    selenium_standalone.run("import micropip")
     base_url = f"http://{server_hostname}:{server_port}/"
     url = base_url + "snowballstemmer-2.0.0-py2.py3-none-any.whl"
-    selenium_standalone.run(f"micropip.install('{url}')")
-    # wait untill micropip is loaded
-    time.sleep(1)
-    selenium_standalone.run("import snowballstemmer")
+    selenium_standalone.run_js(
+        f"""
+        await pyodide.runPythonAsync(`
+            import micropip
+            await micropip.install('{url}')
+            import snowballstemmer
+        `);
+        """
+    )
 
 
 def test_add_requirement_relative_url():
@@ -76,9 +77,16 @@ def test_add_requirement_relative_url():
     import micropip
 
     transaction = {"wheels": []}
-    micropip.PACKAGE_MANAGER.add_requirement(
+    coroutine = micropip.PACKAGE_MANAGER.add_requirement(
         "./snowballstemmer-2.0.0-py2.py3-none-any.whl", {}, transaction
     )
+    try:
+        coroutine.send(None)
+    except StopIteration as result:
+        pass
+    else:
+        raise Exception("Coroutine didn't finish in one pass")
+
     [name, req, version] = transaction["wheels"][0]
     assert name == "snowballstemmer"
     assert version == "2.0.0"
@@ -91,19 +99,21 @@ def test_add_requirement_relative_url():
 
 
 def test_install_custom_relative_url(selenium_standalone):
-    selenium_standalone.load_package("micropip")
-    selenium_standalone.run("import micropip")
-
     root = Path(__file__).resolve().parents[2]
     src = root / "src" / "tests" / "data"
     target = root / "build" / "test_data"
     target.symlink_to(src, True)
+    url = "./test_data/snowballstemmer-2.0.0-py2.py3-none-any.whl"
     try:
-        url = "./test_data/snowballstemmer-2.0.0-py2.py3-none-any.whl"
-        selenium_standalone.run(f"micropip.install('{url}')")
-        # wait untill micropip is loaded
-        time.sleep(1)
-        selenium_standalone.run("import snowballstemmer")
+        selenium_standalone.run_js(
+            f"""
+            await pyodide.runPythonAsync(`
+                import micropip
+                await micropip.install('{url}')
+                import snowballstemmer
+            `)
+            """
+        )
     finally:
         target.unlink()
 

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -82,7 +82,7 @@ def test_add_requirement_relative_url():
     )
     try:
         coroutine.send(None)
-    except StopIteration as result:
+    except StopIteration as _result:
         pass
     else:
         raise Exception("Coroutine didn't finish in one pass")

--- a/packages/micropip/test_micropip.py
+++ b/packages/micropip/test_micropip.py
@@ -80,6 +80,9 @@ def test_add_requirement_relative_url():
     coroutine = micropip.PACKAGE_MANAGER.add_requirement(
         "./snowballstemmer-2.0.0-py2.py3-none-any.whl", {}, transaction
     )
+    # The following is a way to synchronously run a coroutine that does only
+    # synchronous operations (and assert that it indeed only did synch
+    # operations)
     try:
         coroutine.send(None)
     except StopIteration as _result:

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 

--- a/src/tests/test_python.py
+++ b/src/tests/test_python.py
@@ -9,8 +9,7 @@ def test_init(selenium_standalone):
 
 
 def test_webbrowser(selenium):
-    selenium.run("import antigravity")
-    time.sleep(2)
+    selenium.run_async("import antigravity")
     assert len(selenium.driver.window_handles) == 2
 
 

--- a/src/tests/test_webworker.py
+++ b/src/tests/test_webworker.py
@@ -54,12 +54,11 @@ def test_runwebworker_exception_after_import(selenium_standalone):
 def test_runwebworker_micropip(selenium_standalone):
     output = selenium_standalone.run_webworker(
         """
-        def stem(*args):
-            import snowballstemmer
-            stemmer = snowballstemmer.stemmer('english')
-            return stemmer.stemWords('go goes going gone'.split())[0]
         import micropip
-        micropip.install('snowballstemmer').then(stem)
+        await micropip.install('snowballstemmer')
+        import snowballstemmer
+        stemmer = snowballstemmer.stemmer('english')
+        stemmer.stemWords('go goes going gone'.split())[0]
         """
     )
     assert output == "go"


### PR DESCRIPTION
Micropip used a synchronous `XMLHttpRequest` to fetch the json header data from PyPi. Synchronous http requests are deprecated on the main thread and it generates a deprecation warning. Furthermore, the `XMLHttpRequest` API itself is pretty lousy and the `fetch` API should be used instead. Using the `fetch` API allows much simpler code and also avoids leaking the callback that we need to attach to the `XMLHttpRequest`. Avoiding the synchronous requests means that we can now fetch all the header data for all the packages we are loading simultaneously, rather than waiting for one request to finish before the next starts.

Micropip was designed with a fair amount of callback hell before. Now that we have full support for asyncio, we can just `await` the `fetch` API directly, at the cost of requiring the `_get_url()` function to be marked as `async`. This also requires the entire tree of functions calling `_get_url` to be marked `async` and allows us to get rid of all of the `resolve` and `reject` and `callback` callback hell parameters. Also, rather than manually counting how many requests have been resolved, I switched to using `asyncio.gather`.

The one issue here is that `asyncio.gather` schedules coroutines on the event loop, but for testing purposes we'd rather avoid using an event loop at all. For this I made a mock version of `gather` that just runs the coroutines in order.

Finally, rather than returning a promise, I switched to returning a future. This has several benefits: shorter code, more idiomatic python, it works the same natively (so now with a trivial mock event loop one could test the main entry point) and it avoids leaking the promise executor.

Similar changes probably should be made to `console.py` which leaks a bunch of python closures in the same way.

**API Change:** Now returns a `Future` instead of a `Promise`. When using from Javascript, this isn't be noticeable since `Future`s get wrapped in a `Promise`. When using from Python, the API is different but in trade we avoid memory leaks.