### PR TITLE
Docs textwrap, typo fixes, add links

### DIFF
--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,8 +1,9 @@
 (how_to_contribute)=
-
 # How to Contribute
 
-Thank you for your interest in contributing to PYODIDE! There are many ways to contribute, and we appreciate all of them. Here are some guidelines & pointers for diving into it.
+Thank you for your interest in contributing to Pyodide! There are many ways to
+contribute, and we appreciate all of them. Here are some guidelines & pointers
+for diving into it.
 
 ## Development Workflow
 
@@ -13,70 +14,118 @@ For code-style the use of [pre-commit](https://pre-commit.com/) is also recommen
 pip install pre-commit
 pre-commit install
 ```
-This will run a set of linters at each commit. Currently it runs yaml syntax validation and is removing trailing whitespaces.
+This will run a set of linters at each commit. Currently it runs yaml syntax
+validation and is removing trailing whitespaces.
 
 ## Code of Conduct
 
-PYODIDE has adopted a {ref}`code-of-conduct` that we expect all contributors and core members to adhere to.
+Pyodide has adopted a {ref}`code-of-conduct` that we expect all contributors and
+core members to adhere to.
 
 ## Development
 
-Work on PYODIDE happens on Github. Core members and contributors can make Pull Requests to fix issues and add features, which all go through the same review process. We’ll detail how you can start making PRs below.
+Work on Pyodide happens on Github. Core members and contributors can make Pull
+Requests to fix issues and add features, which all go through the same review
+process. We’ll detail how you can start making PRs below.
 
-We’ll do our best to keep `master` in a non-breaking state, ideally with tests always passing. The unfortunate reality of software development is sometimes things break. As such, `master` cannot be expected to remain reliable at all times. We recommend using the latest stable version of PYODIDE.
+We’ll do our best to keep `master` in a non-breaking state, ideally with tests
+always passing. The unfortunate reality of software development is sometimes
+things break. As such, `master` cannot be expected to remain reliable at all
+times. We recommend using the latest stable version of Pyodide.
 
-PYODIDE follows semantic versioning (http://semver.org/) - major versions for breaking changes (x.0.0), minor versions for new features (0.x.0), and patches for bug fixes (0.0.x).
+Pyodide follows semantic versioning (http://semver.org/) - major versions for
+breaking changes (x.0.0), minor versions for new features (0.x.0), and patches
+for bug fixes (0.0.x).
 
-We keep a file, {ref}`docs/changelog.md <changelog>`, outlining changes to PYODIDE in each release. We like to think of the audience for changelogs as non-developers who primarily run the latest stable. So the change log will primarily outline user-visible changes such as new features and deprecations, and will exclude things that might otherwise be inconsequential to the end user experience, such as infrastructure or refactoring.
+We keep a file, {ref}`docs/changelog.md <changelog>`, outlining changes to
+Pyodide in each release. We like to think of the audience for changelogs as
+non-developers who primarily run the latest stable. So the change log will
+primarily outline user-visible changes such as new features and deprecations,
+and will exclude things that might otherwise be inconsequential to the end user
+experience, such as infrastructure or refactoring.
 
 ## Bugs & Issues
 
-We use [Github Issues](https://github.com/iodide-project/pyodide/issues) for announcing and discussing bugs and features. Use [this link](https://github.com/iodide-project/pyodide/issues/new) to report an bug or issue. We provide a template to give you a guide for how to file optimally. If you have the chance, please search the existing issues before reporting a bug. It's possible that someone else has already reported your error. This doesn't always work, and sometimes it's hard to know what to search for, so consider this extra credit. We won't mind if you accidentally file a duplicate report.
+We use [Github Issues](https://github.com/iodide-project/pyodide/issues) for
+announcing and discussing bugs and features. Use 
+[this link](https://github.com/iodide-project/pyodide/issues/new) to report a
+bug or issue. We provide a template to give you a guide for how to file
+optimally. If you have the chance, please search the existing issues before
+reporting a bug. It's possible that someone else has already reported your
+error. This doesn't always work, and sometimes it's hard to know what to search
+for, so consider this extra credit. We won't mind if you accidentally file a
+duplicate report.
 
-Core contributors are monitoring new issues & comments all the time, and will label & organize issues to align with development priorities.
+Core contributors are monitoring new issues & comments all the time, and will
+label & organize issues to align with development priorities.
 
 
 
 ## How to Contribute
 
-Pull requests are the primary mechanism we use to change PYODIDE. GitHub itself has some [great documentation](https://help.github.com/articles/about-pull-requests/) on using the Pull Request feature. We use the "fork and pull" model [described here](https://help.github.com/articles/about-pull-requests/), where contributors push changes to their personal fork and create pull requests to bring those changes into the source repository.
+Pull requests are the primary mechanism we use to change Pyodide. GitHub itself
+has some
+[great documentation](https://help.github.com/articles/about-pull-requests/)
+on using the Pull Request feature. We use the "fork and pull" model
+[described here](https://help.github.com/articles/about-pull-requests/),
+where contributors push changes to their personal fork and create pull requests
+to bring those changes into the source repository.
 
 Please make pull requests against the `master` branch.
 
-If you’re looking for a way to jump in and contribute, our list of [`good first issues`](https://github.com/iodide-project/pyodide/labels/good%20first%20issue) is a great place to start.
+If you’re looking for a way to jump in and contribute, our list of
+[good first issues](https://github.com/iodide-project/pyodide/labels/good%20first%20issue)
+is a great place to start.
 
-If you’d like to fix a currently-filed issue, please take a look at the comment thread on the issue to ensure no one is already working on it. If no one has claimed the issue, make a comment stating you’d like to tackle it in a PR. If someone has claimed the issue but has not worked on it in a few weeks, make a comment asking if you can take over, and we’ll figure it out from there.
+If you’d like to fix a currently-filed issue, please take a look at the comment
+thread on the issue to ensure no one is already working on it. If no one has
+claimed the issue, make a comment stating you’d like to tackle it in a PR. If
+someone has claimed the issue but has not worked on it in a few weeks, make a
+comment asking if you can take over, and we’ll figure it out from there.
 
-We use [pytest](https://pytest.org), driving [Selenium](https://www.seleniumhq.org) as our testing framework. Every PR will automatically run through our tests, and our test framework will alert you on Github if your PR doesn’t pass all of them. If your PR fails a test, try to figure out whether or not you can update your code to make the test pass again, or ask for help. As a policy we will not accept a PR that fails any of our tests, and will likely ask you to add tests if your PR adds new functionality. Writing tests can be scary, but they make open-source contributions easier for everyone to assess. Take a moment and look through how we’ve written our tests, and try to make your tests match. If you are having trouble, we can help you get started on our test-writing journey.
+We use [pytest](https://pytest.org), driving
+[Selenium](https://www.seleniumhq.org) as our testing framework. Every PR will
+automatically run through our tests, and our test framework will alert you on
+Github if your PR doesn’t pass all of them. If your PR fails a test, try to
+figure out whether or not you can update your code to make the test pass again,
+or ask for help. As a policy we will not accept a PR that fails any of our
+tests, and will likely ask you to add tests if your PR adds new functionality.
+Writing tests can be scary, but they make open-source contributions easier for
+everyone to assess. Take a moment and look through how we’ve written our tests,
+and try to make your tests match. If you are having trouble, we can help you get
+started on our test-writing journey.
 
-All code submissions should pass `make lint`.  Python is checked with the default settings of `flake8`.  C and Javascript are checked against the Mozilla style in `clang-format`.
+All code submissions should pass `make lint`.  Python is checked with the
+default settings of `flake8`.  C and Javascript are checked against the Mozilla
+style in `clang-format`.
 
 ## Documentation
 
 Documentation is a critical part of any open source project and we are very
-welcome to any documentation improvements.
-Pyodide has a documentation written in Markdown in the `docs/` folder. We
-use the [MyST](
-https://myst-parser.readthedocs.io/en/latest/using/syntax.html#targets-and-cross-referencing)
-for parsing Markdown in sphinx.  You may want to have a look at the [MyST
-syntax
-guide](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#the-myst-syntax-guide)
-when contributing, in particular regarding [cross-referencing
-sections](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#targets-and-cross-referencing).
+welcome to any documentation improvements. Pyodide has a documentation written
+in Markdown in the `docs/` folder. We use the
+[MyST](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#targets-and-cross-referencing)
+for parsing Markdown in sphinx.  You may want to have a look at the
+[MyST syntax guide](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#the-myst-syntax-guide)
+when contributing, in particular regarding
+[cross-referencing sections](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#targets-and-cross-referencing).
 
 ### Building the docs
-From the directory ``docs``, first install the Python dependencies with ``pip install -r requirements-doc.txt``.
-You also need to install JsDoc, which is a ``node`` dependency. Install it with ``sudo npm install -g jsdoc``.
-Then to build the docs run ``make html``.
-The built documentation will be in the subdirectory ``docs/_build/html``. To view them, cd into ``_build/html`` and start a file server,
-for instance ``http-server``.
+From the directory ``docs``, first install the Python dependencies with
+``pip install -r requirements-doc.txt``. You also need to install JsDoc, which is a
+``node`` dependency. Install it with ``sudo npm install -g jsdoc``. Then to
+build the docs run ``make html``. The built documentation will be in the
+subdirectory ``docs/_build/html``. To view them, cd into ``_build/html`` and
+start a file server, for instance ``http-server``.
 
 ## Migrating patches
 
-It often happens that patches need to be migrated between different versions of upstream packages.
+It often happens that patches need to be migrated between different versions of
+upstream packages.
 
 If patches fail to apply automatically, one solution can be to
-1. Checkout the initial version of the upstream package in a separate repo, and create a branch from it.
+1. Checkout the initial version of the upstream package in a separate repo, and
+   create a branch from it.
 2. Add existing patches with `git apply <path.path>`
 3. Checkout the new version of the upstream package and create a branch from it.
 4. Cherry-pick patches to the new version,
@@ -91,13 +140,17 @@ If patches fail to apply automatically, one solution can be to
 
 ## License
 
-All contributions to PYODIDE will be licensed under the [Mozilla Public License 2.0 (MPL 2.0)](https://www.mozilla.org/en-US/MPL/2.0/). This is considered a "weak copyleft" license. Check out the [tl;drLegal entry][] for more information, as well as Mozilla's [MPL 2.0 FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/) if you need further clarification on what is and isn't permitted.
+All contributions to Pyodide will be licensed under the
+[Mozilla Public License 2.0 (MPL 2.0)](https://www.mozilla.org/en-US/MPL/2.0/).
+This is considered a "weak copyleft" license. Check out the [tl;drLegal entry][] for more
+information, as well as Mozilla's
+[MPL 2.0 FAQ](https://www.mozilla.org/en-US/MPL/2.0/FAQ/) if you need further
+clarification on what is and isn't permitted.
 
 
 ## Get in Touch
 
-- __Gitter:__ Pyodide currently shares the [#iodide](https://gitter.im/iodide-project/iodide) channel over at gitter.im
-
-
+- __Gitter:__ Pyodide currently shares the
+  [#iodide](https://gitter.im/iodide-project/iodide) channel over at gitter.im
 
 [tl;drLegal entry]:https://tldrlegal.com/license/mozilla-public-license-2.0-(mpl-2)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -86,7 +86,7 @@ from pyodide_build.testing import run_in_pyodide
 def test_add():
     assert 1 + 1 == 2
 ```
-In this case, the body of the function will automatically be run in pyodide.
+In this case, the body of the function will automatically be run in Pyodide.
 The decorator can also be called with arguments. It has two configuration
 options --- standalone and packages.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,6 @@ may be installed from PyPI to be used with Pyodide.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Usage
 
    usage/quickstart.md
    usage/webworker.md

--- a/docs/project/governance.md
+++ b/docs/project/governance.md
@@ -1,57 +1,58 @@
-# pyodide governance and decision-making
+(governance)=
+# Pyodide Governance and Decision-making
 
 The purpose of this document is to formalize the governance process used by the
-pyodide project, to clarify how decisions are made and how the various
-members of our community interact.
-This document establishes a decision-making structure that takes into account
-feedback from all members of the community and strives to find consensus, while
-avoiding any deadlocks.
+Pyodide project, to clarify how decisions are made and how the various members
+of our community interact. This document establishes a decision-making structure
+that takes into account feedback from all members of the community and strives
+to find consensus, while avoiding deadlocks.
 
-Anyone with an interest in the project can join the community, contribute to
-the project design and participate in the decision making process. This
-document describes how to participate and earn merit in the pyodide community.
+Anyone with an interest in the project can join the community, contribute to the
+project design and participate in the decision making process. This document
+describes how to participate and earn merit in the Pyodide community.
 
 ## Roles And Responsibilities
 
 ### Contributors
 
 Contributors are community members who contribute in concrete ways to the
-project. Anyone can become a contributor, and contributions can take many
-forms, for instance, answering user questions – not only code – as detailed in
-the {ref}`how_to_contibute`
+project. Anyone can become a contributor, and contributions can take many forms,
+for instance, answering user questions – not only code – as detailed in
+{any}`how_to_contribute`.
 
 ### Community members team
 
-The community members team is composed of community members who have permission on
-Github to label and close issues. Their work is
-crucial to improve the communication in the project.
+The community members team is composed of community members who have permission
+on Github to label and close issues. Their work is crucial to improve the
+communication in the project.
 
-After participating in pyodide development with pull requests and reviews for a
-period of time, any contributor may become a member of the team.
-The process for adding team members is modeled on the [CPython project](
-https://devguide.python.org/triaging/#becoming-a-member-of-the-python-triage-team).
-Any core developer is welcome to propose a pyodide contributor to join the
-community members team. Other core developers are then consulted: while it is expected
-that most acceptances will be unanimous, a two-thirds majority is enough.
+After participating in Pyodide development with pull requests and reviews for a
+period of time, any contributor may become a member of the team. The process for
+adding team members is modeled on the 
+[CPython project](https://devguide.python.org/triaging/#becoming-a-member-of-the-python-triage-team).
+Any core developer is welcome to propose a Pyodide contributor to join the
+community members team. Other core developers are then consulted: while it is
+expected that most acceptances will be unanimous, a two-thirds majority is
+enough.
 
 ### Core developers
 
 Core developers are community members who have shown that they are dedicated to
 the continued development of the project through ongoing engagement with the
-community. They have shown they can be trusted to maintain pyodide with
-care. Being a core developer allows contributors to more easily carry on
-with their project related activities by giving them direct access to the
-project’s repository and is represented as being a member of the core team on the
-pyodide [GitHub organization](https://github.com/orgs/pyodide/teams/core/members).
-Core developers are expected to review code
-contributions, can merge approved pull requests, can cast votes for and against
-merging a pull-request, and can make decisions about major changes to the
-API (all contributors are welcome to participate in the discussion).
+community. They have shown they can be trusted to maintain Pyodide with care.
+Being a core developer allows contributors to more easily carry on with their
+project related activities by giving them direct access to the project’s
+repository and is represented as being a member of the core team on the Pyodide
+[GitHub organization](https://github.com/orgs/Pyodide/teams/core/members). Core
+developers are expected to review code contributions, can merge approved pull
+requests, can cast votes for and against merging a pull-request, and can make
+decisions about major changes to the API (all contributors are welcome to
+participate in the discussion).
 
 New core developers can be nominated by any existing core developers. Once they
-have been nominated, there will be a vote by the current core developers.
-Voting on new core developers is one of the few activities that takes place on
-the project's private communication channels. While it is expected that most votes
+have been nominated, there will be a vote by the current core developers. Voting
+on new core developers is one of the few activities that takes place on the
+project's private communication channels. While it is expected that most votes
 will be unanimous, a two-thirds majority of the cast votes is enough. The vote
 needs to be open for at least one week.
 
@@ -65,19 +66,19 @@ active again.
 
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
-place on the project contributors' [issue
-tracker](https://github.com/pyodide/pyodide/issues) and on [Github
-discussion](https://github.com/pyodide/pyodide/discussions).
-Occasionally, sensitive discussion occurs on a private communication channels.
+place on the project contributors' 
+[issue tracker](https://github.com/Pyodide/Pyodide/issues) and on 
+[Github discussion](https://github.com/Pyodide/Pyodide/discussions). Occasionally,
+sensitive discussion occurs on a private communication channels.
 
-pyodide uses a "consensus seeking" process for making decisions. The group
-tries to find a resolution that has no open objections among core developers.
-At any point during the discussion, any core-developer can call for a vote,
-which will conclude two weeks from the call for the vote. This is what we
-hereafter may refer to as “the decision making process”.
+Pyodide uses a "consensus seeking" process for making decisions. The group tries
+to find a resolution that has no open objections among core developers. At any
+point during the discussion, any core-developer can call for a vote, which will
+conclude two weeks from the call for the vote. This is what we hereafter may
+refer to as “the decision making process”.
 
-Decisions (in addition to adding core developers as above)
-are made according to the following rules:
+Decisions (in addition to adding core developers as above) are made according to
+the following rules:
 
 * **Maintenance changes**, include for instance improving the wording in the
   documentation, updating CI or dependencies.  Core developers are expected to
@@ -87,9 +88,9 @@ are made according to the following rules:
   is received, then the consensus rules from the following section apply.
 
 * **Code changes in general, and especially those impacting user facing APIs**,
-  as well as more significant documentation changes, require review and
-  approval by a core developer and no objections raised by any core developer
-  (lazy consensus). This process happens on the pull-request page.
+  as well as more significant documentation changes, require review and approval
+  by a core developer and no objections raised by any core developer (lazy
+  consensus). This process happens on the pull-request page.
 
 * **Changes to the governance model** use the same decision process outlined
   above.

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -16,12 +16,15 @@ In both cases, files need to be served with a web server and cannot be loaded fr
 
 ## Why can't I load files from the local file system?
 
-For security reasons Javascript in the browser is not allowed to load local data files. You need to serve them with a web-browser.
-Recently there is a [Native File System API](https://wicg.github.io/file-system-access/) supported in Chrome but not in Firefox. [There is a discussion about implementing it for Firefox here.](https://github.com/mozilla/standards-positions/issues/154)
+For security reasons Javascript in the browser is not allowed to load local data
+files. You need to serve them with a web-browser. Recently there is a
+[Native File System API](https://wicg.github.io/file-system-access/) supported in Chrome
+but not in Firefox.
+[There is a discussion about implementing it for Firefox here.](https://github.com/mozilla/standards-positions/issues/154)
 
 
-## How can I change the behavior of `runPython` and `runPythonAsync`?
-The definitions of `runPython` and `runPythonAsync` are very simple:
+## How can I change the behavior of {any}`runPython <pyodide.runPython>` and {any}`runPythonAsync <pyodide.runPythonAsync>`?
+The definitions of {any}`runPython <pyodide.runPython>` and {any}`runPythonAsync <pyodide.runPythonAsync>` are very simple:
 ```javascript
 function runPython(code){
   pyodide.pyodide_py.eval_code(code, pyodide.globals);
@@ -34,16 +37,15 @@ async function runPythonAsync(code, messageCallback, errorCallback) {
   return pyodide.runPython(code);
 };
 ```
-To make your own version of `runPython`:
+To make your own version of {any}`runPython <pyodide.runPython>`:
 
 ```pyodide
 pyodide.runPython(`
   import pyodide
-  old_eval_code = pyodide.eval_code
   def my_eval_code(code, ns):
     extra_info = None
-    result = old_eval_code(code, ns)
-    return [ns["extra_info"], result]
+    result = pyodide.eval_code(code, ns)
+    return ns["extra_info"], result]
 `)
 
 function myRunPython(code){
@@ -57,14 +59,14 @@ function myAsyncRunPython(code){
 ```
 Then `pyodide.myRunPython("2+7")` returns `[None, 9]` and
 `pyodide.myRunPython("extra_info='hello' ; 2 + 2")` returns `['hello', 4]`.
-If you want to change which packages `loadPackagesFromImports` loads, you can
-monkey patch `pyodide-py.find_imports` which takes `code` as an argument
+If you want to change which packages {any}`pyodide.loadPackagesFromImports` loads, you can
+monkey patch {any}`pyodide.find_imports` which takes `code` as an argument
 and returns a list of packages imported.
 
 ## How can I execute code in a custom namespace?
 
 The second argument to {any}`pyodide.eval_code` is a global namespace to execute the code in.
-The namespace is a Python dictionary. 
+The namespace is a Python dictionary.
 ```javascript
 let my_namespace = pyodide.globals.dict();
 pyodide.pyodide_py.eval_code(`x = 1 + 1`, my_namespace);
@@ -113,7 +115,7 @@ but this usage is deprecated.
 
 ## How do I create custom Python packages from Javascript?
 
-Put a collection of functions into a Javascript object and use `pyodide.registerJsModule`:
+Put a collection of functions into a Javascript object and use {any}`pyodide.registerJsModule`:
 Javascript:
 ```javascript
 let my_module = {
@@ -129,7 +131,7 @@ let my_module = {
       return x*x - 1;
     },
     c  : 2,
-  },  
+  },
 };
 pyodide.registerJsModule("my_js_module", my_module);
 ```

--- a/docs/usage/loading-packages.md
+++ b/docs/usage/loading-packages.md
@@ -4,11 +4,11 @@
 Only the Python standard library is available after importing Pyodide.
 To use other packages, you’ll need to load them using either:
  - {any}`pyodide.loadPackage` for packages built with Pyodide, or 
- - `micropip.install` for pure Python packages with wheels available on PyPi or
+ - {any}`micropip.install` for pure Python packages with wheels available on PyPi or
    from other URLs.
 
 ```{note}
-`micropip` can also be used to load packages built in Pyodide (in
+{mod}`micropip` can also be used to load packages built in Pyodide (in
 which case it relies on {any}`pyodide.loadPackage`).
 ```
 
@@ -17,7 +17,7 @@ You can do this with {any}`pyodide.runPythonAsync`
 which will automatically download all packages that the code snippet imports. 
 It only supports packages included in Pyodide (not on PyPi) at present.
 
-## Loading packages with pyodide.loadPackage
+## Loading packages with {any}`pyodide.loadPackage`
 
 Packages can be loaded by name, for those included in the official Pyodide
 repository using e.g.,
@@ -43,7 +43,7 @@ Multiple packages can also be loaded in a single call,
 pyodide.loadPackage(['cycler', 'pytz'])
 ```
 
-`pyodide.loadPackage` returns a `Promise`.
+{any}`pyodide.loadPackage` returns a `Promise`.
 
 ```javascript
 pyodide.loadPackage('matplotlib').then(() => {
@@ -56,7 +56,7 @@ pyodide.loadPackage('matplotlib').then(() => {
 
 ### Installing packages from PyPI
 
-Pyodide supports installing pure Python wheels from PyPI with `micropip`. You
+Pyodide supports installing pure Python wheels from PyPI with {mod}`micropip`. You
 can use the `then` method on the `Promise` that {func}`micropip.install`
 returns to do work once the packages have finished loading:
 
@@ -77,7 +77,7 @@ downloaded wheel against pre-recorded hash digests from the PyPi JSON API.
 
 ### Installing wheels from arbitrary URLs
 
-Pure Python wheels can also be installed from any URL with micropip,
+Pure Python wheels can also be installed from any URL with {mod}`micropip`,
 ```py
 import micropip
 micropip.install(
@@ -90,14 +90,14 @@ convention](https://www.python.org/dev/peps/pep-0427/#file-format), which will
 be the case if the wheels is made using standard Python tools (`pip wheel`,
 `setup.py bdist_wheel`).
 
-All required dependencies need also to be previously installed with `micropip`
+All required dependencies need also to be previously installed with {mod}`micropip`
 or {any}`pyodide.loadPackage`.
 
-If the file is on a remote server, it must set Cross-Origin Resource Sharing (CORS) headers to
-allow access. Otherwise, you can prepend a CORS proxy to the URL. Note however
-that using third-party CORS proxies has security implications, particularly
-since we are not able to check the file integrity, unlike with installs from
-PyPi.
+If the file is on a remote server, it must set Cross-Origin Resource Sharing
+(CORS) headers to allow access. Otherwise, you can prepend a CORS proxy to the
+URL. Note however that using third-party CORS proxies has security implications,
+particularly since we are not able to check the file integrity, unlike with
+installs from PyPi.
 
 
 ## Example

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -19,8 +19,8 @@ the `pyodide.js` file there from a `<script>` tag. See the following section on
 The `pyodide.js` file has a single `Promise` object which bootstraps the Python
 environment: `languagePluginLoader`. Since this must happen asynchronously, it
 is a `Promise`, which you must call `then` on to complete initialization. When
-the promise resolves, Pyodide will have installed a namespace in global scope:
-`pyodide`.
+the promise resolves, Pyodide will have installed a namespace in the global
+scope called {js:mod}`pyodide`.
 
 ```pyodide
 languagePluginLoader.then(() => {
@@ -124,9 +124,14 @@ Create and save a test `index.html` page with the following contents:
 
 ## Accessing Python scope from Javascript
 
-You can also access from Javascript all functions and variables defined in Python using the {any}`pyodide.globals` object.
+You can also access from Javascript all functions and variables defined in
+Python using the {any}`pyodide.pyimport` api or the {any}`pyodide.globals`
+object.
 
-For example, if you initialize the variable `x = numpy.ones([3,3])` in Python, you can access it from Javascript in your browser's developer console as follows: `pyodide.globals.get("x")`. The same goes for functions and imports. See {ref}`type-translations` for more details.
+For example, if you run the code `x = numpy.ones([3,3])` in Python, you can
+access the variable ``x`` from Javascript in your browser's developer console as
+follows: `pyodide.globals.get("x")`. The same goes for functions and imports.
+See {ref}`type-translations` for more details.
 
 You can try it yourself in the browser console:
 ```js
@@ -139,7 +144,9 @@ let x = pyodide.globals.get("numpy").ones(new Int32Array([3, 3]));
 // x >>> [Float64Array(3), Float64Array(3), Float64Array(3)]
 ```
 
-Since you have full scope access, you can also re-assign new values or even Javascript functions to variables, and create new ones from Javascript:
+Since you have full access to Python global scope, you can also re-assign new
+values or even Javascript functions to variables, and create new ones from
+Javascript:
 
 ```js
 // re-assign a new value to an existing variable
@@ -157,7 +164,10 @@ Feel free to play around with the code using the browser console and the above e
 
 ## Accessing Javascript scope from Python
 
-The Javascript scope can be accessed from Python using the `js` module (see {ref}`type-translations_using-js-obj-from-py`). This module represents the global object `window` that allows us to directly manipulate the DOM and access global variables and functions from Python.
+The Javascript scope can be accessed from Python using the `js` module (see
+{ref}`type-translations_using-js-obj-from-py`). This module represents the
+global object `window` that allows us to directly manipulate the DOM and access
+global variables and functions from Python.
 
 ```python
 import js


### PR DESCRIPTION
I textwrapped a few files, added a few API reference links in faq.md and loading-packages.md, and normalized capitalization again (PYODIDE, pyodide ==> Pyodide).