### PR TITLE
Move all configuration variables for compile into Makefile.envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,42 +12,6 @@ CPYTHONLIB=$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/python$(PYMINOR)
 
 CC=emcc
 CXX=em++
-OPTFLAGS=-O2
-CFLAGS=\
-	$(OPTFLAGS) \
-	-g \
-	-I$(PYTHONINCLUDE) \
-	-fPIC \
-	-Wall \
-	-Wno-warn-absolute-paths \
-	-Werror=unused-variable \
-	-Werror=sometimes-uninitialized \
-	-Werror=int-conversion \
-	-Werror=incompatible-pointer-types \
-	$(EXTRA_CFLAGS)
-LDFLAGS=\
-	-s BINARYEN_EXTRA_PASSES="--pass-arg=max-func-params@61" \
-	$(OPTFLAGS) \
-	-s MODULARIZE=1 \
-	$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/libpython$(PYMINOR).a \
-	-s TOTAL_MEMORY=20971520 \
-	-s ALLOW_MEMORY_GROWTH=1 \
-    --use-preload-plugins \
-	-s MAIN_MODULE=1 \
-	-s EMULATE_FUNCTION_POINTER_CASTS=1 \
-	-s LINKABLE=1 \
-	-s EXPORT_ALL=1 \
-	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv", "_main"]' \
-	-s WASM=1 \
-	-s USE_FREETYPE=1 \
-	-s USE_LIBPNG=1 \
-	-std=c++14 \
-	-L$(wildcard $(CPYTHONROOT)/build/sqlite*/.libs) -lsqlite3 \
-	$(wildcard $(CPYTHONROOT)/build/bzip2*/libbz2.a) \
-	-lstdc++ \
-	--memory-init-file 0 \
-	-s LZ4=1 \
-	$(EXTRA_LDFLAGS)
 
 all: check \
 	build/pyodide.asm.js \
@@ -79,7 +43,7 @@ build/pyodide.asm.js: \
 	date +"[%F %T] Building pyodide.asm.js..."
 	[ -d build ] || mkdir build
 	$(CXX) -s EXPORT_NAME="'pyodide'" -o build/pyodide.asm.js $(filter %.o,$^) \
-		$(LDFLAGS) -s FORCE_FILESYSTEM=1 \
+		$(MAIN_MODULE_LDFLAGS) -s FORCE_FILESYSTEM=1 \
 		--preload-file $(CPYTHONLIB)@/lib/python$(PYMINOR) \
 		--preload-file src/webbrowser.py@/lib/python$(PYMINOR)/webbrowser.py \
 		--preload-file src/_testcapi.py@/lib/python$(PYMINOR)/_testcapi.py \
@@ -149,7 +113,7 @@ clean-all: clean
 	rm -fr cpython/build
 
 %.o: %.c $(CPYTHONLIB) $(wildcard src/**/*.h)
-	$(CC) -o $@ -c $< $(CFLAGS) -Isrc/core/
+	$(CC) -o $@ -c $< $(MAIN_MODULE_CFLAGS) -Isrc/core/
 
 
 build/test.data: $(CPYTHONLIB) $(UGLIFYJS)

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -7,6 +7,7 @@ export PYODIDE_BINARYEN_VERSION ?= version_100
 export BASH_ENV := $(PYODIDE_ROOT)/pyodide_env.sh
 SHELL := /bin/bash
 
+export TOOLSDIR=$(PYODIDE_ROOT)/tools
 export PYVERSION=3.8.2
 export PYMINOR=$(basename $(PYVERSION))
 export HOSTPYTHONROOT=$(shell python3.8 -c "import sys; print(sys.prefix)")
@@ -43,6 +44,8 @@ export LDFLAGS_BASE=\
 	-s LZ4=1 \
 	$(EXTRA_LDFLAGS)
 
