### PR TITLE
Shorten pytest summary table test names (from #1340)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -49,6 +49,7 @@ def pytest_configure(config):
     of a test for the short summary table. Monkey patch it to reduce the verbosity of the test names in the table.
     This leaves enough room to see the information about the test failure in the summary.
     """
+    filter = config.getoption("-k").strip()
     old_cwd_relative_nodeid = config.cwd_relative_nodeid
 
     def cwd_relative_nodeid(*args):
@@ -56,10 +57,12 @@ def pytest_configure(config):
         result = result.replace("src/tests/", "")
         result = result.replace("packages/", "")
         result = result.replace("::test_", "::")
-        result = result.replace("[chrome]", "")
-        result = result.replace("[firefox]", "")
-        result = result.replace("chrome-", "")
-        result = result.replace("firefox-", "")
+        if filter == "chrome":
+            result = result.replace("[chrome]", "")
+            result = result.replace("chrome-", "")
+        if filter == "firefox":
+            result = result.replace("[firefox]", "")
+            result = result.replace("firefox-", "")
         return result
 
     config.cwd_relative_nodeid = cwd_relative_nodeid

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,8 @@ import queue
 import sys
 import shutil
 
+import pytest
+
 ROOT_PATH = pathlib.Path(__file__).parents[0].resolve()
 TEST_PATH = ROOT_PATH / "src" / "tests"
 BUILD_PATH = ROOT_PATH / "build"
@@ -25,6 +27,7 @@ import selenium.webdriver.common.utils  # noqa: E402
 # XXX: Temporary fix for ConnectionError in selenium
 
 selenium.webdriver.common.utils.is_connectable = _selenium_is_connectable
+
 
 def pytest_addoption(parser):
     group = parser.getgroup("general")
@@ -40,10 +43,11 @@ def pytest_addoption(parser):
         help="If provided, tests marked as xfail will be run",
     )
 
+
 def pytest_configure(config):
     """Monkey patch the function cwd_relative_nodeid returns the description
-        of a test for the short summary table. Monkey patch it to reduce the verbosity of the test names in the table.
-        This leaves enough room to see the information about the test failure in the summary.
+    of a test for the short summary table. Monkey patch it to reduce the verbosity of the test names in the table.
+    This leaves enough room to see the information about the test failure in the summary.
     """
     old_cwd_relative_nodeid = config.cwd_relative_nodeid
 
@@ -258,6 +262,7 @@ def selenium_common(request, web_server_main):
     finally:
         selenium.driver.quit()
 
+
 @pytest.fixture(params=["firefox", "chrome"], scope="function")
 def selenium_standalone(request, web_server_main):
     with selenium_common(request, web_server_main) as selenium:
@@ -266,11 +271,13 @@ def selenium_standalone(request, web_server_main):
         finally:
             print(selenium.logs)
 
+
 # selenium instance cached at the module level
 @pytest.fixture(params=["firefox", "chrome"], scope="module")
 def selenium_module_scope(request, web_server_main):
     with selenium_common(request, web_server_main) as selenium:
         yield selenium
+
 
 # We want one version of this decorated as a function-scope fixture and one
 # version decorated as a context manager.
@@ -280,6 +287,7 @@ def selenium_per_function(selenium_module_scope):
         yield selenium_module_scope
     finally:
         print(selenium_module_scope.logs)
+
 
 selenium = pytest.fixture(selenium_per_function)
 # Hypothesis is unhappy with function scope fixtures. Instead, use the

--- a/conftest.py
+++ b/conftest.py
@@ -49,7 +49,6 @@ def pytest_configure(config):
     of a test for the short summary table. Monkey patch it to reduce the verbosity of the test names in the table.
     This leaves enough room to see the information about the test failure in the summary.
     """
-    filter = config.getoption("-k").strip()
     old_cwd_relative_nodeid = config.cwd_relative_nodeid
 
     def cwd_relative_nodeid(*args):
@@ -57,12 +56,6 @@ def pytest_configure(config):
         result = result.replace("src/tests/", "")
         result = result.replace("packages/", "")
         result = result.replace("::test_", "::")
-        if filter == "chrome":
-            result = result.replace("[chrome]", "")
-            result = result.replace("chrome-", "")
-        if filter == "firefox":
-            result = result.replace("[firefox]", "")
-            result = result.replace("firefox-", "")
         return result
 
     config.cwd_relative_nodeid = cwd_relative_nodeid

--- a/conftest.py
+++ b/conftest.py
@@ -26,26 +26,39 @@ import selenium.webdriver.common.utils  # noqa: E402
 
 selenium.webdriver.common.utils.is_connectable = _selenium_is_connectable
 
-try:
-    import pytest
+def pytest_addoption(parser):
+    group = parser.getgroup("general")
+    group.addoption(
+        "--build-dir",
+        action="store",
+        default=BUILD_PATH,
+        help="Path to the build directory",
+    )
+    group.addoption(
+        "--run-xfail",
+        action="store_true",
+        help="If provided, tests marked as xfail will be run",
+    )
 
-    def pytest_addoption(parser):
-        group = parser.getgroup("general")
-        group.addoption(
-            "--build-dir",
-            action="store",
-            default=BUILD_PATH,
-            help="Path to the build directory",
-        )
-        group.addoption(
-            "--run-xfail",
-            action="store_true",
-            help="If provided, tests marked as xfail will be run",
-        )
+def pytest_configure(config):
+    """Monkey patch the function cwd_relative_nodeid returns the description
+        of a test for the short summary table. Monkey patch it to reduce the verbosity of the test names in the table.
+        This leaves enough room to see the information about the test failure in the summary.
+    """
+    old_cwd_relative_nodeid = config.cwd_relative_nodeid
 
+    def cwd_relative_nodeid(*args):
+        result = old_cwd_relative_nodeid(*args)
+        result = result.replace("src/tests/", "")
+        result = result.replace("packages/", "")
+        result = result.replace("::test_", "::")
+        result = result.replace("[chrome]", "")
+        result = result.replace("[firefox]", "")
+        result = result.replace("chrome-", "")
+        result = result.replace("firefox-", "")
+        return result
 
-except ImportError:
-    pytest = None  # type: ignore
+    config.cwd_relative_nodeid = cwd_relative_nodeid
 
 
 class JavascriptException(Exception):
@@ -80,12 +93,12 @@ class SeleniumWrapper:
                 f"{(build_dir / 'test.html').resolve()} " f"does not exist!"
             )
         self.driver.get(f"http://{server_hostname}:{server_port}/test.html")
