### PR TITLE
Use Python Futures and async instead of Promises in console.py

### DIFF
--- a/src/pyodide-py/pyodide/console.py
+++ b/src/pyodide-py/pyodide/console.py
@@ -13,7 +13,8 @@ IN_BROWSER = "js" in sys.modules
 if IN_BROWSER:
     from js.pyodide import loadPackagesFromImports as _load_packages_from_imports
 else:
-    def _load_packages_from_imports(*args): # type: ignore
+
+    def _load_packages_from_imports(*args):  # type: ignore
         fut = Future()
         fut.set_result(None)
         return fut
@@ -193,9 +194,14 @@ class InteractiveConsole(code.InteractiveConsole):
             return super().runsource(*args, **kwargs)
 
     if IN_BROWSER:
+
         def runcode(self, code):
-            self.run_complete = ensure_future(self.runcode_async(code, self.run_complete))
+            self.run_complete = ensure_future(
+                self.runcode_async(code, self.run_complete)
+            )
+
     else:
+
         def runcode(self, code):
             coroutine = self.runcode_async(code, self.run_complete)
             try:

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -57,7 +57,9 @@
             for( const c of command.split('\n') ) {
                 const prompt = pyconsole.push(c) ? ps2 : ps1;
                 term.set_prompt(prompt);
-                await pyconsole.run_complete;
+                run_complete = pyconsole.run_complete;
+                await run_complete;
+                run_complete.destroy();
             }
             term.resume();
         }
@@ -69,7 +71,9 @@
             prompt: ps1,
             completionEscape: false,
             completion: function(command, callback) {
-              callback(pyconsole.complete(command).toJs()[0]);
+              let proxy = pyconsole.complete(command);
+              callback(proxy[0]);
+              proxy.destroy();
             }
           }
         );

--- a/src/tests/test_console.py
+++ b/src/tests/test_console.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 import sys
 import io
+import time
 
 sys.path.append(str(Path(__file__).parents[2] / "src" / "pyodide-py"))
 
@@ -140,11 +141,12 @@ def safe_selenium_sys_redirections(selenium):
 
 def test_interactive_console(selenium, safe_selenium_sys_redirections):
     def ensure_run_completed():
+        time.sleep(0.5)
         selenium.driver.execute_async_script(
             """
-        const done = arguments[arguments.length - 1];
-        pyodide.globals.get("shell").run_complete.then(done);
-        """
+            const done = arguments[arguments.length - 1];
+            pyodide.globals.get("shell").run_complete.then(done);
+            """
         )
 
     selenium.run(


### PR DESCRIPTION
This is similar to #1324. The current `console.py` leaks the `load_packages_and_run` and `run` closures by using them with the `promise.then` api. Instead, using a `Future` avoids the leak.