### PR TITLE
Make "initializePyodide" function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ build/pyodide.asm.js: \
 	$(CPYTHONLIB)
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d build ] || mkdir build
-	$(CXX) -s EXPORT_NAME="'pyodide'" -o build/pyodide.asm.js $(filter %.o,$^) \
+	$(CXX) -s EXPORT_NAME="'_createPyodideModule'" -o build/pyodide.asm.js $(filter %.o,$^) \
 		$(LDFLAGS) -s FORCE_FILESYSTEM=1 \
 		--preload-file $(CPYTHONLIB)@/lib/python$(PYMINOR) \
 		--preload-file src/webbrowser.py@/lib/python$(PYMINOR)/webbrowser.py \

--- a/conftest.py
+++ b/conftest.py
@@ -154,7 +154,7 @@ class SeleniumWrapper:
             (async () => {
                 try {
                     let result = await run();
-                    if(pyodide && pyodide._module && pyodide._module._PyErr_Occurred()){
+                    if(globalThis.pyodide && pyodide._module && pyodide._module._PyErr_Occurred()){
                         try {
                             pyodide._module._pythonexc2js();
                         } catch(e){

--- a/packages/micropip/micropip/micropip.py
+++ b/packages/micropip/micropip/micropip.py
@@ -13,7 +13,7 @@ import sys
 
 # Provide stubs for testing in native python
 try:
-    from js import pyodide as js_pyodide
+    import pyodide_js
 
     IN_BROWSER = True
 except ImportError:
@@ -121,7 +121,7 @@ class _PackageManager:
 
     def __init__(self):
         if IN_BROWSER:
-            self.builtin_packages = js_pyodide._module.packages.dependencies.to_py()
+            self.builtin_packages = pyodide_js._module.packages.dependencies.to_py()
         else:
             self.builtin_packages = {}
         self.installed_packages = {}
@@ -157,7 +157,7 @@ class _PackageManager:
             # Note: branch never happens in out-of-browser testing because we
             # report that all dependencies are empty.
             self.installed_packages.update(dict((k, None) for k in pyodide_packages))
-            wheel_promises.append(js_pyodide.loadPackage(list(pyodide_packages)))
+            wheel_promises.append(pyodide_js.loadPackage(list(pyodide_packages)))
 
         # Now install PyPI packages
         for name, wheel, ver in transaction["wheels"]:

--- a/src/pyodide-py/pyodide/console.py
+++ b/src/pyodide-py/pyodide/console.py
@@ -10,9 +10,10 @@ import rlcompleter
 # this import can fail when we are outside a browser (e.g. for tests)
 try:
     import js
+    import pyodide_js
 
     _dummy_promise = js.Promise.resolve()
-    _load_packages_from_imports = js.pyodide.loadPackagesFromImports
+    _load_packages_from_imports = pyodide_js.loadPackagesFromImports
 
 except ImportError:
 

--- a/src/templates/console.html
+++ b/src/templates/console.html
@@ -7,8 +7,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/echo_newline.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" rel="stylesheet"/>
     <script type="text/javascript">
-        // set the pyodide files URL (packages.json, pyodide.asm.data etc)
-        window.languagePluginUrl = '{{ PYODIDE_BASE_URL }}';
+        window.pyodideBaseURL = '{{ PYODIDE_BASE_URL }}';
     </script>
     <script src="{{ PYODIDE_BASE_URL }}pyodide.js"></script>
     <style>
@@ -17,7 +16,8 @@
   </head>
   <body>
     <script>
-      languagePluginLoader.then(() => {
+      initializePyodide({ baseURL : pyodideBaseURL }).then((pyodide) => {
+        globalThis.pyodide = pyodide;
         let namespace = pyodide.pyimport("dict")();
         pyodide.runPython(`
             import sys


### PR DESCRIPTION
Closes #277. As discussed in #1239.

Instead of exposing a promise called `languagePluginLoader`, expose a function called `initializePyodide`. For backwards compatibility, if `languagePluginURL` is defined, then it automatically does `initializePyodide({ baseURL : languagePluginURL })`. In this case we also print a deprecation warning.

We need to add some documentation for this.

I also tried to reduce the number of places that need `pyodide` to be in global scope. We still need this to load packages, but I think it's possible to avoid that by using dynamic module imports.