-        self.run_js("Error.stackTraceLimit = Infinity")
-        self.run_js("await languagePluginLoader")
+        self.run_js("Error.stackTraceLimit = Infinity;")
+        self.run_js("await languagePluginLoader;")
 
     @property
     def logs(self):
-        logs = self.driver.execute_script("return window.logs")
+        logs = self.driver.execute_script("return window.logs;")
         if logs is not None:
             return "\n".join(str(x) for x in logs)
         else:
@@ -225,54 +238,54 @@ class ChromeWrapper(SeleniumWrapper):
         return Chrome(options=options)
 
 
-if pytest is not None:
+@contextlib.contextmanager
+def selenium_common(request, web_server_main):
+    server_hostname, server_port, server_log = web_server_main
+    if request.param == "firefox":
+        cls = FirefoxWrapper
+    elif request.param == "chrome":
+        cls = ChromeWrapper
+    else:
+        assert False
+    selenium = cls(
+        build_dir=request.config.option.build_dir,
+        server_port=server_port,
+        server_hostname=server_hostname,
+        server_log=server_log,
+    )
+    try:
+        yield selenium
+    finally:
+        selenium.driver.quit()
 
-    @contextlib.contextmanager
-    def selenium_common(request, web_server_main):
-        server_hostname, server_port, server_log = web_server_main
-        if request.param == "firefox":
-            cls = FirefoxWrapper
-        elif request.param == "chrome":
-            cls = ChromeWrapper
-        selenium = cls(
-            build_dir=request.config.option.build_dir,
-            server_port=server_port,
-            server_hostname=server_hostname,
-            server_log=server_log,
-        )
+@pytest.fixture(params=["firefox", "chrome"], scope="function")
+def selenium_standalone(request, web_server_main):
+    with selenium_common(request, web_server_main) as selenium:
         try:
             yield selenium
         finally:
