### PR TITLE
Minor improvements to build handling of PYODIDE_PACKAGES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,9 +190,9 @@ check:
 	./tools/dependency-check.sh
 
 minimal :
-	PYODIDE_PACKAGES="micropip" make
+	PYODIDE_PACKAGES+=",micropip" make
 
 debug :
-	EXTRA_CFLAGS+="-D DEBUG_F" \
-	PYODIDE_PACKAGES+="micropip,pyparsing,pytz,packaging,kiwisolver" \
+	EXTRA_CFLAGS+=" -D DEBUG_F" \
+	PYODIDE_PACKAGES+=", micropip, pyparsing, pytz, packaging, kiwisolver, " \
 	make

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -5,7 +5,7 @@ include ../Makefile.envs
 all:
 	mkdir -p $(PYODIDE_LIBRARIES)
 	PYTHONPATH=$(PYODIDE_LIBRARIES)/lib/python ../bin/pyodide buildall . ../build \
-		--target=$(TARGETPYTHONROOT) --only $(PYODIDE_PACKAGES) --install-dir $(PYODIDE_LIBRARIES)
+		--target=$(TARGETPYTHONROOT) --only "$(PYODIDE_PACKAGES)" --install-dir $(PYODIDE_LIBRARIES)
 
 update-all:
 	for pkg in $$(find . -maxdepth 1 -type d -exec basename {} \; | tail -n +2); do \

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -3,7 +3,6 @@ PYODIDE_LIBRARIES=$(abspath ./.artifacts)
 include ../Makefile.envs
 
 ifeq ($(strip $(PYODIDE_PACKAGES)),)
-	ONLY_PACKAGES=""
 else
 	ONLY_PACKAGES=--only "$(PYODIDE_PACKAGES)"
 endif

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -2,10 +2,17 @@ export PYODIDE_ROOT=$(abspath ..)
 PYODIDE_LIBRARIES=$(abspath ./.artifacts)
 include ../Makefile.envs
 
+ifeq ($(strip $(PYODIDE_PACKAGES)),)
+	ONLY_PACKAGES=""
+else
+	ONLY_PACKAGES=--only "$(PYODIDE_PACKAGES)"
+endif
+
 all:
 	mkdir -p $(PYODIDE_LIBRARIES)
 	PYTHONPATH=$(PYODIDE_LIBRARIES)/lib/python ../bin/pyodide buildall . ../build \
-		--target=$(TARGETPYTHONROOT) --only "$(PYODIDE_PACKAGES)" --install-dir $(PYODIDE_LIBRARIES)
+		--target=$(TARGETPYTHONROOT) $(ONLY_PACKAGES) --install-dir $(PYODIDE_LIBRARIES)
+
 
 update-all:
 	for pkg in $$(find . -maxdepth 1 -type d -exec basename {} \; | tail -n +2); do \

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -129,8 +129,6 @@ def generate_dependency_graph(
 
     while packages:
         pkgname = packages.pop()
-        if not pkgname:
-            continue
 
         pkg = Package(packages_dir / pkgname)
         pkg_map[pkg.name] = pkg

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -302,7 +302,7 @@ def make_parser(parser):
         nargs="?",
         default=None,
         help=(
-            "Only build the specified packages, provided as a comma " "separated list"
+            "Only build the specified packages, provided as a comma-separated list"
         ),
     )
     parser.add_argument(

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -301,9 +301,7 @@ def make_parser(parser):
         type=str,
         nargs="?",
         default=None,
-        help=(
-            "Only build the specified packages, provided as a comma-separated list"
-        ),
+        help=("Only build the specified packages, provided as a comma-separated list"),
     )
     parser.add_argument(
         "--n-jobs",

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -129,6 +129,8 @@ def generate_dependency_graph(
 
     while packages:
         pkgname = packages.pop()
+        if not pkgname:
+            continue
 
         pkg = Package(packages_dir / pkgname)
         pkg_map[pkg.name] = pkg

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -39,7 +39,7 @@ def _parse_package_subset(query: Optional[str]) -> Optional[Set[str]]:
     packages = {el.strip() for el in query.split(",")}
     packages.update(["micropip", "distlib"])
     packages.discard("")
-    return set(packages)
+    return packages
 
 
 def file_packager_path() -> Path:

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -36,7 +36,7 @@ def _parse_package_subset(query: Optional[str]) -> Optional[Set[str]]:
     """
     if query is None:
         return None
-    packages = set([el.strip() for el in query.split(",")])
+    packages = {el.strip() for el in query.split(",")}
     packages.update(["micropip", "distlib"])
     packages.discard("")
     return set(packages)

--- a/pyodide_build/common.py
+++ b/pyodide_build/common.py
@@ -36,9 +36,9 @@ def _parse_package_subset(query: Optional[str]) -> Optional[Set[str]]:
     """
     if query is None:
         return None
-    packages = query.split(",")
-    packages = [el.strip() for el in packages]
-    packages = ["micropip", "distlib"] + packages
+    packages = set([el.strip() for el in query.split(",")])
+    packages.update(["micropip", "distlib"])
+    packages.discard("")
     return set(packages)
 
 

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -18,3 +18,14 @@ def test_parse_package_subset():
 
     # duplicates are removed
     assert _parse_package_subset("numpy,numpy") == {"micropip", "distlib", "numpy"}
+
+    # no empty package name included, spaces are handled
+    assert _parse_package_subset("x,  a, b, c   ,,, d,,") == {
+        "micropip",
+        "distlib",
+        "x",
+        "a",
+        "b",
+        "c",
+        "d",
+    }


### PR DESCRIPTION
Allow spaces, leading / trailing comma in `PYODIDE_PACKAGES`. This makes `PYODIDE_PACKAGES="somepkg" make debug` work as expected (builds `somepkg` in addition to the standard list). 

Currently would result in `PYODIDE_PACKAGES` that looks like `somepkgmicropip,...` which leads to an error because no package named `somepkgmicropip` exists. Currently you can say `PYODIDE_PACKAGES="somepkg," make debug` but `PYODIDE_PACKAGES="somepkg," make` doesn't work because of the trailing comma.