+export CXXFLAGS_BASE=
+
 export SIDE_MODULE_LDFLAGS=	$(LDFLAGS_BASE) -s SIDE_MODULE=1
 export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) -s MAIN_MODULE=1 \
 	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv", "_main"]' \
@@ -57,6 +60,8 @@ export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) -s MAIN_MODULE=1 \
 	-lstdc++ \
 	--memory-init-file 0 \
 
+export SIDE_MODULE_CXXFLAGS = $(CXXFLAGS_BASE)
+
 export SIDE_MODULE_CFLAGS= $(CFLAGS_BASE)
 export MAIN_MODULE_CFLAGS= $(CFLAGS_BASE) \
     	-Wall \
@@ -67,7 +72,6 @@ export MAIN_MODULE_CFLAGS= $(CFLAGS_BASE) \
     	-Werror=incompatible-pointer-types \
 		-I$(PYTHONINCLUDE) 
 
-export PYTHON_CFLAGS=$(CFLAGS_BASE)
 
 .output_vars:
 	set

--- a/Makefile.envs
+++ b/Makefile.envs
@@ -23,3 +23,51 @@ export PYODIDE=1
 # This is the legacy environment variable used for the aforementioned purpose
 export PYODIDE_PACKAGE_ABI=1
 export EM_COMPILER_WRAPPER=ccache
+
+export OPTFLAGS=-O2
+export CFLAGS_BASE=\
+	$(OPTFLAGS) \
+	-g \
+	-fPIC \
+	$(EXTRA_CFLAGS)
+
+export LDFLAGS_BASE=\
+	-s BINARYEN_EXTRA_PASSES="--pass-arg=max-func-params@61" \
+	$(OPTFLAGS) \
+	-s MODULARIZE=1 \
+	-s EMULATE_FUNCTION_POINTER_CASTS=1 \
+	-s LINKABLE=1 \
+	-s EXPORT_ALL=1 \
+	-s WASM=1 \
+	-std=c++14 \
+	-s LZ4=1 \
+	$(EXTRA_LDFLAGS)
+
+export SIDE_MODULE_LDFLAGS=	$(LDFLAGS_BASE) -s SIDE_MODULE=1
+export MAIN_MODULE_LDFLAGS= $(LDFLAGS_BASE) -s MAIN_MODULE=1 \
+	-s EXPORTED_FUNCTIONS='["___cxa_guard_acquire", "__ZNSt3__28ios_base4initEPv", "_main"]' \
+	$(CPYTHONROOT)/installs/python-$(PYVERSION)/lib/libpython$(PYMINOR).a \
+	-s TOTAL_MEMORY=20971520 \
+	-s ALLOW_MEMORY_GROWTH=1 \
+    --use-preload-plugins \
+	-s USE_FREETYPE=1 \
+	-s USE_LIBPNG=1 \
+	-L$(wildcard $(CPYTHONROOT)/build/sqlite*/.libs) -lsqlite3 \
+	$(wildcard $(CPYTHONROOT)/build/bzip2*/libbz2.a) \
+	-lstdc++ \
+	--memory-init-file 0 \
+
+export SIDE_MODULE_CFLAGS= $(CFLAGS_BASE)
+export MAIN_MODULE_CFLAGS= $(CFLAGS_BASE) \
+    	-Wall \
+    	-Wno-warn-absolute-paths \
+    	-Werror=unused-variable \
+    	-Werror=sometimes-uninitialized \
+    	-Werror=int-conversion \
+    	-Werror=incompatible-pointer-types \
+		-I$(PYTHONINCLUDE) 
+
+export PYTHON_CFLAGS=$(CFLAGS_BASE)
+
+.output_vars:
+	set

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -3,6 +3,8 @@ include ../Makefile.envs
 
 ROOT=$(abspath .)
 
+PYTHON_CFLAGS=$(CFLAGS_BASE)
+
 BUILD=$(ROOT)/build/Python-$(PYVERSION)
 INSTALL=$(ROOT)/installs/python-$(PYVERSION)
 TARBALL=$(ROOT)/downloads/Python-$(PYVERSION).tgz

