### PR TITLE
MAINT Fix release deployment with non stable version tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^\d+\.\d+\.\d+$/
+              only: /^\d+\.\d+\.\w+$/
       - deploy-s3:
           requires:
             - lint


### PR DESCRIPTION
I tried to make an 0.17.0a1 release for https://github.com/iodide-project/pyodide/issues/1327 however the release CI didn't trigger because the regexp assumed stable version tag. 