### PR TITLE
DOC Update project history and infrastructure support sections

### DIFF
--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -15,12 +15,13 @@ Python. When used inside a browser, Python has full access to the Web APIs.
 ## History
 
 Pyodide was created in 2018 by [Michael Droettbom](https://github.com/mdboom)
-at Mozilla as part of the [iodide project](https://iodide.io), an environment
-for *literate scientific computing and communication for the web*.
+at Mozilla as part of the [iodide project](https://iodide.io), a set of experiments around
+scientific computing and communication for the web.
 
-At present Pyodide is an independent and community driven open-source project. The decision
-making process is outlined in the {ref}`project governance
-<project_governance>`.
+At present Pyodide is an independent and community driven open-source project.
+The decision making process is outlined in the {ref}`project governance
+<project_governance>`. Pyodide may be used standalone in any context where you
+want to run Python inside a web browser.
 
 ## Infrastructure support
 

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -19,9 +19,9 @@ at Mozilla as part of the [iodide project](https://iodide.io), a set of experime
 scientific computing and communication for the web.
 
 At present Pyodide is an independent and community driven open-source project.
-The decision making process is outlined in the {ref}`project governance
-<project_governance>`. Pyodide may be used standalone in any context where you
-want to run Python inside a web browser.
+The decision making process is outlined in the {ref}`project governance <project-governance>`.
+Pyodide may be used standalone in any context where you want to run Python
+inside a web browser.
 
 ## Infrastructure support
 

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -14,7 +14,7 @@ Python. When used inside a browser, Python has full access to the Web APIs.
 
 ## History
 
-Pyodide was created in 2018 by [Michael Droettbom](https://github.com/mdboom)
+Pyodide was created in 2018 by [Michael Droettboom](https://github.com/mdboom)
 at Mozilla as part of the [iodide project](https://iodide.io), a set of experiments around
 scientific computing and communication for the web.
 

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -15,7 +15,7 @@ Python. When used inside a browser, Python has full access to the Web APIs.
 ## History
 
 Pyodide was created in 2018 by [Michael Droettboom](https://github.com/mdboom)
-at Mozilla as part of the [iodide project](https://iodide.io), a set of experiments around
+at Mozilla as part of the [iodide project](https://github.com/iodide-project/iodide), a set of experiments around
 scientific computing and communication for the web.
 
 At present Pyodide is an independent and community driven open-source project.

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -6,13 +6,26 @@ Pyodide brings the Python runtime to the browser via WebAssembly, along with
 the Python scientific stack including NumPy, Pandas, Matplotlib, parts of
 SciPy, and NetworkX. The [packages
 directory](https://github.com/iodide-project/pyodide/tree/master/packages)
-lists over 35 packages which are currently available.
+lists over 75 packages which are currently available. In addition it's possible
+to install pure Python wheels from PyPi.
 
 Pyodide provides transparent conversion of objects between Javascript and
 Python. When used inside a browser, Python has full access to the Web APIs.
 
-While closely related to the [iodide project](https://iodide.io), a tool for
-*literate scientific computing and communication for the web*, Pyodide goes
-beyond running in a notebook environment. To maximize the flexibility of the
-modern web, **Pyodide** may be used standalone in any context where you want to
-**run Python inside a web browser**.
+## History
+
+Pyodide was created in 2018 by [Michael Droettbom](https://github.com/mdboom)
+at Mozilla as part of the [iodide project](https://iodide.io), an environment
+for *literate scientific computing and communication for the web*.
+
+At present Pyodide is an independent and community driven open-source project. The decision
+making process is outlined in the {ref}`project governance
+<project_governance>`.
+
+## Infrastructure support
+
+We would also like to thank,
+ - [Mozilla](https://www.mozilla.org/en-US/) and
+[CircleCl](https://circleci.com/) for Continuous Integration resources
+ - [JsDelivr](https://www.jsdelivr.com/) for providing a CDN for pyodide packages
+ - [ReadTheDocs](https://readthedocs.org/) for hosting the documentation.

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -1,4 +1,5 @@
-# pyodide governance and decision-making
+(project_governance)=
+# Pyodide governance and decision-making
 
 The purpose of this document is to formalize the governance process used by the
 pyodide project, to clarify how decisions are made and how the various

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -1,4 +1,4 @@
-(project_governance)=
+(project-governance)=
 # Pyodide governance and decision-making
 
 The purpose of this document is to formalize the governance process used by the


### PR DESCRIPTION
I added the documentation sections about the project history and infractructure support, as part of https://github.com/iodide-project/pyodide/issues/1217

 @wlach @mdboom @bcolloran @hamilton @teonbrooks  If there are other things you would like to add there, for instance about the Iodide project there please don't hesitate to comment.