--- a/cpython/Makefile
+++ b/cpython/Makefile
@@ -91,7 +91,7 @@ $(SQLITEBUILD)/libsqlite3.la: $(SQLITETARBALL)
 	# as a CPPFLAG
 	( \
 		cd $(SQLITEBUILD); \
-		emconfigure ./configure CFLAGS="-fPIC" CPPFLAGS="-DSQLITE_OMIT_POPEN"; \
+		emconfigure ./configure CFLAGS="$(PYTHON_CFLAGS)" CPPFLAGS="-DSQLITE_OMIT_POPEN"; \
 		emmake make -j $${PYODIDE_JOBS:-3}; \
 	)
 
@@ -101,7 +101,7 @@ $(BZIP2BUILD)/libbz2.a: $(BZIP2TARBALL)
 	tar -C $(ROOT)/build/ -xf $(BZIP2TARBALL)
 	( \
 		cd $(BZIP2BUILD); \
-		emmake make -j $${PYODIDE_JOBS:-3} CC=emcc CFLAGS="-Wall -Winline -O2 -fomit-frame-pointer -D_FILE_OFFSET_BITS=64 -fPIC" AR=emar RANLIB=emranlib libbz2.a; \
+		emmake make -j $${PYODIDE_JOBS:-3} CC=emcc CFLAGS="$(PYTHON_CFLAGS) -D_FILE_OFFSET_BITS=64" AR=emar RANLIB=emranlib libbz2.a; \
 	)
 
 
@@ -111,7 +111,7 @@ $(BUILD)/Makefile: $(BUILD)/.patched $(ZLIBBUILD)/.configured $(SQLITEBUILD)/lib
 		cd $(BUILD); \
 		CONFIG_SITE=./config.site READELF=true emconfigure \
 		  ./configure \
-			  CFLAGS="-fPIC -sEMULATE_FUNCTION_POINTER_CASTS=1" \
+			  CFLAGS="${PYTHON_CFLAGS}" \
 			  CPPFLAGS="-I$(SQLITEBUILD) -I$(BZIP2BUILD) -I$(ZLIBBUILD)" \
 			  --without-pymalloc \
 			  --disable-shared \

--- a/pyodide_build/buildall.py
+++ b/pyodide_build/buildall.py
@@ -259,28 +259,28 @@ def make_parser(parser):
         "--cflags",
         type=str,
         nargs="?",
-        default=common.DEFAULTCFLAGS,
+        default=common.get_make_flag("SIDE_MODULE_CFLAGS"),
         help="Extra compiling flags",
     )
     parser.add_argument(
         "--cxxflags",
         type=str,
         nargs="?",
-        default=common.DEFAULTCXXFLAGS,
+        default=common.get_make_flag("SIDE_MODULE_CXXFLAGS"),
         help="Extra C++ specific compiling flags",
     )
     parser.add_argument(
         "--ldflags",
         type=str,
         nargs="?",
-        default=common.DEFAULTLDFLAGS,
+        default=common.get_make_flag("SIDE_MODULE_LDFLAGS"),
         help="Extra linking flags",
     )
     parser.add_argument(
         "--target",
         type=str,
         nargs="?",
-        default=common.TARGETPYTHON,
+        default=common.get_make_flag("TARGETPYTHONROOT"),
         help="The path to the target Python installation",
     )
     parser.add_argument(

--- a/pyodide_build/buildpkg.py
+++ b/pyodide_build/buildpkg.py
@@ -305,28 +305,28 @@ def make_parser(parser: argparse.ArgumentParser):
         "--cflags",
         type=str,
         nargs="?",
-        default=common.DEFAULTCFLAGS,
+        default=common.get_make_flag("SIDE_MODULE_CFLAGS"),
         help="Extra compiling flags",
     )
     parser.add_argument(
         "--cxxflags",
         type=str,
         nargs="?",
-        default=common.DEFAULTCXXFLAGS,
+        default=common.get_make_flag("SIDE_MODULE_CXXFLAGS"),
         help="Extra C++ specifc compiling flags",
     )
     parser.add_argument(
         "--ldflags",
         type=str,
         nargs="?",
-        default=common.DEFAULTLDFLAGS,
+        default=common.get_make_flag("SIDE_MODULE_LDFLAGS"),
         help="Extra linking flags",
     )
     parser.add_argument(
         "--target",
         type=str,
         nargs="?",
-        default=common.TARGETPYTHON,
+        default=common.get_make_flag("TARGETPYTHONROOT"),
         help="The path to the target Python installation",
     )
     parser.add_argument(

--- a/pyodide_build/pywasmcross.py
+++ b/pyodide_build/pywasmcross.py
@@ -40,7 +40,7 @@ from pyodide_build import common
 from pyodide_build._f2c_fixes import fix_f2c_clapack_calls
 
 
-TOOLSDIR = common.TOOLSDIR
+TOOLSDIR = Path(common.get_make_flag("TOOLSDIR"))
 symlinks = set(["cc", "c++", "ld", "ar", "gcc", "gfortran"])
 
 
@@ -443,7 +443,7 @@ def make_parser(parser):
             "--cflags",
             type=str,
             nargs="?",
-            default=common.DEFAULTCFLAGS,
+            default=common.get_make_flag("SIDE_MODULE_CFLAGS"),
             help="Extra compiling flags",
             action=EnvironmentRewritingArgument,
         )