-            selenium.driver.quit()
+            print(selenium.logs)
 
-    @pytest.fixture(params=["firefox", "chrome"], scope="function")
-    def selenium_standalone(request, web_server_main):
-        with selenium_common(request, web_server_main) as selenium:
-            try:
-                yield selenium
-            finally:
-                print(selenium.logs)
+# selenium instance cached at the module level
+@pytest.fixture(params=["firefox", "chrome"], scope="module")
+def selenium_module_scope(request, web_server_main):
+    with selenium_common(request, web_server_main) as selenium:
+        yield selenium
 
-    # selenium instance cached at the module level
-    @pytest.fixture(params=["firefox", "chrome"], scope="module")
-    def selenium_module_scope(request, web_server_main):
-        with selenium_common(request, web_server_main) as selenium:
-            yield selenium
+# We want one version of this decorated as a function-scope fixture and one
+# version decorated as a context manager.
+def selenium_per_function(selenium_module_scope):
+    try:
+        selenium_module_scope.clean_logs()
+        yield selenium_module_scope
+    finally:
+        print(selenium_module_scope.logs)
 
-    # We want one version of this decorated as a function-scope fixture and one
-    # version decorated as a context manager.
-    def selenium_per_function(selenium_module_scope):
-        try:
-            selenium_module_scope.clean_logs()
-            yield selenium_module_scope
-        finally:
-            print(selenium_module_scope.logs)
-
-    selenium = pytest.fixture(selenium_per_function)
-    # Hypothesis is unhappy with function scope fixtures. Instead, use the
-    # module scope fixture `selenium_module_scope` and use:
-    # `with selenium_context_manager(selenium_module_scope) as selenium`
-    selenium_context_manager = contextlib.contextmanager(selenium_per_function)
+selenium = pytest.fixture(selenium_per_function)
+# Hypothesis is unhappy with function scope fixtures. Instead, use the
+# module scope fixture `selenium_module_scope` and use:
+# `with selenium_context_manager(selenium_module_scope) as selenium`
+selenium_context_manager = contextlib.contextmanager(selenium_per_function)
 
 
 @pytest.fixture(scope="session")

--- a/src/tests/test_pytest_wrapper.py
+++ b/src/tests/test_pytest_wrapper.py
@@ -3,14 +3,14 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).parents[2] / "tools"))
 
-from pytest_wrapper import clean_args
+from pytest_wrapper import remove_num_threads_option
 
 
 def test_find_imports():
     args = ["-v", "-n", "3"]
-    clean_args(args)
+    remove_num_threads_option(args)
     assert args == ["-v"]
 
     args = ["-v", "-n", "3", "-k", "firefox"]
-    clean_args(args)
+    remove_num_threads_option(args)
     assert args == ["-v", "-k", "firefox"]

--- a/tools/pytest_wrapper.py
+++ b/tools/pytest_wrapper.py
@@ -7,7 +7,7 @@ import sys
 args = sys.argv[1:]
 
 
-def clean_args(args: List[str]) -> None:
+def remove_num_threads_option(args: List[str]) -> None:
     """Remove -n <n> from argument list"""
     for i in range(0, len(args)):
         if args[i] == "-n":
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     print("Rerunnning failed tests sequentially")
-    clean_args(args)
+    remove_num_threads_option(args)
     try:
         subprocess.run(["pytest", "--lf"] + args, check=True)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
