### PR TITLE
Remove as_nested_list

### DIFF
--- a/docs/project/changelog.md
+++ b/docs/project/changelog.md
@@ -27,6 +27,8 @@ substitutions:
   are now wrapped in `PyProxy`. Added a new `toJs` API to `PyProxy` to request the
   conversion behavior that used to be implicit.
   [#1167](https://github.com/iodide-project/pyodide/pull/1167)
+- {{ API }} Added `JsProxy.to_py` API to convert a Javascript object to Python.
+  [#1244](https://github.com/iodide-project/pyodide/pull/1244)
 - {{ Feature }} Flexible jsimports: it now possible to add custom Python
   "packages" backed by Javascript code, like the `js` package.  The `js` package
   is now implemented using this system.
@@ -85,6 +87,9 @@ substitutions:
   available by default and automatically enabled by any relevant asyncio API,
   so for instance `asyncio.ensure_future` works without any configuration.
   [#1158](https://github.com/iodide-project/pyodide/pull/1158)
+- {{ API }} Removed `as_nested_list` API in favor of `JsProxy.to_py`.
+  [#1345](https://github.com/iodide-project/pyodide/pull/1345)
+
 
 ### pyodide-js
 

--- a/docs/usage/api-reference.md
+++ b/docs/usage/api-reference.md
@@ -11,7 +11,6 @@ Backward compatibility of the API is not guaranteed at this point.
 .. autosummary::
    :toctree: ./python-api/
 
-   pyodide.as_nested_list
    pyodide.eval_code
    pyodide.find_imports
    pyodide.open_url

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -1,4 +1,4 @@
-from ._base import open_url, eval_code, eval_code_async, find_imports, as_nested_list
+from ._base import open_url, eval_code, eval_code_async, find_imports
 from ._core import JsException, create_once_callable, create_proxy  # type: ignore
 from ._importhooks import JsFinder
 from .webloop import WebLoopPolicy
@@ -22,7 +22,6 @@ __all__ = [
     "eval_code",
     "eval_code_async",
     "find_imports",
-    "as_nested_list",
     "JsException",
     "register_js_module",
     "unregister_js_module",

--- a/src/pyodide-py/pyodide/_base.py
+++ b/src/pyodide-py/pyodide/_base.py
@@ -420,25 +420,3 @@ def find_imports(code: str) -> List[str]:
                 continue
             imports.add(module_name.split(".")[0])
     return list(sorted(imports))
-
-
-def as_nested_list(obj) -> List:
-    """Convert a nested JS array to nested Python list.
-
-    Assumes a Javascript object is made of (possibly nested) arrays and
-    converts them to nested Python lists.
-
-    Parameters
-    ----------
-    obj
-       a Javscript object made of nested arrays.
-
-    Returns
-    -------
-    Python list, or a nested Python list
-    """
-    try:
-        it = iter(obj)
-        return [as_nested_list(x) for x in it]
-    except TypeError:
-        return obj


### PR DESCRIPTION
The `JsProxy.to_py` API subsumes this functionality.