@@ -451,7 +451,7 @@ def make_parser(parser):
             "--cxxflags",
             type=str,
             nargs="?",
-            default=common.DEFAULTCXXFLAGS,
+            default=common.get_make_flag("SIDE_MODULE_CXXFLAGS"),
             help="Extra C++ specific compiling flags",
             action=EnvironmentRewritingArgument,
         )
@@ -459,7 +459,7 @@ def make_parser(parser):
             "--ldflags",
             type=str,
             nargs="?",
-            default=common.DEFAULTLDFLAGS,
+            default=common.get_make_flag("SIDE_MODULE_LDFLAGS"),
             help="Extra linking flags",
             action=EnvironmentRewritingArgument,
         )
@@ -467,7 +467,7 @@ def make_parser(parser):
             "--target",
             type=str,
             nargs="?",
-            default=common.TARGETPYTHON,
+            default=common.get_make_flag("TARGETPYTHONROOT"),
             help="The path to the target Python installation",
         )
         parser.add_argument(

--- a/pyodide_build/tests/test_common.py
+++ b/pyodide_build/tests/test_common.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).parents[2]))
 
-from pyodide_build.common import _parse_package_subset  # noqa
+from pyodide_build.common import (
+    _parse_package_subset,
+    get_make_flag,
+    get_make_environment_vars,
+)  # noqa
 
 
 def test_parse_package_subset():
@@ -29,3 +33,18 @@ def test_parse_package_subset():
         "c",
         "d",
     }
+
+
+def test_get_make_flag():
+    assert len(get_make_flag("SIDE_MODULE_LDFLAGS")) > 0
+    assert len(get_make_flag("SIDE_MODULE_CFLAGS")) > 0
+    # n.b. right now CXXFLAGS is empty so don't check length here, just check it returns
+    get_make_flag("SIDE_MODULE_CXXFLAGS")
+
+
+def test_get_make_environment_vars():
+    vars = get_make_environment_vars()
+    assert "SIDE_MODULE_LDFLAGS" in vars
+    assert "SIDE_MODULE_CFLAGS" in vars
+    assert "SIDE_MODULE_CXXFLAGS" in vars
+    assert "TOOLSDIR" in vars


### PR DESCRIPTION
Because if you're fiddling with the build at all it is a pain that settings for building are spread between:
/pyodide_build/common.py
/cpython/Makefile,
/Makefile
/Makefile.envs

I don't think this is urgent, so probably can hold off until after the coming release if it needs to, but it just makes it so much easier to check changes to build flags and make sure optimisation and compiler options are consistent where they need to be.