### PR TITLE
DOC Add Safari compatibility in release notes

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -13,9 +13,11 @@ substitutions:
 ## Version [Unreleased]
 
 ### Improvements to package loading and dynamic linking
-- {{Enhancement}} Uses the emscripten preload plugin system to preload .so files in packages
-- {{Enhancement}} Support for shared library packages. This is used for CLAPACK which makes scipy a lot smaller.
-  [#1236] https://github.com/iodide-project/pyodide/pull/1236
+- {{ Enhancement }} Uses the emscripten preload plugin system to preload .so files in packages
+- {{ Enhancement }} Support for shared library packages. This is used for CLAPACK which makes scipy a lot smaller.
+  [#1236](https://github.com/iodide-project/pyodide/pull/1236)
+- {{ Fix }} Pyodide and included packages can now be used with Safari v14+.
+  Safari v13 has also been observed to work on some (but not all) devices.
 
 ### Python / JS type conversions
 - {{ Feature }} A `JsProxy` of a Javascript `Promise` or other awaitable object is now a


### PR DESCRIPTION
Closes https://github.com/iodide-project/pyodide/issues/721 Closes https://github.com/iodide-project/pyodide/issues/524

I have confirmed that master works fine on Safari v14 https://github.com/iodide-project/pyodide/issues/721#issuecomment-797117141