The pytest summary table has a lot of redundant information in it and when there's a lot of test failures it's hard to read the resulting table. This strips some of the redundant text out of the table to make the output a bit more manageable. Split from #1340.

Before:

```sh
FAILED src/tests/test_asyncio.py::test_await_error[chrome] - assert 1 == 0
FAILED src/tests/test_asyncio.py::test_eval_code_await_error[chrome] - assert...
FAILED src/tests/test_asyncio.py::test_await_fetch[chrome] - assert 1 == 0
FAILED src/tests/test_asyncio.py::test_await_pyproxy_eval_async[chrome] - con...
FAILED src/tests/test_asyncio.py::test_eval_code_await_fetch[chrome] - assert...
FAILED src/tests/test_asyncio.py::test_await_pyproxy_async_def[chrome] - asse...
FAILED src/tests/test_jsproxy.py::test_mount_object[chrome] - assert 2 == 0
FAILED src/tests/test_jsproxy.py::test_unregister_jsmodule[chrome] - conftest...
FAILED src/tests/test_jsproxy.py::test_nested_import[chrome] - assert 2 == 0
FAILED src/tests/test_jsproxy.py::test_register_jsmodule_docs_example[chrome]
FAILED src/tests/test_jsproxy.py::test_mixins_errors[chrome] - assert 5 == 0
FAILED src/tests/test_pyodide.py::test_run_python_async_toplevel_await[chrome]
FAILED src/tests/test_pyodide.py::test_create_once_proxy[chrome] - assert 1 == 0
FAILED src/tests/test_typeconversions.py::test_error_js2py2js[chrome] - asser...
FAILED src/tests/test_typeconversions.py::test_javascript_error[chrome] - ass...
FAILED src/tests/test_typeconversions.py::test_javascript_error_back_to_js[chrome]
FAILED src/tests/test_typeconversions.py::test_to_py[chrome] - assert 6 == 0
FAILED src/tests/test_webloop.py::test_await_js_promise[chrome] - assert 1 == 0
FAILED packages/micropip/test_micropip.py::test_install_custom_url[chrome] - ...
FAILED packages/micropip/test_micropip.py::test_install_simple[chrome] - asse...
FAILED packages/micropip/test_micropip.py::test_install_custom_relative_url[chrome]
```

After:
```sh
FAILED test_asyncio.py::await_error - assert 1 == 0
FAILED test_asyncio.py::eval_code_await_error - assert 1 == 0
FAILED test_asyncio.py::await_pyproxy_eval_async - conftest.JavascriptExcepti...
FAILED test_asyncio.py::await_fetch - assert 1 == 0
FAILED test_asyncio.py::eval_code_await_fetch - assert 1 == 0
FAILED test_asyncio.py::await_pyproxy_async_def - assert 2 == 0
FAILED test_jsproxy.py::mount_object - assert 2 == 0
FAILED test_jsproxy.py::unregister_jsmodule - conftest.JavascriptException: P...
FAILED test_jsproxy.py::nested_import - assert 2 == 0
FAILED test_jsproxy.py::register_jsmodule_docs_example - assert 2 == 0
FAILED test_jsproxy.py::mixins_errors - assert 5 == 0
FAILED test_pyodide.py::run_python_async_toplevel_await - assert 2 == 0
FAILED test_pyodide.py::create_once_proxy - assert 1 == 0
FAILED test_typeconversions.py::javascript_error - assert 2 == 0
FAILED test_typeconversions.py::javascript_error_back_to_js - assert 2 == 0
FAILED test_typeconversions.py::to_py - assert 6 == 0
FAILED test_webloop.py::await_js_promise - assert 1 == 0
FAILED test_typeconversions.py::error_js2py2js - assert 2 == 0
FAILED micropip/test_micropip.py::install_simple - assert 18 == 0
FAILED micropip/test_micropip.py::install_custom_url - assert 12 == 0
FAILED micropip/test_micropip.py::install_custom_relative_url - assert 12 == 0
```