### PR TITLE
MAINT Set master back to 0.17.0dev0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   environment:
     - EMSDK_NUM_CORES: 4
       EMCC_CORES: 4
-      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/v0.17.0a2/full/
+      PYODIDE_BASE_URL: https://cdn.jsdelivr.net/pyodide/dev/full/
 
 jobs:
   lint:

--- a/src/pyodide-py/pyodide/__init__.py
+++ b/src/pyodide-py/pyodide/__init__.py
@@ -15,7 +15,7 @@ if platform.system() == "Emscripten":
     asyncio.set_event_loop_policy(WebLoopPolicy())
 
 
-__version__ = "0.17.0a2"
+__version__ = "0.17.0dev0"
 
 __all__ = [
     "open_url",


### PR DESCRIPTION
Following https://github.com/iodide-project/pyodide/pull/1356

This is in particular necessary to make `PYODIDE_BASE_URL` correct for the dev URL

I think it's preferable to keep using 0.17.0a2 in the documentation otherwise.