### PR TITLE
MAINT Compile core with -Wall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ benchmark: all
 
 clean:
 	rm -fr build/*
-	rm -fr src/*.o
+	rm -fr src/*/*.o
 	rm -fr node_modules
 	make -C packages clean
 	echo "The Emsdk, CPython are not cleaned. cd into those directories to do so."

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ CFLAGS=\
 	-g \
 	-I$(PYTHONINCLUDE) \
 	-fPIC \
+	-Wall \
 	-Wno-warn-absolute-paths \
+	-Werror=unused-variable \
 	-Werror=int-conversion \
 	-Werror=incompatible-pointer-types \
 	$(EXTRA_CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ CFLAGS=\
 	-Wall \
 	-Wno-warn-absolute-paths \
 	-Werror=unused-variable \
+	-Werror=sometimes-uninitialized \
 	-Werror=int-conversion \
 	-Werror=incompatible-pointer-types \
 	$(EXTRA_CFLAGS)

--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -94,7 +94,7 @@ wrap_exception(bool attach_python_error)
   PyObject* type = NULL;
   PyObject* value = NULL;
   PyObject* traceback = NULL;
-  PyObject* pystr;
+  PyObject* pystr = NULL;
   JsRef pyexc_proxy = NULL;
   JsRef jserror = NULL;
 

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -199,8 +199,6 @@ finally:
 static PyObject*
 JsProxy_RichCompare(PyObject* a, PyObject* b, int op)
 {
-  JsProxy* aproxy = (JsProxy*)a;
-
   if (!JsProxy_Check(b)) {
     switch (op) {
       case Py_EQ:
@@ -818,6 +816,7 @@ JsMethod_Vectorcall(PyObject* self,
                     PyObject* kwnames)
 {
   bool kwargs = false;
+  bool success = false;
   if (kwnames != NULL) {
     // There were kwargs? But maybe kwnames is the empty tuple?
     PyObject* kwname = PyTuple_GetItem(kwnames, 0); /* borrowed!*/
@@ -846,7 +845,6 @@ JsMethod_Vectorcall(PyObject* self,
 
   // Recursion error?
   FAIL_IF_NONZERO(Py_EnterRecursiveCall(" in JsProxy_Vectorcall"));
-  bool success = false;
   JsRef idargs = NULL;
   JsRef idkwargs = NULL;
   JsRef idarg = NULL;

--- a/src/core/jsproxy.c
+++ b/src/core/jsproxy.c
@@ -817,6 +817,12 @@ JsMethod_Vectorcall(PyObject* self,
 {
   bool kwargs = false;
   bool success = false;
+  JsRef idargs = NULL;
+  JsRef idkwargs = NULL;
+  JsRef idarg = NULL;
+  JsRef idresult = NULL;
+  PyObject* pyresult = NULL;
+
   if (kwnames != NULL) {
     // There were kwargs? But maybe kwnames is the empty tuple?
     PyObject* kwname = PyTuple_GetItem(kwnames, 0); /* borrowed!*/
@@ -845,11 +851,6 @@ JsMethod_Vectorcall(PyObject* self,
 
   // Recursion error?
   FAIL_IF_NONZERO(Py_EnterRecursiveCall(" in JsProxy_Vectorcall"));
-  JsRef idargs = NULL;
-  JsRef idkwargs = NULL;
-  JsRef idarg = NULL;
-  JsRef idresult = NULL;
-  PyObject* pyresult = NULL;
 
   Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
   idargs = hiwire_array();

--- a/src/core/python2js.c
+++ b/src/core/python2js.c
@@ -192,7 +192,6 @@ static JsRef
 _python2js_set(PyObject* x, PyObject* cache, int depth)
 {
   bool success = false;
-  bool cached = false;
   PyObject* iter = NULL;
   PyObject* pykey = NULL;
   JsRef jskey = NULL;


### PR DESCRIPTION
Related to https://github.com/iodide-project/pyodide/pull/1335 adds `-Wall` to CFLAGS for core.

Fixes a few unused variables. The function `_python2js_bytes` is also never used currently, I'm not sure if it's an error or if we should remove it.

There are a few remaining `-Wsometimes-uninitialized` warnings, such as,
```
src/core/jsproxy.c:847:3: warning: variable 'idkwargs' is used uninitialized whenever 'if' conditio
n is true [-Wsometimes-uninitialized]                                                              
  FAIL_IF_NONZERO(Py_EnterRecursiveCall(" in JsProxy_Vectorcall"));                                
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                 
src/core/error_handling.h:166:9: note: expanded from macro 'FAIL_IF_NONZERO'                       
    if ((num) != 0) {                                                          \                   
        ^~~~~~~~~~                                                                                 
src/core/jsproxy.c:889:16: note: uninitialized use occurs here                                     
  hiwire_CLEAR(idkwargs);                                                                          
               ^~~~~~~~                                                                            
src/core/hiwire.h:49:19: note: expanded from macro 'hiwire_CLEAR'                                  
    hiwire_decref(x);                                                          \                   
                  ^                                                                                
src/core/jsproxy.c:847:3: note: remove the 'if' if its condition is always false                   
  FAIL_IF_NONZERO(Py_EnterRecursiveCall(" in JsProxy_Vectorcall"));                                
  ^
src/core/error_handling.h:166:5: note: expanded from macro 'FAIL_IF_NONZERO'
    if ((num) != 0) {                                                          \
    ^
src/core/jsproxy.c:849:3: note: variable 'idkwargs' is declared here
  JsRef idkwargs = NULL; 
```
cc @hoodmane 
we probably should add `-Werror=sometimes-uninitialized` to the compilation flags.


