### PR TITLE
Fix various memory leaks in core (from #1340)

### DIFF
--- a/src/core/error_handling.c
+++ b/src/core/error_handling.c
@@ -14,7 +14,7 @@ _Py_IDENTIFIER(last_type);
 _Py_IDENTIFIER(last_value);
 _Py_IDENTIFIER(last_traceback);
 
-EM_JS_NUM(errcode, log_error, (char* msg), {
+EM_JS_NUM(errcode, console_error, (char* msg), {
   let jsmsg = UTF8ToString(msg);
   console.error(jsmsg);
 });
@@ -30,6 +30,7 @@ PyodideErr_SetJsError(JsRef err)
 {
   PyObject* py_err = JsProxy_create(err);
   PyErr_SetObject((PyObject*)(py_err->ob_type), py_err);
+  Py_DECREF(py_err);
 }
 
 PyObject* internal_error;

--- a/src/core/hiwire.c
+++ b/src/core/hiwire.c
@@ -73,6 +73,9 @@ EM_JS_NUM(int, hiwire_init, (), {
       many_objects_warning_threshold += 100;
     }
 #endif
+#ifdef HW_TRACE_REFS
+    console.warn("hw.new_value", idval, jsval);
+#endif
     return idval;
   };
 

--- a/src/core/js2python.c
+++ b/src/core/js2python.c
@@ -64,7 +64,9 @@ _js2python_memoryview(JsRef id)
   if (jsproxy == NULL) {
     return NULL;
   }
-  return PyMemoryView_FromObject(jsproxy);
+  PyObject* result = PyMemoryView_FromObject(jsproxy);
+  Py_CLEAR(jsproxy);
+  return result;
 }
 
 EM_JS_REF(PyObject*, js2python, (JsRef id), {

--- a/src/core/pyproxy.c
+++ b/src/core/pyproxy.c
@@ -551,6 +551,7 @@ FutureDoneCallback_call(FutureDoneCallback* self,
   int errcode;
   if (result != NULL) {
     errcode = FutureDoneCallback_call_resolve(self, result);
+    Py_DECREF(result);
   } else {
     errcode = FutureDoneCallback_call_reject(self);
   }


### PR DESCRIPTION
In 5 different spots, we forgot a `DECREF` of some sort. I added in some code to trace hiwire allocations behind the compile flag `-D HW_TRACE_REFS`. Also, consistently use `hiwire_resolve_promise` in `JsProxy` asyncio methods and store the module header data for js modules in a `__dict__`.